### PR TITLE
feat: Add data.go.kr runtime evidence growth summary

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -83,6 +83,7 @@ jobs:
           python scripts/validate-external-coverage.py
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
+          python scripts/validate-runtime-evidence-growth.py
 
       - name: Select manifest path
         run: |

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -56,6 +56,7 @@ jobs:
           python scripts/validate-external-coverage.py
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
+          python scripts/validate-runtime-evidence-growth.py
 
       - name: Validate provider verification evidence
         working-directory: datapan-cli

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-25T06:22:58Z`
+- generated_at: `2026-06-29T08:46:04Z`
 - provider: `data.go.kr`
-- datapan_version: `v0.1.29`
-- source_registry: `C:\workspace\datapan-registry\data\data-go-kr.registry.json`
-- previous_registry: `C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json`
+- datapan_version: `0.1.0-dev`
+- source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
+- previous_registry: `/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json`
 - release_manifest: `manifest.json`
 
 ## Registry
@@ -29,6 +29,9 @@
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
 - verification_plan: `9` batches, `83` planned operations, `11409` gateway gaps, `340` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
+- runtime_evidence_growth: `2.1%` coverage, target `10.0%`, remaining `965`, status `below_target`
+- runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
+- runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
 Top adapter targets:
 

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,
   "adapters": [

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -156,6 +156,7 @@ data.go.kr mastery should produce or preserve:
 - `reports/latest-verification-summary.json`
 - `reports/data-go-kr/error-action-catalog.json`
 - `reports/data-go-kr/registry-impact-plan.json`
+- `reports/data-go-kr/runtime-evidence-growth.json`
 
 ## Source-Scoped Generation Contract
 
@@ -168,6 +169,7 @@ match those roots.
 | `reports/data-go-kr/external-coverage-summary.json` | `sources/data_go_kr.json`, `reports/coverage.json`, `reports/adapter-targets.json`, `reports/route-disposition.json`, `data/provider-index.json` | `scripts/validate-external-coverage.py` validates schema and cross-checks source identity, raw coverage metrics, route evidence counts, adapter target counts, provider-index host count, and missing host counts. |
 | `reports/data-go-kr/error-action-catalog.json` | `sources/data_go_kr.json`, `reports/error-catalog.json`, `reports/route-disposition.json`, provider verification reports | `scripts/validate-error-action-catalogs.py` validates checked-in action rules; future generation should also fail on unmapped known error signatures. |
 | `reports/data-go-kr/registry-impact-plan.json` | `sources/data_go_kr.json`, catalog diff, verification evidence, route disposition, error action catalog, promoted dataset mappings | `scripts/validate-impact-plans.py` validates schema, summary counts, target counts, identity fields, and promoted/served dataset boundaries before client/server consumers act on it. |
+| `reports/data-go-kr/runtime-evidence-growth.json` | `reports/coverage.json`, `reports/latest-verification.json`, `reports/latest-verification-summary.json`, `reports/verification-plan.json`, `data/provider-index.json` | `scripts/validate-runtime-evidence-growth.py` validates current evidence totals, evidence coverage percent, 10% target gap, provider split readiness, and next planned verification batches. |
 
 This contract keeps `data/data-go-kr.registry.json` as the compatibility
 registry path while moving generated evidence toward `reports/data-go-kr/`.
@@ -188,10 +190,14 @@ CI should fail rather than treating the checked-in summary as authoritative.
 7. Add an operational gate that fails validation for missing external routes
    without route-disposition evidence and permits adapter backlog only from
    adapter-candidate evidence. Done in PR #4.
-8. Increase runtime verification evidence for call-capable registered adapters.
-9. Add a data.go.kr draft impact plan and validate its client/server action
+8. Add a runtime evidence growth summary that measures current evidence
+   coverage against the 10% target and validates the next planned batches.
+   Tracked by Gira #15.
+9. Execute the next runtime verification batches for gateway and registered
+   external adapters.
+10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
-10. Generate future data.go.kr impact plans directly from catalog diff,
+11. Generate future data.go.kr impact plans directly from catalog diff,
    verification evidence, route disposition, and promoted dataset mappings.
 
 ## Done Criteria

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -85,6 +85,9 @@ Current strengths:
   hints for the current data.go.kr registry-only changes.
 - `reports/source-reference-drift.json` validates a manual baseline for
   official source references from every checked-in source profile.
+- `reports/data-go-kr/runtime-evidence-growth.json` measures current runtime
+  evidence against the 10% target and validates the next planned verification
+  batches.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -234,6 +237,8 @@ Done when:
 - live source reference drift checks run outside ordinary PR validation so
   external site outages are visible health failures without making every PR
   nondeterministic;
+- data.go.kr runtime evidence growth is measured by a checked-in source-scoped
+  report before additional verification batches are executed;
 - data.go.kr runtime evidence coverage trends toward the documented `10%`
   target;
 - external adapter coverage trends toward the documented `98%` target;
@@ -273,7 +278,8 @@ Use this order unless a production failure changes priority:
 11. Add source reference drift report schema and manual baseline. Tracked by
     Gira #11.
 12. Add a manual or scheduled drift-check workflow. Tracked by Gira #13.
-13. Expand runtime verification evidence by source/provider priority.
+13. Add a data.go.kr runtime evidence growth summary. Tracked by Gira #15.
+14. Expand runtime verification evidence by source/provider priority.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
-  "source_registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "output_dir": "C:\\workspace\\datapan-registry",
-  "artifact_count": 37,
+  "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "output_dir": "/home/statpan/workspace/opensource/datapan-registry",
+  "artifact_count": 39,
   "artifacts": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -62,10 +62,16 @@
       "sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "kind": "schema",
+      "bytes": 7881,
+      "sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "kind": "schema",
-      "bytes": 2352,
-      "sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "bytes": 2391,
+      "sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",
@@ -125,8 +131,8 @@
       "path": "schemas/index.json",
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
-      "bytes": 7088,
-      "sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb"
+      "bytes": 7490,
+      "sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -139,71 +145,78 @@
       "path": "data/provider-index.json",
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
-      "bytes": 5586,
-      "sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c"
+      "bytes": 5588,
+      "sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
-      "bytes": 470,
-      "sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70"
+      "bytes": 505,
+      "sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
-      "bytes": 15967,
-      "sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6"
+      "bytes": 15985,
+      "sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
-      "bytes": 3305388,
-      "sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f"
+      "bytes": 3305406,
+      "sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
-      "bytes": 11399459,
-      "sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f"
+      "bytes": 11399477,
+      "sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
-      "bytes": 15179,
-      "sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471"
+      "bytes": 15197,
+      "sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
-      "bytes": 22338,
-      "sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff"
+      "bytes": 22374,
+      "sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
-      "bytes": 53695,
-      "sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b"
+      "bytes": 53713,
+      "sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
-      "bytes": 16839,
-      "sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554"
+      "bytes": 17021,
+      "sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
-      "bytes": 9095,
-      "sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1"
+      "bytes": 9491,
+      "sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+    },
+    {
+      "path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "kind": "runtime_evidence_growth",
+      "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
+      "bytes": 4516,
+      "sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
     },
     {
       "path": "reports/latest-verification.json",
@@ -216,8 +229,8 @@
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 12518,
-      "sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff"
+      "bytes": 12536,
+      "sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -230,20 +243,20 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 2435,
-      "sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5"
+      "bytes": 2453,
+      "sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
-      "bytes": 3603,
-      "sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875"
+      "bytes": 4463,
+      "sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
-      "bytes": 3041,
-      "sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa"
+      "bytes": 3342,
+      "sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,31 +1,31 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-25T06:22:58Z
-- datapan_version: v0.1.29
+- generated_at: 2026-06-29T08:46:04Z
+- datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
-- source_registry: C:\workspace\datapan-registry\data\data-go-kr.registry.json
-- previous_registry: C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json
-- release_registry: C:\workspace\datapan-registry\data\data-go-kr.registry.json
+- source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
+- previous_registry: /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json
+- release_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
 - provider_limit: 0
-- verification_source: C:\workspace\datapan-registry\reports\latest-verification.json
-- unadapted_external_probe_source: C:\workspace\datapan-registry\reports\unadapted-external-probe.json
+- verification_source: /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json
+- unadapted_external_probe_source: /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json
 
 ## Commands
 
 ```bash
-datapan catalog release draft --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output-dir C:\workspace\datapan-registry --provider-limit 0 --previous-registry C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --json
-# provider index: C:\workspace\datapan-registry\data\provider-index.json
-datapan catalog diff --old C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json --new C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\catalog-diff.json --json
-datapan catalog audit --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output C:\workspace\datapan-registry\reports\catalog-audit.json --json
-datapan catalog errors --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output C:\workspace\datapan-registry\reports\error-catalog.json --json
-datapan catalog dependencies --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\dependencies.json --json
-datapan catalog adapter-targets --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\adapter-targets.json --json
-datapan catalog route-disposition --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --probe C:\workspace\datapan-registry\reports\unadapted-external-probe.json --limit 0 --output C:\workspace\datapan-registry\reports\route-disposition.json --json
-datapan catalog providers --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\provider-backlog.json --json
-datapan catalog verify --input C:\workspace\datapan-registry\reports\latest-verification.json --json
-datapan catalog verify summary --input C:\workspace\datapan-registry\reports\latest-verification.json --output C:\workspace\datapan-registry\reports\latest-verification-summary.json --json
-datapan catalog verify --input C:\workspace\datapan-registry\reports\unadapted-external-probe.json --json
-datapan catalog verify summary --input C:\workspace\datapan-registry\reports\unadapted-external-probe.json --output C:\workspace\datapan-registry\reports\unadapted-external-probe-summary.json --json
-datapan catalog coverage --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --route-disposition C:\workspace\datapan-registry\reports\route-disposition.json --output C:\workspace\datapan-registry\reports\coverage.json --json
-datapan catalog verify plan --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --output C:\workspace\datapan-registry\reports\verification-plan.json --json
+datapan catalog release draft --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output-dir /home/statpan/workspace/opensource/datapan-registry --provider-limit 0 --previous-registry /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
+# provider index: /home/statpan/workspace/opensource/datapan-registry/data/provider-index.json
+datapan catalog diff --old /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --new /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-diff.json --json
+datapan catalog audit --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-audit.json --json
+datapan catalog errors --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/error-catalog.json --json
+datapan catalog dependencies --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/dependencies.json --json
+datapan catalog adapter-targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/adapter-targets.json --json
+datapan catalog route-disposition --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --probe /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json
+datapan catalog providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/provider-backlog.json --json
+datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
+datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification-summary.json --json
+datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --json
+datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --output /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe-summary.json --json
+datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --output /home/statpan/workspace/opensource/datapan-registry/reports/coverage.json --json
+datapan catalog verify plan --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/verification-plan.json --json
 ```

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 10,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,
   "audit": {
     "specs_total": 12060,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "old": "C:\\workspace\\datapan-registry\\.datapan\\previous\\data-go-kr.registry.json",
-  "new": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
+  "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "counts": {

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-06-25T06:23:03Z",
+  "generated_at": "2026-06-29T08:46:08Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
-  "route_disposition": "C:\\workspace\\datapan-registry\\reports\\route-disposition.json",
+  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
+  "route_disposition": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
   "summary": {
     "specs": 12060,
     "operations": 12205,
@@ -52,7 +52,7 @@
   },
   "route_evidence": {
     "present": true,
-    "report": "C:\\workspace\\datapan-registry\\reports\\route-disposition.json",
+    "report": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
     "routes_total": 28,
     "with_probe_evidence": 28,
     "dead_route_candidates": 14,
@@ -381,8 +381,8 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-25T06:23:03Z",
-    "datapan_version": "v0.1.29",
+    "generated_at": "2026-06-29T08:46:08Z",
+    "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,
     "adapters": [
@@ -688,19 +688,19 @@
   "next": [
     {
       "label": "missing adapters",
-      "command": "datapan providers --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --gaps --limit 20 --json"
+      "command": "datapan providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --gaps --limit 20 --json"
     },
     {
       "label": "adapter targets",
-      "command": "datapan targets --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --limit 20 --json"
+      "command": "datapan targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 20 --json"
     },
     {
       "label": "coverage report",
-      "command": "datapan coverage --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --verification C:\\workspace\\datapan-registry\\reports\\latest-verification.json --route-disposition C:\\workspace\\datapan-registry\\reports\\route-disposition.json --json"
+      "command": "datapan coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json"
     },
     {
       "label": "verify forest",
-      "command": "datapan verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
+      "command": "datapan verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
     }
   ]
 }

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": "datapan.runtime-evidence-growth.v1",
+  "generated_at": "2026-06-29T00:00:00Z",
+  "datapan_version": "v0.1.29",
+  "provider": "data.go.kr",
+  "source_id": "data_go_kr",
+  "source_profile": "sources/data_go_kr.json",
+  "generation_inputs": {
+    "coverage": "reports/coverage.json",
+    "latest_verification": "reports/latest-verification.json",
+    "latest_verification_summary": "reports/latest-verification-summary.json",
+    "verification_plan": "reports/verification-plan.json",
+    "provider_index": "data/provider-index.json"
+  },
+  "coverage": {
+    "operations": 12205,
+    "callable_operations": 12063,
+    "data_go_kr_gateway_operations": 11419,
+    "external_endpoint_operations": 595,
+    "registered_adapter_operations": 586,
+    "call_capable_adapters": 21
+  },
+  "evidence": {
+    "total": 256,
+    "verified": 22,
+    "failed": 87,
+    "skipped": 147,
+    "unknown": 0,
+    "coverage_percent": 2.1,
+    "by_kind": [
+      {
+        "key": "data_go_kr_gateway",
+        "count": 10
+      },
+      {
+        "key": "external_endpoint",
+        "count": 227
+      },
+      {
+        "key": "service_root",
+        "count": 19
+      }
+    ]
+  },
+  "growth_target": {
+    "target_percent": 10.0,
+    "target_evidence_total": 1221,
+    "remaining_to_target": 965,
+    "status": "below_target"
+  },
+  "verification_plan": {
+    "planned_batches": 9,
+    "planned_operations": 83,
+    "uncovered_gateway_candidates": 11409,
+    "uncovered_adapter_candidates": 340,
+    "missing_adapter_hosts": 10,
+    "planned_by_kind": [
+      {
+        "key": "data_go_kr_gateway",
+        "count": 10
+      },
+      {
+        "key": "external_endpoint",
+        "count": 73
+      }
+    ],
+    "batches": [
+      {
+        "label": "gateway",
+        "kind": "data_go_kr_gateway",
+        "candidates": 11419,
+        "uncovered_candidates": 11409,
+        "planned_operations": 10,
+        "output": ".datapan/verification/gateway-next.json"
+      },
+      {
+        "label": "ekape",
+        "provider": "ekape",
+        "kind": "external_endpoint",
+        "candidates": 49,
+        "uncovered_candidates": 34,
+        "planned_operations": 10,
+        "output": ".datapan/verification/ekape-next.json"
+      },
+      {
+        "label": "emuseum",
+        "provider": "emuseum",
+        "kind": "external_endpoint",
+        "candidates": 3,
+        "uncovered_candidates": 3,
+        "planned_operations": 3,
+        "output": ".datapan/verification/emuseum-next.json"
+      },
+      {
+        "label": "epost",
+        "provider": "epost",
+        "kind": "external_endpoint",
+        "candidates": 28,
+        "uncovered_candidates": 13,
+        "planned_operations": 10,
+        "output": ".datapan/verification/epost-next.json"
+      },
+      {
+        "label": "geoje",
+        "provider": "geoje",
+        "kind": "external_endpoint",
+        "candidates": 41,
+        "uncovered_candidates": 35,
+        "planned_operations": 10,
+        "output": ".datapan/verification/geoje-next.json"
+      },
+      {
+        "label": "jeonju",
+        "provider": "jeonju",
+        "kind": "external_endpoint",
+        "candidates": 80,
+        "uncovered_candidates": 75,
+        "planned_operations": 10,
+        "output": ".datapan/verification/jeonju-next.json"
+      },
+      {
+        "label": "q-net",
+        "provider": "q-net",
+        "kind": "external_endpoint",
+        "candidates": 147,
+        "uncovered_candidates": 132,
+        "planned_operations": 10,
+        "output": ".datapan/verification/q-net-next.json"
+      },
+      {
+        "label": "uiryeong",
+        "provider": "uiryeong",
+        "kind": "external_endpoint",
+        "candidates": 40,
+        "uncovered_candidates": 34,
+        "planned_operations": 10,
+        "output": ".datapan/verification/uiryeong-next.json"
+      },
+      {
+        "label": "ulsan",
+        "provider": "ulsan",
+        "kind": "external_endpoint",
+        "candidates": 20,
+        "uncovered_candidates": 14,
+        "planned_operations": 10,
+        "output": ".datapan/verification/ulsan-next.json"
+      }
+    ]
+  },
+  "provider_split_readiness": {
+    "status": "ready",
+    "adapter_count": 26,
+    "verification_capable_adapters": 26,
+    "call_capable_adapters": 21
+  },
+  "warnings": [
+    {
+      "kind": "runtime_evidence_below_target",
+      "severity": "warning",
+      "message": "Runtime evidence coverage is 2.1% against the 10.0% target; 965 additional evidence records are needed before this target is met."
+    }
+  ]
+}

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
   "source_profile": "sources/data_go_kr.json",
@@ -43,7 +43,7 @@
     ]
   },
   "growth_target": {
-    "target_percent": 10.0,
+    "target_percent": 10,
     "target_evidence_total": 1221,
     "remaining_to_target": 965,
     "status": "below_target"

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -1,21 +1,21 @@
 {
-  "manifest": "C:\\workspace\\datapan-registry\\manifest.json",
-  "root": "C:\\workspace\\datapan-registry",
+  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
+  "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-25T06:23:15Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:22Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
   "summary": {
-    "gates_total": 21,
-    "passed": 21,
-    "warned": 0,
+    "gates_total": 23,
+    "passed": 22,
+    "warned": 1,
     "failed": 0,
-    "required_artifacts": 15,
+    "required_artifacts": 16,
     "missing_required_artifacts": 0,
     "recommended_artifacts": 3,
     "missing_recommended_artifacts": 0,
-    "schema_artifacts": 19,
+    "schema_artifacts": 20,
     "registry_specs": 12060
   },
   "gates": [
@@ -24,8 +24,8 @@
       "status": "pass",
       "severity": "required",
       "message": "release manifest checksums and schema-bound artifacts verified",
-      "expected": 37,
-      "actual": 37
+      "expected": 39,
+      "actual": 39
     },
     {
       "id": "required_artifact_schema_index",
@@ -138,6 +138,16 @@
       "actual": 1
     },
     {
+      "id": "required_artifact_runtime_evidence_growth",
+      "status": "pass",
+      "severity": "required",
+      "message": "required release artifact is present",
+      "artifact_kind": "runtime_evidence_growth",
+      "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "expected": 1,
+      "actual": 1
+    },
+    {
       "id": "required_artifact_provenance",
       "status": "pass",
       "severity": "required",
@@ -212,8 +222,8 @@
       "status": "pass",
       "severity": "required",
       "message": "release includes all Datapan schema files known to this CLI",
-      "expected": 19,
-      "actual": 19
+      "expected": 20,
+      "actual": 20
     },
     {
       "id": "registry_has_specs",
@@ -224,6 +234,16 @@
       "artifact_path": "data/data-go-kr.registry.json",
       "expected": 1,
       "actual": 12060
+    },
+    {
+      "id": "runtime_evidence_growth_target",
+      "status": "warn",
+      "severity": "recommended",
+      "message": "runtime evidence coverage is below the release target",
+      "artifact_kind": "runtime_evidence_growth",
+      "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "expected": 1221,
+      "actual": 256
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -1,10 +1,10 @@
 {
-  "manifest": "C:\\workspace\\datapan-registry\\manifest.json",
-  "root": "C:\\workspace\\datapan-registry",
+  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
+  "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-verification.v1",
   "manifest_schema_version": "datapan.release-manifest.v1",
-  "artifact_count": 37,
-  "checked": 37,
+  "artifact_count": 39,
+  "checked": 39,
   "failed": 0,
   "ok": true,
   "results": [
@@ -90,13 +90,22 @@
       "actual_sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 7881,
+      "actual_bytes": 7881,
+      "expected_sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52",
+      "actual_sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "kind": "schema",
       "status": "verified",
-      "expected_bytes": 2352,
-      "actual_bytes": 2352,
-      "expected_sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65",
-      "actual_sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "expected_bytes": 2391,
+      "actual_bytes": 2391,
+      "expected_sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0",
+      "actual_sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",
@@ -183,10 +192,10 @@
       "path": "schemas/index.json",
       "kind": "schema_index",
       "status": "verified",
-      "expected_bytes": 7088,
-      "actual_bytes": 7088,
-      "expected_sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb",
-      "actual_sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb"
+      "expected_bytes": 7490,
+      "actual_bytes": 7490,
+      "expected_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1",
+      "actual_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -201,91 +210,100 @@
       "path": "data/provider-index.json",
       "kind": "provider_index",
       "status": "verified",
-      "expected_bytes": 5586,
-      "actual_bytes": 5586,
-      "expected_sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c",
-      "actual_sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c"
+      "expected_bytes": 5588,
+      "actual_bytes": 5588,
+      "expected_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62",
+      "actual_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "status": "verified",
-      "expected_bytes": 470,
-      "actual_bytes": 470,
-      "expected_sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70",
-      "actual_sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70"
+      "expected_bytes": 505,
+      "actual_bytes": 505,
+      "expected_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0",
+      "actual_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "status": "verified",
-      "expected_bytes": 15967,
-      "actual_bytes": 15967,
-      "expected_sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6",
-      "actual_sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6"
+      "expected_bytes": 15985,
+      "actual_bytes": 15985,
+      "expected_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c",
+      "actual_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "status": "verified",
-      "expected_bytes": 3305388,
-      "actual_bytes": 3305388,
-      "expected_sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f",
-      "actual_sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f"
+      "expected_bytes": 3305406,
+      "actual_bytes": 3305406,
+      "expected_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08",
+      "actual_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "status": "verified",
-      "expected_bytes": 11399459,
-      "actual_bytes": 11399459,
-      "expected_sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f",
-      "actual_sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f"
+      "expected_bytes": 11399477,
+      "actual_bytes": 11399477,
+      "expected_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2",
+      "actual_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "status": "verified",
-      "expected_bytes": 15179,
-      "actual_bytes": 15179,
-      "expected_sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471",
-      "actual_sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471"
+      "expected_bytes": 15197,
+      "actual_bytes": 15197,
+      "expected_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061",
+      "actual_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "status": "verified",
-      "expected_bytes": 22338,
-      "actual_bytes": 22338,
-      "expected_sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff",
-      "actual_sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff"
+      "expected_bytes": 22374,
+      "actual_bytes": 22374,
+      "expected_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81",
+      "actual_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "status": "verified",
-      "expected_bytes": 53695,
-      "actual_bytes": 53695,
-      "expected_sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b",
-      "actual_sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b"
+      "expected_bytes": 53713,
+      "actual_bytes": 53713,
+      "expected_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b",
+      "actual_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "status": "verified",
-      "expected_bytes": 16839,
-      "actual_bytes": 16839,
-      "expected_sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554",
-      "actual_sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554"
+      "expected_bytes": 17021,
+      "actual_bytes": 17021,
+      "expected_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9",
+      "actual_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "status": "verified",
-      "expected_bytes": 9095,
-      "actual_bytes": 9095,
-      "expected_sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1",
-      "actual_sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1"
+      "expected_bytes": 9491,
+      "actual_bytes": 9491,
+      "expected_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764",
+      "actual_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+    },
+    {
+      "path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "kind": "runtime_evidence_growth",
+      "status": "verified",
+      "expected_bytes": 4516,
+      "actual_bytes": 4516,
+      "expected_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff",
+      "actual_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
     },
     {
       "path": "reports/latest-verification.json",
@@ -300,10 +318,10 @@
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 12518,
-      "actual_bytes": 12518,
-      "expected_sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff",
-      "actual_sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff"
+      "expected_bytes": 12536,
+      "actual_bytes": 12536,
+      "expected_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f",
+      "actual_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -318,28 +336,28 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "status": "verified",
-      "expected_bytes": 2435,
-      "actual_bytes": 2435,
-      "expected_sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5",
-      "actual_sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5"
+      "expected_bytes": 2453,
+      "actual_bytes": 2453,
+      "expected_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312",
+      "actual_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "status": "verified",
-      "expected_bytes": 3603,
-      "actual_bytes": 3603,
-      "expected_sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875",
-      "actual_sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875"
+      "expected_bytes": 4463,
+      "actual_bytes": 4463,
+      "expected_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c",
+      "actual_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "status": "verified",
-      "expected_bytes": 3041,
-      "actual_bytes": 3041,
-      "expected_sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa",
-      "actual_sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa"
+      "expected_bytes": 3342,
+      "actual_bytes": 3342,
+      "expected_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b",
+      "actual_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-25T05:05:17Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 0,

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 179,

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "probe": "C:\\workspace\\datapan-registry\\reports\\unadapted-external-probe.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/unadapted-external-probe-summary.json
+++ b/reports/unadapted-external-probe-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-25T05:21:35Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\unadapted-external-probe.json",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
   "provider": "data.go.kr",
   "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 0,

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-06-25T06:23:11Z",
+  "generated_at": "2026-06-29T08:46:15Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
+  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "batch_size": 10,
   "timeout": "10s",
   "summary": {
@@ -22,7 +22,7 @@
       "candidates": 11419,
       "uncovered_candidates": 11409,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
       "output": ".datapan/verification/gateway-next.json"
     },
     {
@@ -32,7 +32,7 @@
       "candidates": 49,
       "uncovered_candidates": 34,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
       "output": ".datapan/verification/ekape-next.json"
     },
     {
@@ -42,7 +42,7 @@
       "candidates": 3,
       "uncovered_candidates": 3,
       "planned_operations": 3,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider emuseum --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/emuseum-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider emuseum --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/emuseum-next.json --json",
       "output": ".datapan/verification/emuseum-next.json"
     },
     {
@@ -52,7 +52,7 @@
       "candidates": 28,
       "uncovered_candidates": 13,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
       "output": ".datapan/verification/epost-next.json"
     },
     {
@@ -62,7 +62,7 @@
       "candidates": 41,
       "uncovered_candidates": 35,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
       "output": ".datapan/verification/geoje-next.json"
     },
     {
@@ -72,7 +72,7 @@
       "candidates": 80,
       "uncovered_candidates": 75,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
       "output": ".datapan/verification/jeonju-next.json"
     },
     {
@@ -82,7 +82,7 @@
       "candidates": 147,
       "uncovered_candidates": 132,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
       "output": ".datapan/verification/q-net-next.json"
     },
     {
@@ -92,7 +92,7 @@
       "candidates": 40,
       "uncovered_candidates": 34,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
       "output": ".datapan/verification/uiryeong-next.json"
     },
     {
@@ -102,7 +102,7 @@
       "candidates": 20,
       "uncovered_candidates": 14,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
       "output": ".datapan/verification/ulsan-next.json"
     }
   ],
@@ -249,7 +249,7 @@
   "next": [
     {
       "label": "coverage",
-      "command": "datapan catalog coverage --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --verification C:\\workspace\\datapan-registry\\reports\\latest-verification.json --json"
+      "command": "datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json"
     }
   ]
 }

--- a/schemas/datapan.release-manifest.v1.schema.json
+++ b/schemas/datapan.release-manifest.v1.schema.json
@@ -76,6 +76,7 @@
             "provider_backlog",
             "coverage",
             "verification_plan",
+            "runtime_evidence_growth",
             "verification",
             "verification_summary",
             "unadapted_external_probe",

--- a/schemas/datapan.runtime-evidence-growth.v1.schema.json
+++ b/schemas/datapan.runtime-evidence-growth.v1.schema.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
+  "title": "Datapan Runtime Evidence Growth v1",
+  "description": "Source-scoped runtime verification evidence coverage and growth plan.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "provider",
+    "source_id",
+    "source_profile",
+    "generation_inputs",
+    "coverage",
+    "evidence",
+    "growth_target",
+    "verification_plan",
+    "provider_split_readiness",
+    "warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "datapan.runtime-evidence-growth.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "datapan_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_id": {
+      "$ref": "#/$defs/source_id"
+    },
+    "source_profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generation_inputs": {
+      "$ref": "#/$defs/generation_inputs"
+    },
+    "coverage": {
+      "$ref": "#/$defs/coverage"
+    },
+    "evidence": {
+      "$ref": "#/$defs/evidence"
+    },
+    "growth_target": {
+      "$ref": "#/$defs/growth_target"
+    },
+    "verification_plan": {
+      "$ref": "#/$defs/verification_plan"
+    },
+    "provider_split_readiness": {
+      "$ref": "#/$defs/provider_split_readiness"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/warning"
+      }
+    }
+  },
+  "$defs": {
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "percent": {
+      "type": "number",
+      "minimum": 0
+    },
+    "generation_inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "latest_verification",
+        "latest_verification_summary",
+        "verification_plan",
+        "provider_index"
+      ],
+      "properties": {
+        "coverage": {
+          "type": "string"
+        },
+        "latest_verification": {
+          "type": "string"
+        },
+        "latest_verification_summary": {
+          "type": "string"
+        },
+        "verification_plan": {
+          "type": "string"
+        },
+        "provider_index": {
+          "type": "string"
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operations",
+        "callable_operations",
+        "data_go_kr_gateway_operations",
+        "external_endpoint_operations",
+        "registered_adapter_operations",
+        "call_capable_adapters"
+      ],
+      "properties": {
+        "operations": {
+          "$ref": "#/$defs/count"
+        },
+        "callable_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "data_go_kr_gateway_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "external_endpoint_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "registered_adapter_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "call_capable_adapters": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "verified",
+        "failed",
+        "skipped",
+        "unknown",
+        "coverage_percent",
+        "by_kind"
+      ],
+      "properties": {
+        "total": {
+          "$ref": "#/$defs/count"
+        },
+        "verified": {
+          "$ref": "#/$defs/count"
+        },
+        "failed": {
+          "$ref": "#/$defs/count"
+        },
+        "skipped": {
+          "$ref": "#/$defs/count"
+        },
+        "unknown": {
+          "$ref": "#/$defs/count"
+        },
+        "coverage_percent": {
+          "$ref": "#/$defs/percent"
+        },
+        "by_kind": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/key_count"
+          }
+        }
+      }
+    },
+    "growth_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "target_percent",
+        "target_evidence_total",
+        "remaining_to_target",
+        "status"
+      ],
+      "properties": {
+        "target_percent": {
+          "$ref": "#/$defs/percent"
+        },
+        "target_evidence_total": {
+          "$ref": "#/$defs/count"
+        },
+        "remaining_to_target": {
+          "$ref": "#/$defs/count"
+        },
+        "status": {
+          "enum": ["below_target", "at_target", "above_target"]
+        }
+      }
+    },
+    "verification_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "planned_batches",
+        "planned_operations",
+        "uncovered_gateway_candidates",
+        "uncovered_adapter_candidates",
+        "missing_adapter_hosts",
+        "planned_by_kind",
+        "batches"
+      ],
+      "properties": {
+        "planned_batches": {
+          "$ref": "#/$defs/count"
+        },
+        "planned_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "uncovered_gateway_candidates": {
+          "$ref": "#/$defs/count"
+        },
+        "uncovered_adapter_candidates": {
+          "$ref": "#/$defs/count"
+        },
+        "missing_adapter_hosts": {
+          "$ref": "#/$defs/count"
+        },
+        "planned_by_kind": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/key_count"
+          }
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/batch"
+          }
+        }
+      }
+    },
+    "provider_split_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "adapter_count",
+        "verification_capable_adapters",
+        "call_capable_adapters"
+      ],
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "adapter_count": {
+          "$ref": "#/$defs/count"
+        },
+        "verification_capable_adapters": {
+          "$ref": "#/$defs/count"
+        },
+        "call_capable_adapters": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "key_count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "count"],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "count": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "batch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "label",
+        "kind",
+        "candidates",
+        "uncovered_candidates",
+        "planned_operations",
+        "output"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": ["data_go_kr_gateway", "external_endpoint", "service_root"]
+        },
+        "candidates": {
+          "$ref": "#/$defs/count"
+        },
+        "uncovered_candidates": {
+          "$ref": "#/$defs/count"
+        },
+        "planned_operations": {
+          "$ref": "#/$defs/count"
+        },
+        "output": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "severity", "message"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "enum": ["info", "warning", "blocking"]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
-  "count": 19,
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
+  "count": 20,
   "schemas": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -86,13 +86,22 @@
       "sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
+      "title": "Datapan Runtime Evidence Growth v1",
+      "contract": "runtime-evidence-growth",
+      "version": "v1",
+      "bytes": 7881,
+      "sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "id": "https://schemas.datapan.dev/datapan.release-manifest.v1.schema.json",
       "title": "Datapan Release Manifest v1",
       "contract": "release-manifest",
       "version": "v1",
-      "bytes": 2352,
-      "sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "bytes": 2391,
+      "sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",

--- a/scripts/validate-runtime-evidence-growth.py
+++ b/scripts/validate-runtime-evidence-growth.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Validate checked-in Datapan runtime evidence growth reports."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import math
+import pathlib
+import sys
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit(
+        "missing dependency: install jsonschema before running runtime evidence growth validation"
+    ) from exc
+
+
+TARGET_PERCENT = 10.0
+
+
+def load_json(path: pathlib.Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def as_dict(value: object, path: pathlib.Path) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def default_reports() -> list[pathlib.Path]:
+    return sorted(pathlib.Path("reports").glob("*/runtime-evidence-growth.json"))
+
+
+def key_counts(counter: collections.Counter[str]) -> list[dict[str, object]]:
+    return [{"key": key, "count": counter[key]} for key in sorted(counter)]
+
+
+def validate_consistency(path: pathlib.Path, report: dict[str, object]) -> None:
+    source_profile = pathlib.Path(str(report.get("source_profile")))
+    if not source_profile.exists():
+        raise ValueError(f"source_profile does not exist: {source_profile}")
+
+    profile = as_dict(load_json(source_profile), source_profile)
+    if report.get("source_id") != profile.get("source_id"):
+        raise ValueError("source_id does not match source_profile")
+    if report.get("provider") != profile.get("provider"):
+        raise ValueError("provider does not match source_profile")
+
+    generation_inputs = as_dict(report.get("generation_inputs"), path)
+    coverage_path = pathlib.Path(str(generation_inputs.get("coverage")))
+    latest_path = pathlib.Path(str(generation_inputs.get("latest_verification")))
+    latest_summary_path = pathlib.Path(str(generation_inputs.get("latest_verification_summary")))
+    verification_plan_path = pathlib.Path(str(generation_inputs.get("verification_plan")))
+    provider_index_path = pathlib.Path(str(generation_inputs.get("provider_index")))
+
+    coverage = as_dict(load_json(coverage_path), coverage_path)
+    coverage_summary = as_dict(coverage.get("summary"), coverage_path)
+    latest = as_dict(load_json(latest_path), latest_path)
+    latest_summary = as_dict(load_json(latest_summary_path), latest_summary_path)
+    verification_plan = as_dict(load_json(verification_plan_path), verification_plan_path)
+    provider_index = as_dict(load_json(provider_index_path), provider_index_path)
+
+    report_coverage = as_dict(report.get("coverage"), path)
+    expected_coverage = {
+        "operations": coverage_summary.get("operations"),
+        "callable_operations": coverage_summary.get("callable_operations"),
+        "data_go_kr_gateway_operations": coverage_summary.get("data_go_kr_gateway_operations"),
+        "external_endpoint_operations": coverage_summary.get("external_endpoint_operations"),
+        "registered_adapter_operations": coverage_summary.get("registered_adapter_operations"),
+        "call_capable_adapters": coverage_summary.get("call_capable_adapters"),
+    }
+    for key, value in expected_coverage.items():
+        if report_coverage.get(key) != value:
+            raise ValueError(f"coverage.{key} expected {value}, got {report_coverage.get(key)}")
+
+    latest_summary_counts = as_dict(latest_summary.get("summary"), latest_summary_path)
+    report_evidence = as_dict(report.get("evidence"), path)
+    for key in ["total", "verified", "failed", "skipped", "unknown"]:
+        if report_evidence.get(key) != latest_summary_counts.get(key):
+            raise ValueError(f"evidence.{key} expected {latest_summary_counts.get(key)}, got {report_evidence.get(key)}")
+
+    results = latest.get("results")
+    if not isinstance(results, list):
+        raise ValueError("latest verification results must be an array")
+    if len(results) != report_evidence.get("total"):
+        raise ValueError(f"evidence.total expected {len(results)} latest verification results")
+
+    by_kind: collections.Counter[str] = collections.Counter()
+    for result in results:
+        if isinstance(result, dict):
+            kind = result.get("dependency_class")
+            if isinstance(kind, str):
+                by_kind[kind] += 1
+    expected_by_kind = key_counts(by_kind)
+    if report_evidence.get("by_kind") != expected_by_kind:
+        raise ValueError("evidence.by_kind does not match latest verification results")
+
+    operations = int(report_coverage["operations"])
+    evidence_total = int(report_evidence["total"])
+    expected_percent = round((evidence_total / operations) * 100, 2)
+    if report_evidence.get("coverage_percent") != expected_percent:
+        raise ValueError(
+            f"evidence.coverage_percent expected {expected_percent}, got {report_evidence.get('coverage_percent')}"
+        )
+
+    growth_target = as_dict(report.get("growth_target"), path)
+    target_total = math.ceil(operations * (TARGET_PERCENT / 100))
+    remaining = max(0, target_total - evidence_total)
+    status = "below_target" if remaining else "at_target"
+    if evidence_total > target_total:
+        status = "above_target"
+    expected_growth = {
+        "target_percent": TARGET_PERCENT,
+        "target_evidence_total": target_total,
+        "remaining_to_target": remaining,
+        "status": status,
+    }
+    for key, value in expected_growth.items():
+        if growth_target.get(key) != value:
+            raise ValueError(f"growth_target.{key} expected {value}, got {growth_target.get(key)}")
+
+    report_plan = as_dict(report.get("verification_plan"), path)
+    plan_summary = as_dict(verification_plan.get("summary"), verification_plan_path)
+    for key in [
+        "planned_batches",
+        "planned_operations",
+        "uncovered_gateway_candidates",
+        "uncovered_adapter_candidates",
+        "missing_adapter_hosts",
+    ]:
+        if report_plan.get(key) != plan_summary.get(key):
+            raise ValueError(f"verification_plan.{key} expected {plan_summary.get(key)}, got {report_plan.get(key)}")
+
+    batches = verification_plan.get("batches")
+    if not isinstance(batches, list):
+        raise ValueError("verification_plan.batches must be an array")
+    planned_by_kind: collections.Counter[str] = collections.Counter()
+    expected_batches: list[dict[str, object]] = []
+    for batch in batches:
+        if not isinstance(batch, dict):
+            raise ValueError("verification_plan.batches must contain objects")
+        kind = batch.get("kind")
+        if isinstance(kind, str):
+            planned_by_kind[kind] += int(batch.get("planned_operations", 0))
+        expected_batch = {
+            "label": batch.get("label"),
+            "kind": batch.get("kind"),
+            "candidates": batch.get("candidates"),
+            "uncovered_candidates": batch.get("uncovered_candidates"),
+            "planned_operations": batch.get("planned_operations"),
+            "output": batch.get("output"),
+        }
+        if "provider" in batch:
+            expected_batch["provider"] = batch.get("provider")
+        expected_batches.append(expected_batch)
+    if report_plan.get("planned_by_kind") != key_counts(planned_by_kind):
+        raise ValueError("verification_plan.planned_by_kind does not match verification plan batches")
+    if report_plan.get("batches") != expected_batches:
+        raise ValueError("verification_plan.batches does not match root verification plan")
+
+    split_readiness = as_dict(provider_index.get("split_readiness"), provider_index_path)
+    report_readiness = as_dict(report.get("provider_split_readiness"), path)
+    expected_readiness = {
+        "status": split_readiness.get("status"),
+        "adapter_count": split_readiness.get("adapter_count"),
+        "verification_capable_adapters": split_readiness.get("verification_capable_adapters"),
+        "call_capable_adapters": split_readiness.get("call_capable_adapters"),
+    }
+    for key, value in expected_readiness.items():
+        if report_readiness.get(key) != value:
+            raise ValueError(f"provider_split_readiness.{key} expected {value}, got {report_readiness.get(key)}")
+
+    warnings = report.get("warnings")
+    if remaining > 0:
+        if not isinstance(warnings, list) or not warnings:
+            raise ValueError("warnings must record below-target runtime evidence coverage")
+        if not any(isinstance(warning, dict) and warning.get("kind") == "runtime_evidence_below_target" for warning in warnings):
+            raise ValueError("warnings must include runtime_evidence_below_target")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--schema",
+        default="schemas/datapan.runtime-evidence-growth.v1.schema.json",
+        type=pathlib.Path,
+        help="runtime evidence growth JSON Schema path",
+    )
+    parser.add_argument(
+        "reports",
+        nargs="*",
+        type=pathlib.Path,
+        help="reports to validate; defaults to reports/*/runtime-evidence-growth.json",
+    )
+    args = parser.parse_args()
+
+    reports = args.reports or default_reports()
+    if not reports:
+        print("no runtime evidence growth reports found", file=sys.stderr)
+        return 1
+
+    schema = load_json(args.schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    failures = 0
+
+    for report_path in reports:
+        try:
+            instance = as_dict(load_json(report_path), report_path)
+            errors = sorted(validator.iter_errors(instance), key=lambda error: list(error.path))
+            if not errors:
+                validate_consistency(report_path, instance)
+        except Exception as exc:  # noqa: BLE001 - report all validation blockers
+            print(f"FAIL {report_path}: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+
+        if errors:
+            failures += 1
+            print(f"FAIL {report_path}", file=sys.stderr)
+            for error in errors:
+                location = ".".join(str(part) for part in error.path) or "<root>"
+                print(f"  {location}: {error.message}", file=sys.stderr)
+            continue
+
+        source_id = instance.get("source_id", "<unknown>")
+        evidence = instance.get("evidence", {}).get("total", "<unknown>")
+        remaining = instance.get("growth_target", {}).get("remaining_to_target", "<unknown>")
+        print(f"ok {report_path} ({source_id}, evidence={evidence}, remaining_to_target={remaining})")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Gap

data.go.kr runtime evidence coverage was not measurable as a source-scoped control plane item. Callable-operation coverage is high, but runtime evidence is only `256 / 12,205` operations (`2.1%`), below the documented `10.0%` target.

## Changes

- Add `schemas/datapan.runtime-evidence-growth.v1.schema.json`.
- Add `reports/data-go-kr/runtime-evidence-growth.json` with current evidence totals, target count, remaining gap, provider split readiness, and next planned batches.
- Add `scripts/validate-runtime-evidence-growth.py` to cross-check the report against coverage, latest verification evidence, latest verification summary, verification plan, and provider index.
- Wire the validator into `verify-release.yml` and `release-draft.yml`.
- Update the data.go.kr mastery plan and registry blueprint so the next task is executing planned runtime verification batches, not treating this report as final coverage.

## Warning Status

- Active warning: `runtime_evidence_below_target`.
- Current coverage: `2.1%`.
- Target: `10.0%` / `1,221` evidence records.
- Remaining gap: `965` additional evidence records.
- This warning is intentionally kept in the report and must not be described as harmless.

## Validation

- `python3 scripts/validate-source-profiles.py && python3 scripts/validate-error-action-catalogs.py && python3 scripts/validate-external-coverage.py && python3 scripts/validate-impact-plans.py && python3 scripts/validate-source-reference-drift.py && python3 scripts/validate-runtime-evidence-growth.py`
- `python3 -m py_compile scripts/validate-source-profiles.py scripts/validate-error-action-catalogs.py scripts/validate-external-coverage.py scripts/validate-impact-plans.py scripts/validate-source-reference-drift.py scripts/validate-runtime-evidence-growth.py scripts/check-source-reference-drift.py`
- `jq empty sources/*.json reports/*/error-action-catalog.json reports/data-go-kr/external-coverage-summary.json reports/data-go-kr/registry-impact-plan.json reports/data-go-kr/runtime-evidence-growth.json reports/source-reference-drift.json schemas/*.schema.json schemas/index.json`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path); puts "ok #{path}" }'`
- `git diff --check`

## Follow-Up Gap

`manifest.json` and `schemas/index.json` are generated release artifacts and were not updated by hand. The next spec-governance task should add a generated artifact freshness gate so new schema files cannot drift from generated release metadata.

Closes #15
