### PR TITLE
feat: Regenerate registry release artifacts with runtime evidence growth support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-25T06:22:58Z`
+- generated_at: `2026-06-29T08:46:04Z`
 - provider: `data.go.kr`
-- datapan_version: `v0.1.29`
-- source_registry: `C:\workspace\datapan-registry\data\data-go-kr.registry.json`
-- previous_registry: `C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json`
+- datapan_version: `0.1.0-dev`
+- source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
+- previous_registry: `/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json`
 - release_manifest: `manifest.json`
 
 ## Registry
@@ -29,6 +29,9 @@
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
 - verification_plan: `9` batches, `83` planned operations, `11409` gateway gaps, `340` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
+- runtime_evidence_growth: `2.1%` coverage, target `10.0%`, remaining `965`, status `below_target`
+- runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
+- runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
 Top adapter targets:
 

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,
   "adapters": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
-  "source_registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "output_dir": "C:\\workspace\\datapan-registry",
-  "artifact_count": 37,
+  "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "output_dir": "/home/statpan/workspace/opensource/datapan-registry",
+  "artifact_count": 39,
   "artifacts": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -62,10 +62,16 @@
       "sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "kind": "schema",
+      "bytes": 7881,
+      "sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "kind": "schema",
-      "bytes": 2352,
-      "sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "bytes": 2391,
+      "sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",
@@ -125,8 +131,8 @@
       "path": "schemas/index.json",
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
-      "bytes": 7088,
-      "sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb"
+      "bytes": 7490,
+      "sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -139,71 +145,78 @@
       "path": "data/provider-index.json",
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
-      "bytes": 5586,
-      "sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c"
+      "bytes": 5588,
+      "sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
-      "bytes": 470,
-      "sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70"
+      "bytes": 505,
+      "sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
-      "bytes": 15967,
-      "sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6"
+      "bytes": 15985,
+      "sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
-      "bytes": 3305388,
-      "sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f"
+      "bytes": 3305406,
+      "sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
-      "bytes": 11399459,
-      "sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f"
+      "bytes": 11399477,
+      "sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
-      "bytes": 15179,
-      "sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471"
+      "bytes": 15197,
+      "sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
-      "bytes": 22338,
-      "sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff"
+      "bytes": 22374,
+      "sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
-      "bytes": 53695,
-      "sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b"
+      "bytes": 53713,
+      "sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
-      "bytes": 16839,
-      "sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554"
+      "bytes": 17021,
+      "sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
-      "bytes": 9095,
-      "sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1"
+      "bytes": 9491,
+      "sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+    },
+    {
+      "path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "kind": "runtime_evidence_growth",
+      "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
+      "bytes": 4516,
+      "sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
     },
     {
       "path": "reports/latest-verification.json",
@@ -216,8 +229,8 @@
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 12518,
-      "sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff"
+      "bytes": 12536,
+      "sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -230,20 +243,20 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 2435,
-      "sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5"
+      "bytes": 2453,
+      "sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
-      "bytes": 3603,
-      "sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875"
+      "bytes": 4463,
+      "sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
-      "bytes": 3041,
-      "sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa"
+      "bytes": 3342,
+      "sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,31 +1,31 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-25T06:22:58Z
-- datapan_version: v0.1.29
+- generated_at: 2026-06-29T08:46:04Z
+- datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
-- source_registry: C:\workspace\datapan-registry\data\data-go-kr.registry.json
-- previous_registry: C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json
-- release_registry: C:\workspace\datapan-registry\data\data-go-kr.registry.json
+- source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
+- previous_registry: /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json
+- release_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
 - provider_limit: 0
-- verification_source: C:\workspace\datapan-registry\reports\latest-verification.json
-- unadapted_external_probe_source: C:\workspace\datapan-registry\reports\unadapted-external-probe.json
+- verification_source: /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json
+- unadapted_external_probe_source: /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json
 
 ## Commands
 
 ```bash
-datapan catalog release draft --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output-dir C:\workspace\datapan-registry --provider-limit 0 --previous-registry C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --json
-# provider index: C:\workspace\datapan-registry\data\provider-index.json
-datapan catalog diff --old C:\workspace\datapan-registry\.datapan\previous\data-go-kr.registry.json --new C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\catalog-diff.json --json
-datapan catalog audit --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output C:\workspace\datapan-registry\reports\catalog-audit.json --json
-datapan catalog errors --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --output C:\workspace\datapan-registry\reports\error-catalog.json --json
-datapan catalog dependencies --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\dependencies.json --json
-datapan catalog adapter-targets --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\adapter-targets.json --json
-datapan catalog route-disposition --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --probe C:\workspace\datapan-registry\reports\unadapted-external-probe.json --limit 0 --output C:\workspace\datapan-registry\reports\route-disposition.json --json
-datapan catalog providers --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --limit 0 --output C:\workspace\datapan-registry\reports\provider-backlog.json --json
-datapan catalog verify --input C:\workspace\datapan-registry\reports\latest-verification.json --json
-datapan catalog verify summary --input C:\workspace\datapan-registry\reports\latest-verification.json --output C:\workspace\datapan-registry\reports\latest-verification-summary.json --json
-datapan catalog verify --input C:\workspace\datapan-registry\reports\unadapted-external-probe.json --json
-datapan catalog verify summary --input C:\workspace\datapan-registry\reports\unadapted-external-probe.json --output C:\workspace\datapan-registry\reports\unadapted-external-probe-summary.json --json
-datapan catalog coverage --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --route-disposition C:\workspace\datapan-registry\reports\route-disposition.json --output C:\workspace\datapan-registry\reports\coverage.json --json
-datapan catalog verify plan --registry C:\workspace\datapan-registry\data\data-go-kr.registry.json --verification C:\workspace\datapan-registry\reports\latest-verification.json --output C:\workspace\datapan-registry\reports\verification-plan.json --json
+datapan catalog release draft --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output-dir /home/statpan/workspace/opensource/datapan-registry --provider-limit 0 --previous-registry /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
+# provider index: /home/statpan/workspace/opensource/datapan-registry/data/provider-index.json
+datapan catalog diff --old /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --new /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-diff.json --json
+datapan catalog audit --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-audit.json --json
+datapan catalog errors --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/error-catalog.json --json
+datapan catalog dependencies --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/dependencies.json --json
+datapan catalog adapter-targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/adapter-targets.json --json
+datapan catalog route-disposition --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --probe /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json
+datapan catalog providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/provider-backlog.json --json
+datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
+datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification-summary.json --json
+datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --json
+datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --output /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe-summary.json --json
+datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --output /home/statpan/workspace/opensource/datapan-registry/reports/coverage.json --json
+datapan catalog verify plan --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/verification-plan.json --json
 ```

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 10,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,
   "audit": {
     "specs_total": 12060,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "old": "C:\\workspace\\datapan-registry\\.datapan\\previous\\data-go-kr.registry.json",
-  "new": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
+  "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "counts": {

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-06-25T06:23:03Z",
+  "generated_at": "2026-06-29T08:46:08Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
-  "route_disposition": "C:\\workspace\\datapan-registry\\reports\\route-disposition.json",
+  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
+  "route_disposition": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
   "summary": {
     "specs": 12060,
     "operations": 12205,
@@ -52,7 +52,7 @@
   },
   "route_evidence": {
     "present": true,
-    "report": "C:\\workspace\\datapan-registry\\reports\\route-disposition.json",
+    "report": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
     "routes_total": 28,
     "with_probe_evidence": 28,
     "dead_route_candidates": 14,
@@ -381,8 +381,8 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-25T06:23:03Z",
-    "datapan_version": "v0.1.29",
+    "generated_at": "2026-06-29T08:46:08Z",
+    "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,
     "adapters": [
@@ -688,19 +688,19 @@
   "next": [
     {
       "label": "missing adapters",
-      "command": "datapan providers --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --gaps --limit 20 --json"
+      "command": "datapan providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --gaps --limit 20 --json"
     },
     {
       "label": "adapter targets",
-      "command": "datapan targets --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --limit 20 --json"
+      "command": "datapan targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 20 --json"
     },
     {
       "label": "coverage report",
-      "command": "datapan coverage --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --verification C:\\workspace\\datapan-registry\\reports\\latest-verification.json --route-disposition C:\\workspace\\datapan-registry\\reports\\route-disposition.json --json"
+      "command": "datapan coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json"
     },
     {
       "label": "verify forest",
-      "command": "datapan verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
+      "command": "datapan verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
     }
   ]
 }

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
   "source_profile": "sources/data_go_kr.json",
@@ -43,7 +43,7 @@
     ]
   },
   "growth_target": {
-    "target_percent": 10.0,
+    "target_percent": 10,
     "target_evidence_total": 1221,
     "remaining_to_target": 965,
     "status": "below_target"

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -1,21 +1,21 @@
 {
-  "manifest": "C:\\workspace\\datapan-registry\\manifest.json",
-  "root": "C:\\workspace\\datapan-registry",
+  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
+  "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-25T06:23:15Z",
-  "datapan_version": "v0.1.29",
+  "generated_at": "2026-06-29T08:46:22Z",
+  "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
   "summary": {
-    "gates_total": 21,
-    "passed": 21,
-    "warned": 0,
+    "gates_total": 23,
+    "passed": 22,
+    "warned": 1,
     "failed": 0,
-    "required_artifacts": 15,
+    "required_artifacts": 16,
     "missing_required_artifacts": 0,
     "recommended_artifacts": 3,
     "missing_recommended_artifacts": 0,
-    "schema_artifacts": 19,
+    "schema_artifacts": 20,
     "registry_specs": 12060
   },
   "gates": [
@@ -24,8 +24,8 @@
       "status": "pass",
       "severity": "required",
       "message": "release manifest checksums and schema-bound artifacts verified",
-      "expected": 37,
-      "actual": 37
+      "expected": 39,
+      "actual": 39
     },
     {
       "id": "required_artifact_schema_index",
@@ -138,6 +138,16 @@
       "actual": 1
     },
     {
+      "id": "required_artifact_runtime_evidence_growth",
+      "status": "pass",
+      "severity": "required",
+      "message": "required release artifact is present",
+      "artifact_kind": "runtime_evidence_growth",
+      "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "expected": 1,
+      "actual": 1
+    },
+    {
       "id": "required_artifact_provenance",
       "status": "pass",
       "severity": "required",
@@ -212,8 +222,8 @@
       "status": "pass",
       "severity": "required",
       "message": "release includes all Datapan schema files known to this CLI",
-      "expected": 19,
-      "actual": 19
+      "expected": 20,
+      "actual": 20
     },
     {
       "id": "registry_has_specs",
@@ -224,6 +234,16 @@
       "artifact_path": "data/data-go-kr.registry.json",
       "expected": 1,
       "actual": 12060
+    },
+    {
+      "id": "runtime_evidence_growth_target",
+      "status": "warn",
+      "severity": "recommended",
+      "message": "runtime evidence coverage is below the release target",
+      "artifact_kind": "runtime_evidence_growth",
+      "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "expected": 1221,
+      "actual": 256
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -1,10 +1,10 @@
 {
-  "manifest": "C:\\workspace\\datapan-registry\\manifest.json",
-  "root": "C:\\workspace\\datapan-registry",
+  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
+  "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-verification.v1",
   "manifest_schema_version": "datapan.release-manifest.v1",
-  "artifact_count": 37,
-  "checked": 37,
+  "artifact_count": 39,
+  "checked": 39,
   "failed": 0,
   "ok": true,
   "results": [
@@ -90,13 +90,22 @@
       "actual_sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 7881,
+      "actual_bytes": 7881,
+      "expected_sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52",
+      "actual_sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "kind": "schema",
       "status": "verified",
-      "expected_bytes": 2352,
-      "actual_bytes": 2352,
-      "expected_sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65",
-      "actual_sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "expected_bytes": 2391,
+      "actual_bytes": 2391,
+      "expected_sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0",
+      "actual_sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",
@@ -183,10 +192,10 @@
       "path": "schemas/index.json",
       "kind": "schema_index",
       "status": "verified",
-      "expected_bytes": 7088,
-      "actual_bytes": 7088,
-      "expected_sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb",
-      "actual_sha256": "698438d5e4da5b31e5e28f5a885d64ac52d78524ed55611e6ad2edf563f56feb"
+      "expected_bytes": 7490,
+      "actual_bytes": 7490,
+      "expected_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1",
+      "actual_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -201,91 +210,100 @@
       "path": "data/provider-index.json",
       "kind": "provider_index",
       "status": "verified",
-      "expected_bytes": 5586,
-      "actual_bytes": 5586,
-      "expected_sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c",
-      "actual_sha256": "1fe90afc9a0bde6f94059ac98d5077a364cf0ed9ec0c20d84640033ecc0f1a9c"
+      "expected_bytes": 5588,
+      "actual_bytes": 5588,
+      "expected_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62",
+      "actual_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "status": "verified",
-      "expected_bytes": 470,
-      "actual_bytes": 470,
-      "expected_sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70",
-      "actual_sha256": "7ab76b30a35102482a68941f1c007066077a4c96b202fec48401594a7a714e70"
+      "expected_bytes": 505,
+      "actual_bytes": 505,
+      "expected_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0",
+      "actual_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "status": "verified",
-      "expected_bytes": 15967,
-      "actual_bytes": 15967,
-      "expected_sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6",
-      "actual_sha256": "5eae426a356ca28c417243b891a13eace13fee3b76c43981185d49ea1d6228b6"
+      "expected_bytes": 15985,
+      "actual_bytes": 15985,
+      "expected_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c",
+      "actual_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "status": "verified",
-      "expected_bytes": 3305388,
-      "actual_bytes": 3305388,
-      "expected_sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f",
-      "actual_sha256": "3439be6fd7f35afa4311677b92e1fe005809178839ea5a4b63ca72566fae2b3f"
+      "expected_bytes": 3305406,
+      "actual_bytes": 3305406,
+      "expected_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08",
+      "actual_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "status": "verified",
-      "expected_bytes": 11399459,
-      "actual_bytes": 11399459,
-      "expected_sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f",
-      "actual_sha256": "74437a874c6aef6b3ff04280fa6cb1f3d7007302996c9dd2a9969190e3b9072f"
+      "expected_bytes": 11399477,
+      "actual_bytes": 11399477,
+      "expected_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2",
+      "actual_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "status": "verified",
-      "expected_bytes": 15179,
-      "actual_bytes": 15179,
-      "expected_sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471",
-      "actual_sha256": "fffb446026703678137915edf8ab7691749bbd7ec9ec3757e1514d0e25e33471"
+      "expected_bytes": 15197,
+      "actual_bytes": 15197,
+      "expected_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061",
+      "actual_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "status": "verified",
-      "expected_bytes": 22338,
-      "actual_bytes": 22338,
-      "expected_sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff",
-      "actual_sha256": "e3ca88d7d1621725596cded88930cfcb7f6ddba8e8c87b154fa3d56d99f998ff"
+      "expected_bytes": 22374,
+      "actual_bytes": 22374,
+      "expected_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81",
+      "actual_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "status": "verified",
-      "expected_bytes": 53695,
-      "actual_bytes": 53695,
-      "expected_sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b",
-      "actual_sha256": "4c1a1222f5f4532379775ee25a86a37f91d458ee1814d531dcbeea709f49251b"
+      "expected_bytes": 53713,
+      "actual_bytes": 53713,
+      "expected_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b",
+      "actual_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "status": "verified",
-      "expected_bytes": 16839,
-      "actual_bytes": 16839,
-      "expected_sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554",
-      "actual_sha256": "2c752381d3ab3b8265ee2c7280de1852771f67e8592cf5b95b5ec6d74590f554"
+      "expected_bytes": 17021,
+      "actual_bytes": 17021,
+      "expected_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9",
+      "actual_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "status": "verified",
-      "expected_bytes": 9095,
-      "actual_bytes": 9095,
-      "expected_sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1",
-      "actual_sha256": "508313ed3d7872e04eac0144caac67c989f919f46dded7fb2771797f754d70e1"
+      "expected_bytes": 9491,
+      "actual_bytes": 9491,
+      "expected_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764",
+      "actual_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+    },
+    {
+      "path": "reports/data-go-kr/runtime-evidence-growth.json",
+      "kind": "runtime_evidence_growth",
+      "status": "verified",
+      "expected_bytes": 4516,
+      "actual_bytes": 4516,
+      "expected_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff",
+      "actual_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
     },
     {
       "path": "reports/latest-verification.json",
@@ -300,10 +318,10 @@
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 12518,
-      "actual_bytes": 12518,
-      "expected_sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff",
-      "actual_sha256": "03202f4ae6e92ce6c873c0b634f25cc6dd107dfd250d76a4162e45f6f673b0ff"
+      "expected_bytes": 12536,
+      "actual_bytes": 12536,
+      "expected_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f",
+      "actual_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -318,28 +336,28 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "status": "verified",
-      "expected_bytes": 2435,
-      "actual_bytes": 2435,
-      "expected_sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5",
-      "actual_sha256": "6892279ff55097935dd7caeb166814cae2aa2ae9ad0a6a7203ded5369a1595e5"
+      "expected_bytes": 2453,
+      "actual_bytes": 2453,
+      "expected_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312",
+      "actual_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "status": "verified",
-      "expected_bytes": 3603,
-      "actual_bytes": 3603,
-      "expected_sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875",
-      "actual_sha256": "861bd15269b75d71008c63af30fb224e8c8732ddda642a842113cf9a13cba875"
+      "expected_bytes": 4463,
+      "actual_bytes": 4463,
+      "expected_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c",
+      "actual_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "status": "verified",
-      "expected_bytes": 3041,
-      "actual_bytes": 3041,
-      "expected_sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa",
-      "actual_sha256": "6281d9cbb5623c25ba4a1326450f2fe9170e43d286a785e721b8feadf65cd9aa"
+      "expected_bytes": 3342,
+      "actual_bytes": 3342,
+      "expected_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b",
+      "actual_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-25T05:05:17Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 0,

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 179,

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-25T06:22:58Z",
+  "generated_at": "2026-06-29T08:46:04Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "probe": "C:\\workspace\\datapan-registry\\reports\\unadapted-external-probe.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/unadapted-external-probe-summary.json
+++ b/reports/unadapted-external-probe-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-25T05:21:35Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\unadapted-external-probe.json",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
   "provider": "data.go.kr",
   "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 0,

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-06-25T06:23:11Z",
+  "generated_at": "2026-06-29T08:46:15Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "C:\\workspace\\datapan-registry\\reports\\latest-verification.json",
+  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "batch_size": 10,
   "timeout": "10s",
   "summary": {
@@ -22,7 +22,7 @@
       "candidates": 11419,
       "uncovered_candidates": 11409,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
       "output": ".datapan/verification/gateway-next.json"
     },
     {
@@ -32,7 +32,7 @@
       "candidates": 49,
       "uncovered_candidates": 34,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
       "output": ".datapan/verification/ekape-next.json"
     },
     {
@@ -42,7 +42,7 @@
       "candidates": 3,
       "uncovered_candidates": 3,
       "planned_operations": 3,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider emuseum --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/emuseum-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider emuseum --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/emuseum-next.json --json",
       "output": ".datapan/verification/emuseum-next.json"
     },
     {
@@ -52,7 +52,7 @@
       "candidates": 28,
       "uncovered_candidates": 13,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
       "output": ".datapan/verification/epost-next.json"
     },
     {
@@ -62,7 +62,7 @@
       "candidates": 41,
       "uncovered_candidates": 35,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
       "output": ".datapan/verification/geoje-next.json"
     },
     {
@@ -72,7 +72,7 @@
       "candidates": 80,
       "uncovered_candidates": 75,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
       "output": ".datapan/verification/jeonju-next.json"
     },
     {
@@ -82,7 +82,7 @@
       "candidates": 147,
       "uncovered_candidates": 132,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
       "output": ".datapan/verification/q-net-next.json"
     },
     {
@@ -92,7 +92,7 @@
       "candidates": 40,
       "uncovered_candidates": 34,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
       "output": ".datapan/verification/uiryeong-next.json"
     },
     {
@@ -102,7 +102,7 @@
       "candidates": 20,
       "uncovered_candidates": 14,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input C:\\workspace\\datapan-registry\\reports\\latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
+      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
       "output": ".datapan/verification/ulsan-next.json"
     }
   ],
@@ -249,7 +249,7 @@
   "next": [
     {
       "label": "coverage",
-      "command": "datapan catalog coverage --registry C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json --verification C:\\workspace\\datapan-registry\\reports\\latest-verification.json --json"
+      "command": "datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json"
     }
   ]
 }

--- a/schemas/datapan.release-manifest.v1.schema.json
+++ b/schemas/datapan.release-manifest.v1.schema.json
@@ -76,6 +76,7 @@
             "provider_backlog",
             "coverage",
             "verification_plan",
+            "runtime_evidence_growth",
             "verification",
             "verification_summary",
             "unadapted_external_probe",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-25T06:22:58Z",
-  "datapan_version": "v0.1.29",
-  "count": 19,
+  "generated_at": "2026-06-29T08:46:04Z",
+  "datapan_version": "0.1.0-dev",
+  "count": 20,
   "schemas": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -86,13 +86,22 @@
       "sha256": "99f85d8e10d20c759df43ac42a15346f78dde3e199c61f6488a6086f49a4b936"
     },
     {
+      "path": "schemas/datapan.runtime-evidence-growth.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
+      "title": "Datapan Runtime Evidence Growth v1",
+      "contract": "runtime-evidence-growth",
+      "version": "v1",
+      "bytes": 7881,
+      "sha256": "8dbbcf9ad65c62fb253de6724709116fdfa5504d5a46334428baacaf87457b52"
+    },
+    {
       "path": "schemas/datapan.release-manifest.v1.schema.json",
       "id": "https://schemas.datapan.dev/datapan.release-manifest.v1.schema.json",
       "title": "Datapan Release Manifest v1",
       "contract": "release-manifest",
       "version": "v1",
-      "bytes": 2352,
-      "sha256": "c258291f913f9fe9844fe9987c9180d1949c6f55cac47a45efcac6157afc2a65"
+      "bytes": 2391,
+      "sha256": "65b00ba5de25c7b382bd08baf4fe4ce0bea2ef2033a7a6e7c02e33a2a5ce84f0"
     },
     {
       "path": "schemas/datapan.release-verification.v1.schema.json",


### PR DESCRIPTION
Closes #17

## Summary
- Regenerates datapan-registry release artifacts with the datapan-cli runtime evidence growth support now on main.
- Adds `runtime_evidence_growth` to the release manifest artifact set and schema index output.
- Refreshes release verification/readiness reports so runtime evidence growth is a first-class release gate.

## Runtime Evidence Warning
Release readiness is `ready: true`, but it intentionally retains one warning:

- `runtime_evidence_growth_target`: expected `1221`, actual `256`, remaining `965`

This is not being treated as harmless. It is the current measured gap toward the 10% runtime evidence target and should stay visible until verification evidence grows.

## Validation
- `go test ./internal/cli -run 'TestCatalogRelease'` in clean `datapan-cli` main worktree
- `datapan catalog release draft` with materialized data.go.kr registry, previous registry, latest verification, and existing unadapted external probe evidence
- `datapan catalog release verify --manifest manifest.json --output reports/latest-release-verification.json --json` -> `39/39` artifacts verified
- `datapan catalog release readiness --manifest manifest.json --output reports/latest-release-readiness.json --json` -> `ready: true`, `passed: 22`, `warned: 1`, `failed: 0`
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `jq empty manifest.json schemas/*.json reports/data-go-kr/runtime-evidence-growth.json reports/latest-release-readiness.json reports/latest-release-verification.json`
- `git diff --check`

## Notes
Local checkout does not have `git lfs`; `data/data-go-kr.registry.json` was temporarily materialized for local release verification, then restored to the tracked LFS pointer. GitHub Actions checks out LFS for release verification.
