### PR TITLE
feat: Add epost and ulsan runtime evidence growth batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ re-importing the upstream data.go.kr catalog every time.
 - Missing external adapter hosts: `10`
 - Provider split readiness: `ready`
   (`26` adapters, `26` verification-capable, `21` call-capable)
-- Runtime verification evidence: `256` bounded checks merged into
-  `reports/latest-verification.json` (`22` verified, `87` failed, `147`
+- Runtime verification evidence: `276` bounded checks merged into
+  `reports/latest-verification.json` (`22` verified, `87` failed, `167`
   skipped)
 - Missing external host probe: `28` unadapted external endpoint checks in
   `reports/unadapted-external-probe.json` (`14` HTTP 404, `7` timeout, `6`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-29T08:46:04Z`
+- generated_at: `2026-06-29T09:06:20Z`
 - provider: `data.go.kr`
 - datapan_version: `0.1.0-dev`
 - source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
@@ -24,12 +24,12 @@
 - route_disposition: `28` routes, `14` dead-route candidates, `14` transient failures, `0` parameter-blocked, `0` adapter candidates
 - route_disposition_artifact: `reports/route-disposition.json`
 - provider_backlog: `179` hosts, `10` missing-adapter hosts, `28` operations needing adapters
-- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.1%`, evidence-adjusted adapter candidates `0`
+- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.3%`, evidence-adjusted adapter candidates `0`
 - coverage_artifact: `reports/coverage.json`
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
-- verification_plan: `9` batches, `83` planned operations, `11409` gateway gaps, `340` adapter gaps
+- verification_plan: `9` batches, `70` planned operations, `11409` gateway gaps, `320` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
-- runtime_evidence_growth: `2.1%` coverage, target `10.0%`, remaining `965`, status `below_target`
+- runtime_evidence_growth: `2.3%` coverage, target `10.0%`, remaining `945`, status `below_target`
 - runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
 - runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
@@ -43,7 +43,7 @@ Top adapter targets:
 
 ## Verification Evidence
 
-- verification: `256` total, `22` verified, `87` failed, `147` skipped, `0` unknown
+- verification: `276` total, `22` verified, `87` failed, `167` skipped, `0` unknown
 - verification_artifact: `reports/latest-verification.json`
 - verification_summary_artifact: `reports/latest-verification-summary.json`
 
@@ -51,10 +51,10 @@ Provider evidence:
 
 - `oneclick-law`: `30`
 - `tour`: `26`
+- `epost`: `25`
 - `sisul`: `20`
+- `ulsan`: `16`
 - `andong`: `15`
-- `ekape`: `15`
-- `epost`: `15`
 
 - unadapted_external_probe: `28` total, `0` verified, `28` failed, `0` skipped, `0` unknown
 - unadapted_external_probe_artifact: `reports/unadapted-external-probe.json`

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -194,7 +194,11 @@ CI should fail rather than treating the checked-in summary as authoritative.
    coverage against the 10% target and validates the next planned batches.
    Tracked by Gira #15.
 9. Execute the next runtime verification batches for gateway and registered
-   external adapters.
+   external adapters. Started by Gira #19 with `epost` and `ulsan`
+   excluded-from-latest external endpoint batches. This grows checked runtime
+   evidence from `256` to `276`, but the new records are skipped boundary
+   evidence, not successful callable coverage. Runtime evidence remains below
+   the `10%` target with `945` additional evidence records still required.
 10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -105,7 +105,10 @@ Current gaps:
 - Error inventory has draft action routing for data.go.kr and the first
   non-data.go.kr profile batch, but runtime evidence is not yet generated for
   those non-data.go.kr sources.
-- Runtime evidence coverage is much lower than callable coverage.
+- Runtime evidence coverage is much lower than callable coverage. Gira #19
+  raises data.go.kr runtime evidence from `256` to `276`, but the release
+  readiness warning remains active: the `10%` target requires `1,221` evidence
+  records, so `945` additional records are still required.
 - Multi-source report grouping is designed but not implemented.
 - Impact plans are specified and a data.go.kr draft plan is checked in, but
   full `datapan-cli` generation is not implemented.
@@ -279,7 +282,10 @@ Use this order unless a production failure changes priority:
     Gira #11.
 12. Add a manual or scheduled drift-check workflow. Tracked by Gira #13.
 13. Add a data.go.kr runtime evidence growth summary. Tracked by Gira #15.
-14. Expand runtime verification evidence by source/provider priority.
+14. Expand runtime verification evidence by source/provider priority. Started
+    by Gira #19 with `epost` and `ulsan` external endpoint batches; this is
+    skipped boundary evidence growth, not proof that those operations are
+    callable.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
@@ -132,7 +132,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 7490,
-      "sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
+      "sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -146,91 +146,91 @@
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
       "bytes": 5588,
-      "sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
+      "sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
       "bytes": 505,
-      "sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
+      "sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
       "bytes": 15985,
-      "sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
+      "sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
       "bytes": 3305406,
-      "sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
+      "sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
       "bytes": 11399477,
-      "sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
+      "sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
       "bytes": 15197,
-      "sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
+      "sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
       "bytes": 22374,
-      "sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
+      "sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
       "bytes": 53713,
-      "sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
+      "sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
-      "bytes": 17021,
-      "sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
+      "bytes": 17019,
+      "sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
-      "bytes": 9491,
-      "sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+      "bytes": 9487,
+      "sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
-      "bytes": 4516,
-      "sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
+      "bytes": 4512,
+      "sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "schema": "https://schemas.datapan.dev/datapan.verification.v1.schema.json",
-      "bytes": 186275,
-      "sha256": "b353ae426799425231449a35b069d645a989f5d5dc479b90b29fb27dccd0db0a"
+      "bytes": 198309,
+      "sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 12536,
-      "sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
+      "bytes": 12562,
+      "sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -250,13 +250,13 @@
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "bytes": 4463,
-      "sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
+      "sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "bytes": 3342,
-      "sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
+      "sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,6 +1,6 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-29T08:46:04Z
+- generated_at: 2026-06-29T09:06:20Z
 - datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
 - source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
   "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:08Z",
+  "generated_at": "2026-06-29T09:06:24Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -41,14 +41,14 @@
   },
   "evidence": {
     "present": true,
-    "generated_at": "2026-06-25T05:05:17Z",
-    "total": 256,
+    "generated_at": "2026-06-29T09:06:00Z",
+    "total": 276,
     "verified": 22,
     "failed": 87,
-    "skipped": 147,
+    "skipped": 167,
     "unknown": 0,
-    "verified_percent": 8.6,
-    "evidence_operation_percent": 2.1
+    "verified_percent": 8,
+    "evidence_operation_percent": 2.3
   },
   "route_evidence": {
     "present": true,
@@ -381,7 +381,7 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-29T08:46:08Z",
+    "generated_at": "2026-06-29T09:06:24Z",
     "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
@@ -21,12 +21,12 @@
     "call_capable_adapters": 21
   },
   "evidence": {
-    "total": 256,
+    "total": 276,
     "verified": 22,
     "failed": 87,
-    "skipped": 147,
+    "skipped": 167,
     "unknown": 0,
-    "coverage_percent": 2.1,
+    "coverage_percent": 2.3,
     "by_kind": [
       {
         "key": "data_go_kr_gateway",
@@ -34,7 +34,7 @@
       },
       {
         "key": "external_endpoint",
-        "count": 227
+        "count": 247
       },
       {
         "key": "service_root",
@@ -45,14 +45,14 @@
   "growth_target": {
     "target_percent": 10,
     "target_evidence_total": 1221,
-    "remaining_to_target": 965,
+    "remaining_to_target": 945,
     "status": "below_target"
   },
   "verification_plan": {
     "planned_batches": 9,
-    "planned_operations": 83,
+    "planned_operations": 70,
     "uncovered_gateway_candidates": 11409,
-    "uncovered_adapter_candidates": 340,
+    "uncovered_adapter_candidates": 320,
     "missing_adapter_hosts": 10,
     "planned_by_kind": [
       {
@@ -61,7 +61,7 @@
       },
       {
         "key": "external_endpoint",
-        "count": 73
+        "count": 60
       }
     ],
     "batches": [
@@ -96,8 +96,8 @@
         "provider": "epost",
         "kind": "external_endpoint",
         "candidates": 28,
-        "uncovered_candidates": 13,
-        "planned_operations": 10,
+        "uncovered_candidates": 3,
+        "planned_operations": 3,
         "output": ".datapan/verification/epost-next.json"
       },
       {
@@ -141,8 +141,8 @@
         "provider": "ulsan",
         "kind": "external_endpoint",
         "candidates": 20,
-        "uncovered_candidates": 14,
-        "planned_operations": 10,
+        "uncovered_candidates": 4,
+        "planned_operations": 4,
         "output": ".datapan/verification/ulsan-next.json"
       }
     ]
@@ -157,7 +157,7 @@
     {
       "kind": "runtime_evidence_below_target",
       "severity": "warning",
-      "message": "Runtime evidence coverage is 2.1% against the 10.0% target; 965 additional evidence records are needed before this target is met."
+      "message": "Runtime evidence coverage is 2.3% against the 10.0% target; 945 additional evidence records are needed before this target is met."
     }
   ]
 }

--- a/reports/epost-verification-summary.json
+++ b/reports/epost-verification-summary.json
@@ -1,55 +1,64 @@
 {
-  "generated_at": "2026-06-24T00:23:42Z",
-  "source": "reports/epost-verification.json",
+  "generated_at": "2026-06-29T09:04:28Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/epost-verification.json",
   "provider": "data.go.kr",
-  "registry": "data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 0,
-    "skipped": 5,
+    "skipped": 15,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 5,
+        "count": 15,
         "status": "skipped"
       }
     ],
     "by_reason": [
       {
         "key": "epost_wadl_metadata_only",
-        "count": 3,
+        "count": 12,
         "reason": "epost_wadl_metadata_only"
       },
       {
         "key": "epost_unsupported_protocol",
         "count": 2,
         "reason": "epost_unsupported_protocol"
+      },
+      {
+        "key": "epost_missing_required_params",
+        "count": 1,
+        "reason": "epost_missing_required_params"
       }
     ],
     "by_provider": [
       {
         "key": "epost",
-        "count": 5,
+        "count": 15,
         "provider": "epost"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.epost.go.kr:80",
-        "count": 5,
+        "count": 14,
         "host": "openapi.epost.go.kr:80"
+      },
+      {
+        "key": "openapi.epost.go.kr",
+        "count": 1,
+        "host": "openapi.epost.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 5,
+        "count": 15,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/epost-verification.json
+++ b/reports/epost-verification.json
@@ -1,19 +1,14 @@
 {
-  "generated_at": "2026-06-24T00:23:42Z",
+  "generated_at": "2026-06-29T09:04:28Z",
   "provider": "data.go.kr",
-  "registry": "data\\data-go-kr.registry.json",
-  "limit": 5,
+  "limit": 15,
   "truncated": true,
-  "filters": {
-    "provider": "epost",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 5,
+  "filtered_count": 15,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 0,
-    "skipped": 5,
+    "skipped": 15,
     "unknown": 0
   },
   "results": [
@@ -186,6 +181,208 @@
         "areaNm",
         "searchSe",
         "srchwrd"
+      ]
+    },
+    {
+      "dataset_id": "15056971",
+      "title": "과학기술정보통신부 우정사업본부_우편번호 정보조회",
+      "operation": "새우편번호 정보",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "countPerPage": "1",
+        "currentPage": "1",
+        "srchwrd": ""
+      },
+      "missing_params": [
+        "srchwrd"
+      ]
+    },
+    {
+      "dataset_id": "15057018",
+      "title": "과학기술정보통신부 우정사업본부_집배구 구분코드 조회서비스",
+      "operation": "집배구 구분코드 조회서비스",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "addr": "",
+        "mailDivCd": "",
+        "zip": ""
+      },
+      "missing_params": [
+        "zip",
+        "addr",
+        "mailDivCd"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "광역시/도 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z"
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명목록조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "roadEngFirstName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "roadEngFirstName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명주소검색",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "countPerPage": "1",
+        "currentPage": "1",
+        "keyword": "",
+        "roadEngFirstName": "",
+        "roadEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "roadEngFirstName",
+        "roadEngName",
+        "keyword"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명첫자조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "시/군/구 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "읍면동목록조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "districtEngFirstName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "districtEngFirstName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "읍면동첫자조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "지번주소검색",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "countPerPage": "1",
+        "currentPage": "1",
+        "districtEngFirstName": "",
+        "districtEngName": "",
+        "keyword": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "districtEngFirstName",
+        "districtEngName",
+        "keyword"
       ]
     }
   ]

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
   "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-29T08:46:22Z",
+  "generated_at": "2026-06-29T09:06:41Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -243,7 +243,7 @@
       "artifact_kind": "runtime_evidence_growth",
       "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
       "expected": 1221,
-      "actual": 256
+      "actual": 276
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -194,8 +194,8 @@
       "status": "verified",
       "expected_bytes": 7490,
       "actual_bytes": 7490,
-      "expected_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1",
-      "actual_sha256": "ed24a66269645357b618b5c695ff1b01debc0190db487a563473c19f6600c1b1"
+      "expected_sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a",
+      "actual_sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -212,8 +212,8 @@
       "status": "verified",
       "expected_bytes": 5588,
       "actual_bytes": 5588,
-      "expected_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62",
-      "actual_sha256": "ae50e76b628e3a6ac1d96304377543db12dbb70b223bdcfe76a87aa3f4862e62"
+      "expected_sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd",
+      "actual_sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd"
     },
     {
       "path": "reports/catalog-diff.json",
@@ -221,8 +221,8 @@
       "status": "verified",
       "expected_bytes": 505,
       "actual_bytes": 505,
-      "expected_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0",
-      "actual_sha256": "fed5ae2e6b94f8fd4e688b10051ca6dbd1ec16464dc73e996e575fce3ee74dd0"
+      "expected_sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b",
+      "actual_sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b"
     },
     {
       "path": "reports/catalog-audit.json",
@@ -230,8 +230,8 @@
       "status": "verified",
       "expected_bytes": 15985,
       "actual_bytes": 15985,
-      "expected_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c",
-      "actual_sha256": "491d397bcd4409d6ed0658b9bda2395e9668b0686809c0b6fd43431fd425855c"
+      "expected_sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee",
+      "actual_sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee"
     },
     {
       "path": "reports/error-catalog.json",
@@ -239,8 +239,8 @@
       "status": "verified",
       "expected_bytes": 3305406,
       "actual_bytes": 3305406,
-      "expected_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08",
-      "actual_sha256": "8faa062f5b2874dd07a261e096abe24cf71a8e0e35c599e39456510742a02b08"
+      "expected_sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72",
+      "actual_sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72"
     },
     {
       "path": "reports/dependencies.json",
@@ -248,8 +248,8 @@
       "status": "verified",
       "expected_bytes": 11399477,
       "actual_bytes": 11399477,
-      "expected_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2",
-      "actual_sha256": "f921e67eb2a9a8b0e960a8bb20658b9a3eb083d77e55c1a4e4ac34d5f06b77d2"
+      "expected_sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3",
+      "actual_sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3"
     },
     {
       "path": "reports/adapter-targets.json",
@@ -257,8 +257,8 @@
       "status": "verified",
       "expected_bytes": 15197,
       "actual_bytes": 15197,
-      "expected_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061",
-      "actual_sha256": "c56da6bc7447b5e1f14a5d31e6a2b31c490787b0153f8f4ce32066ff7901a061"
+      "expected_sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0",
+      "actual_sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0"
     },
     {
       "path": "reports/route-disposition.json",
@@ -266,8 +266,8 @@
       "status": "verified",
       "expected_bytes": 22374,
       "actual_bytes": 22374,
-      "expected_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81",
-      "actual_sha256": "f5ff73c6a55b48153b4603eff887b76649bd21111f20a025b4a259766ac39d81"
+      "expected_sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7",
+      "actual_sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7"
     },
     {
       "path": "reports/provider-backlog.json",
@@ -275,53 +275,53 @@
       "status": "verified",
       "expected_bytes": 53713,
       "actual_bytes": 53713,
-      "expected_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b",
-      "actual_sha256": "5082bdb5a0e6de81bba2352eb8aabe7be6693c57319dd50bc66caa1c0f8bcd2b"
+      "expected_sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4",
+      "actual_sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "status": "verified",
-      "expected_bytes": 17021,
-      "actual_bytes": 17021,
-      "expected_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9",
-      "actual_sha256": "e99737c388a9a1e52a1321fc8eafdf4a900cf91d7feb70679465c2ef5b3e96d9"
+      "expected_bytes": 17019,
+      "actual_bytes": 17019,
+      "expected_sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500",
+      "actual_sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "status": "verified",
-      "expected_bytes": 9491,
-      "actual_bytes": 9491,
-      "expected_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764",
-      "actual_sha256": "544366f53259590ac8aff4c279793d05d5b87b2c8296db19b2675c124d424764"
+      "expected_bytes": 9487,
+      "actual_bytes": 9487,
+      "expected_sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54",
+      "actual_sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "status": "verified",
-      "expected_bytes": 4516,
-      "actual_bytes": 4516,
-      "expected_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff",
-      "actual_sha256": "a3055200162934d447489df856ddbfcf59157bca33437505750dc52a6b680dff"
+      "expected_bytes": 4512,
+      "actual_bytes": 4512,
+      "expected_sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16",
+      "actual_sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "status": "verified",
-      "expected_bytes": 186275,
-      "actual_bytes": 186275,
-      "expected_sha256": "b353ae426799425231449a35b069d645a989f5d5dc479b90b29fb27dccd0db0a",
-      "actual_sha256": "b353ae426799425231449a35b069d645a989f5d5dc479b90b29fb27dccd0db0a"
+      "expected_bytes": 198309,
+      "actual_bytes": 198309,
+      "expected_sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671",
+      "actual_sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 12536,
-      "actual_bytes": 12536,
-      "expected_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f",
-      "actual_sha256": "761ace9b89d80607fe3111ac26801744771b43592b37d97e3ec76b5deffd6f7f"
+      "expected_bytes": 12562,
+      "actual_bytes": 12562,
+      "expected_sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138",
+      "actual_sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -347,8 +347,8 @@
       "status": "verified",
       "expected_bytes": 4463,
       "actual_bytes": 4463,
-      "expected_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c",
-      "actual_sha256": "2fb8b2fdedc55947c5d6efa029c08cd5013bb0e92932cda15caa30d30c0cfe2c"
+      "expected_sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474",
+      "actual_sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474"
     },
     {
       "path": "RELEASE_NOTES.md",
@@ -356,8 +356,8 @@
       "status": "verified",
       "expected_bytes": 3342,
       "actual_bytes": 3342,
-      "expected_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b",
-      "actual_sha256": "14a5cc46d174b08281096143169cbf8f2eef0af8444ed12c6661a0beaa84ec6b"
+      "expected_sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb",
+      "actual_sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-25T05:05:17Z",
+  "generated_at": "2026-06-29T09:06:00Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {
-    "total": 256,
+    "total": 276,
     "verified": 22,
     "failed": 87,
-    "skipped": 147,
+    "skipped": 167,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 147,
+        "count": 167,
         "status": "skipped"
       },
       {
@@ -42,6 +42,16 @@
         "reason": "tour_service_root_missing_operation_path"
       },
       {
+        "key": "epost_wadl_metadata_only",
+        "count": 17,
+        "reason": "epost_wadl_metadata_only"
+      },
+      {
+        "key": "ulsan_missing_required_params",
+        "count": 13,
+        "reason": "ulsan_missing_required_params"
+      },
+      {
         "key": "oneclick_connection_refused",
         "count": 11,
         "reason": "oneclick_connection_refused"
@@ -65,11 +75,6 @@
         "key": "qnet_wadl_metadata_only",
         "count": 9,
         "reason": "qnet_wadl_metadata_only"
-      },
-      {
-        "key": "epost_wadl_metadata_only",
-        "count": 8,
-        "reason": "epost_wadl_metadata_only"
       },
       {
         "key": "korad_wadl_metadata_only",
@@ -152,6 +157,11 @@
         "reason": "seoul_bus_service_key_not_registered"
       },
       {
+        "key": "epost_missing_required_params",
+        "count": 3,
+        "reason": "epost_missing_required_params"
+      },
+      {
         "key": "itfind_endpoint_not_found",
         "count": 3,
         "reason": "itfind_endpoint_not_found"
@@ -167,11 +177,6 @@
         "reason": "sisul_missing_required_params"
       },
       {
-        "key": "ulsan_missing_required_params",
-        "count": 3,
-        "reason": "ulsan_missing_required_params"
-      },
-      {
         "key": "ulsan_service_key_not_registered",
         "count": 3,
         "reason": "ulsan_service_key_not_registered"
@@ -180,11 +185,6 @@
         "key": "airport_missing_required_params",
         "count": 2,
         "reason": "airport_missing_required_params"
-      },
-      {
-        "key": "epost_missing_required_params",
-        "count": 2,
-        "reason": "epost_missing_required_params"
       },
       {
         "key": "gblib_service_key_not_registered",
@@ -264,9 +264,19 @@
         "provider": "tour"
       },
       {
+        "key": "epost",
+        "count": 25,
+        "provider": "epost"
+      },
+      {
         "key": "sisul",
         "count": 20,
         "provider": "sisul"
+      },
+      {
+        "key": "ulsan",
+        "count": 16,
+        "provider": "ulsan"
       },
       {
         "key": "andong",
@@ -277,11 +287,6 @@
         "key": "ekape",
         "count": 15,
         "provider": "ekape"
-      },
-      {
-        "key": "epost",
-        "count": 15,
-        "provider": "epost"
       },
       {
         "key": "korad",
@@ -339,11 +344,6 @@
         "provider": "uiryeong"
       },
       {
-        "key": "ulsan",
-        "count": 6,
-        "provider": "ulsan"
-      },
-      {
         "key": "jeonju",
         "count": 5,
         "provider": "jeonju"
@@ -391,9 +391,19 @@
         "host": "oneclick.law.go.kr:80"
       },
       {
+        "key": "openapi.epost.go.kr:80",
+        "count": 22,
+        "host": "openapi.epost.go.kr:80"
+      },
+      {
         "key": "data.sisul.or.kr",
         "count": 20,
         "host": "data.sisul.or.kr"
+      },
+      {
+        "key": "openapi.its.ulsan.kr",
+        "count": 16,
+        "host": "openapi.its.ulsan.kr"
       },
       {
         "key": "data.ekape.or.kr",
@@ -419,11 +429,6 @@
         "key": "open.itfind.or.kr",
         "count": 13,
         "host": "open.itfind.or.kr"
-      },
-      {
-        "key": "openapi.epost.go.kr:80",
-        "count": 13,
-        "host": "openapi.epost.go.kr:80"
       },
       {
         "key": "apis.data.go.kr",
@@ -466,11 +471,6 @@
         "host": "openapi.ebid.lh.or.kr"
       },
       {
-        "key": "openapi.its.ulsan.kr",
-        "count": 6,
-        "host": "openapi.its.ulsan.kr"
-      },
-      {
         "key": "openapi.kpx.or.kr",
         "count": 6,
         "host": "openapi.kpx.or.kr"
@@ -511,14 +511,14 @@
         "host": "oneclick.law.go.kr"
       },
       {
+        "key": "openapi.epost.go.kr",
+        "count": 3,
+        "host": "openapi.epost.go.kr"
+      },
+      {
         "key": "openapi.gblib.or.kr",
         "count": 3,
         "host": "openapi.gblib.or.kr"
-      },
-      {
-        "key": "openapi.epost.go.kr",
-        "count": 2,
-        "host": "openapi.epost.go.kr"
       },
       {
         "key": "data.myhome.go.kr:443",
@@ -529,7 +529,7 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 227,
+        "count": 247,
         "kind": "external_endpoint"
       },
       {

--- a/reports/latest-verification.json
+++ b/reports/latest-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-25T05:05:17Z",
+  "generated_at": "2026-06-29T09:06:00Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 263,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 283,
   "truncated": true,
-  "filtered_count": 256,
+  "filtered_count": 276,
   "summary": {
-    "total": 256,
+    "total": 276,
     "verified": 22,
     "failed": 87,
-    "skipped": 147,
+    "skipped": 167,
     "unknown": 0
   },
   "results": [
@@ -5689,6 +5689,416 @@
       "verified_at": "2026-06-25T05:02:21Z",
       "missing_params": [
         "dataSid"
+      ]
+    },
+    {
+      "dataset_id": "15056971",
+      "title": "과학기술정보통신부 우정사업본부_우편번호 정보조회",
+      "operation": "새우편번호 정보",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "countPerPage": "1",
+        "currentPage": "1",
+        "srchwrd": ""
+      },
+      "missing_params": [
+        "srchwrd"
+      ]
+    },
+    {
+      "dataset_id": "15057018",
+      "title": "과학기술정보통신부 우정사업본부_집배구 구분코드 조회서비스",
+      "operation": "집배구 구분코드 조회서비스",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "addr": "",
+        "mailDivCd": "",
+        "zip": ""
+      },
+      "missing_params": [
+        "zip",
+        "addr",
+        "mailDivCd"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "광역시/도 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z"
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명목록조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "roadEngFirstName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "roadEngFirstName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명주소검색",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "countPerPage": "1",
+        "currentPage": "1",
+        "keyword": "",
+        "roadEngFirstName": "",
+        "roadEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "roadEngFirstName",
+        "roadEngName",
+        "keyword"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "도로명첫자조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "시/군/구 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "읍면동목록조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "districtEngFirstName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "districtEngFirstName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "읍면동첫자조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName"
+      ]
+    },
+    {
+      "dataset_id": "15059038",
+      "title": "과학기술정보통신부 우정사업본부_영문우편번호조회서비스",
+      "operation": "지번주소검색",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr:80",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_wadl_metadata_only",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "cityEngName": "",
+        "countPerPage": "1",
+        "currentPage": "1",
+        "districtEngFirstName": "",
+        "districtEngName": "",
+        "keyword": "",
+        "stateEngName": ""
+      },
+      "missing_params": [
+        "stateEngName",
+        "cityEngName",
+        "districtEngFirstName",
+        "districtEngName",
+        "keyword"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "AVNI통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "DSRC통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 버스 승하차 정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "BasicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm",
+        "BasicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 정기 교통량",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicYear": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "streetName": ""
+      },
+      "missing_params": [
+        "streetName",
+        "basicYear"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 정기 통행속도",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicYear": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "streetName": ""
+      },
+      "missing_params": [
+        "streetName",
+        "basicYear"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "노선별 버스 승하차정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "routeNo": ""
+      },
+      "missing_params": [
+        "routeNo",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "버스통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "정류장별 버스 승하차정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stopName": ""
+      },
+      "missing_params": [
+        "stopName",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "지역별 버스 승하차 정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨3 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
       ]
     }
   ]

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",

--- a/reports/ulsan-verification-summary.json
+++ b/reports/ulsan-verification-summary.json
@@ -1,34 +1,33 @@
 {
-  "generated_at": "2026-06-25T00:06:29Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\ulsan-verification.json",
+  "generated_at": "2026-06-29T09:04:28Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/ulsan-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 0,
     "failed": 3,
-    "skipped": 3,
+    "skipped": 13,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
+        "key": "skipped",
+        "count": 13,
+        "status": "skipped"
+      },
+      {
         "key": "failed",
         "count": 3,
         "status": "failed"
-      },
-      {
-        "key": "skipped",
-        "count": 3,
-        "status": "skipped"
       }
     ],
     "by_reason": [
       {
         "key": "ulsan_missing_required_params",
-        "count": 3,
+        "count": 13,
         "reason": "ulsan_missing_required_params"
       },
       {
@@ -40,21 +39,21 @@
     "by_provider": [
       {
         "key": "ulsan",
-        "count": 6,
+        "count": 16,
         "provider": "ulsan"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.its.ulsan.kr",
-        "count": 6,
+        "count": 16,
         "host": "openapi.its.ulsan.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 6,
+        "count": 16,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/ulsan-verification.json
+++ b/reports/ulsan-verification.json
@@ -1,20 +1,14 @@
 {
-  "generated_at": "2026-06-25T00:06:29Z",
+  "generated_at": "2026-06-29T09:04:28Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 6,
-  "timeout": "8s",
+  "limit": 16,
   "truncated": true,
-  "filters": {
-    "provider": "ulsan",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 6,
+  "filtered_count": 16,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 0,
     "failed": 3,
-    "skipped": 3,
+    "skipped": 13,
     "unknown": 0
   },
   "results": [
@@ -151,6 +145,214 @@
         "pageNo": "1"
       },
       "body_shape": "xml_error"
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "AVNI통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "DSRC통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 버스 승하차 정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "BasicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm",
+        "BasicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 정기 교통량",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicYear": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "streetName": ""
+      },
+      "missing_params": [
+        "streetName",
+        "basicYear"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "가로별 정기 통행속도",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicYear": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "streetName": ""
+      },
+      "missing_params": [
+        "streetName",
+        "basicYear"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "노선별 버스 승하차정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "routeNo": ""
+      },
+      "missing_params": [
+        "routeNo",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "버스통행패턴(동별)",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "정류장별 버스 승하차정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stopName": ""
+      },
+      "missing_params": [
+        "stopName",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057770",
+      "title": "울산광역시 교통정보",
+      "operation": "지역별 버스 승하차 정보",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "basicDay": "",
+        "dongnm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dongnm",
+        "basicDay"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨3 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:02:46Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
     }
   ]
 }

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T08:46:15Z",
+  "generated_at": "2026-06-29T09:06:32Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -8,12 +8,12 @@
   "timeout": "10s",
   "summary": {
     "operations": 12205,
-    "evidence_total": 256,
+    "evidence_total": 276,
     "uncovered_gateway_candidates": 11409,
-    "uncovered_adapter_candidates": 340,
+    "uncovered_adapter_candidates": 320,
     "missing_adapter_hosts": 10,
     "planned_batches": 9,
-    "planned_operations": 83
+    "planned_operations": 70
   },
   "batches": [
     {
@@ -50,8 +50,8 @@
       "provider": "epost",
       "kind": "external_endpoint",
       "candidates": 28,
-      "uncovered_candidates": 13,
-      "planned_operations": 10,
+      "uncovered_candidates": 3,
+      "planned_operations": 3,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
       "output": ".datapan/verification/epost-next.json"
     },
@@ -100,8 +100,8 @@
       "provider": "ulsan",
       "kind": "external_endpoint",
       "candidates": 20,
-      "uncovered_candidates": 14,
-      "planned_operations": 10,
+      "uncovered_candidates": 4,
+      "planned_operations": 4,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
       "output": ".datapan/verification/ulsan-next.json"
     }

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-29T08:46:04Z",
+  "generated_at": "2026-06-29T09:06:20Z",
   "datapan_version": "0.1.0-dev",
   "count": 20,
   "schemas": [

--- a/scripts/validate-runtime-evidence-growth.py
+++ b/scripts/validate-runtime-evidence-growth.py
@@ -102,7 +102,7 @@ def validate_consistency(path: pathlib.Path, report: dict[str, object]) -> None:
 
     operations = int(report_coverage["operations"])
     evidence_total = int(report_evidence["total"])
-    expected_percent = round((evidence_total / operations) * 100, 2)
+    expected_percent = round((evidence_total / operations) * 100, 1)
     if report_evidence.get("coverage_percent") != expected_percent:
         raise ValueError(
             f"evidence.coverage_percent expected {expected_percent}, got {report_evidence.get('coverage_percent')}"


### PR DESCRIPTION
Closes #19

## Gap

data.go.kr runtime evidence coverage is still far below the documented 10% target. The previous release had `256` evidence records; this PR adds the next priority external endpoint batches for `epost` and `ulsan` and raises checked runtime evidence to `276`.

## Changes

- Merge excluded-from-latest `epost` and `ulsan` verification batches into provider-specific reports.
- Regenerate `reports/latest-verification.json`, summaries, release readiness/verification reports, runtime evidence growth, manifest, schema index, and release notes.
- Record the #19 evidence growth in the data.go.kr mastery plan and registry blueprint.
- Align `validate-runtime-evidence-growth.py` with the release generator's one-decimal percentage rounding so generated `2.3%` coverage validates from the source totals.

## Warning Status

- Active warning remains: `runtime_evidence_growth_target` / `runtime_evidence_below_target`.
- Target: `1,221` evidence records for `10.0%` runtime evidence coverage.
- Actual: `276` evidence records (`2.3%`).
- Remaining gap: `945` additional evidence records.
- This warning is not harmless and is intentionally preserved in readiness output.

## Evidence Boundary

The new `epost` and `ulsan` records are not successful callable coverage.

- `epost`: `25` total provider evidence records after merge, all `skipped`.
- `ulsan`: `16` total provider evidence records after merge, `3` failed and `13` skipped.
- Latest evidence has `276` unique records by provider, dataset, operation, host, and dependency class.

## Validation

- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 -m py_compile scripts/validate-runtime-evidence-growth.py`
- `jq empty sources/*.json reports/*/error-action-catalog.json reports/data-go-kr/external-coverage-summary.json reports/data-go-kr/registry-impact-plan.json reports/data-go-kr/runtime-evidence-growth.json reports/source-reference-drift.json reports/latest-verification.json reports/latest-verification-summary.json reports/latest-release-readiness.json reports/latest-release-verification.json manifest.json schemas/*.json schemas/index.json`
- `git diff --check`

Local release draft/verify/readiness were run with a materialized `data/data-go-kr.registry.json` because this checkout does not have `git lfs`; the file was restored to the tracked LFS pointer afterward. GitHub Actions checks out LFS for release verification.
