### PR TITLE
feat: Add gateway geoje jeonju q-net runtime evidence batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ re-importing the upstream data.go.kr catalog every time.
 - Missing external adapter hosts: `10`
 - Provider split readiness: `ready`
   (`26` adapters, `26` verification-capable, `21` call-capable)
-- Runtime verification evidence: `276` bounded checks merged into
-  `reports/latest-verification.json` (`22` verified, `87` failed, `167`
+- Runtime verification evidence: `316` bounded checks merged into
+  `reports/latest-verification.json` (`22` verified, `87` failed, `207`
   skipped)
 - Missing external host probe: `28` unadapted external endpoint checks in
   `reports/unadapted-external-probe.json` (`14` HTTP 404, `7` timeout, `6`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-29T09:06:20Z`
+- generated_at: `2026-06-29T09:17:25Z`
 - provider: `data.go.kr`
 - datapan_version: `0.1.0-dev`
 - source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
@@ -24,12 +24,12 @@
 - route_disposition: `28` routes, `14` dead-route candidates, `14` transient failures, `0` parameter-blocked, `0` adapter candidates
 - route_disposition_artifact: `reports/route-disposition.json`
 - provider_backlog: `179` hosts, `10` missing-adapter hosts, `28` operations needing adapters
-- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.3%`, evidence-adjusted adapter candidates `0`
+- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.6%`, evidence-adjusted adapter candidates `0`
 - coverage_artifact: `reports/coverage.json`
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
-- verification_plan: `9` batches, `70` planned operations, `11409` gateway gaps, `320` adapter gaps
+- verification_plan: `9` batches, `70` planned operations, `11399` gateway gaps, `290` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
-- runtime_evidence_growth: `2.3%` coverage, target `10.0%`, remaining `945`, status `below_target`
+- runtime_evidence_growth: `2.6%` coverage, target `10.0%`, remaining `905`, status `below_target`
 - runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
 - runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
@@ -43,7 +43,7 @@ Top adapter targets:
 
 ## Verification Evidence
 
-- verification: `276` total, `22` verified, `87` failed, `167` skipped, `0` unknown
+- verification: `316` total, `22` verified, `87` failed, `207` skipped, `0` unknown
 - verification_artifact: `reports/latest-verification.json`
 - verification_summary_artifact: `reports/latest-verification-summary.json`
 
@@ -52,9 +52,9 @@ Provider evidence:
 - `oneclick-law`: `30`
 - `tour`: `26`
 - `epost`: `25`
+- `q-net`: `25`
+- `data.go.kr`: `20`
 - `sisul`: `20`
-- `ulsan`: `16`
-- `andong`: `15`
 
 - unadapted_external_probe: `28` total, `0` verified, `28` failed, `0` skipped, `0` unknown
 - unadapted_external_probe_artifact: `reports/unadapted-external-probe.json`

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -197,8 +197,10 @@ CI should fail rather than treating the checked-in summary as authoritative.
    external adapters. Started by Gira #19 with `epost` and `ulsan`
    excluded-from-latest external endpoint batches. This grows checked runtime
    evidence from `256` to `276`, but the new records are skipped boundary
-   evidence, not successful callable coverage. Runtime evidence remains below
-   the `10%` target with `945` additional evidence records still required.
+   evidence, not successful callable coverage. Continued by Gira #21 with
+   gateway, `geoje`, `jeonju`, and `q-net` boundary batches, growing checked
+   runtime evidence to `316`. Runtime evidence remains below the `10%` target
+   with `905` additional evidence records still required.
 10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -105,10 +105,10 @@ Current gaps:
 - Error inventory has draft action routing for data.go.kr and the first
   non-data.go.kr profile batch, but runtime evidence is not yet generated for
   those non-data.go.kr sources.
-- Runtime evidence coverage is much lower than callable coverage. Gira #19
-  raises data.go.kr runtime evidence from `256` to `276`, but the release
-  readiness warning remains active: the `10%` target requires `1,221` evidence
-  records, so `945` additional records are still required.
+- Runtime evidence coverage is much lower than callable coverage. Gira #19 and
+  Gira #21 raise data.go.kr runtime evidence from `256` to `316`, but the
+  release readiness warning remains active: the `10%` target requires `1,221`
+  evidence records, so `905` additional records are still required.
 - Multi-source report grouping is designed but not implemented.
 - Impact plans are specified and a data.go.kr draft plan is checked in, but
   full `datapan-cli` generation is not implemented.
@@ -283,9 +283,10 @@ Use this order unless a production failure changes priority:
 12. Add a manual or scheduled drift-check workflow. Tracked by Gira #13.
 13. Add a data.go.kr runtime evidence growth summary. Tracked by Gira #15.
 14. Expand runtime verification evidence by source/provider priority. Started
-    by Gira #19 with `epost` and `ulsan` external endpoint batches; this is
-    skipped boundary evidence growth, not proof that those operations are
-    callable.
+    by Gira #19 with `epost` and `ulsan` external endpoint batches and
+    continued by Gira #21 with gateway, `geoje`, `jeonju`, and `q-net`
+    batches; this is skipped boundary evidence growth, not proof that those
+    operations are callable.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
@@ -132,7 +132,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 7490,
-      "sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a"
+      "sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -146,91 +146,91 @@
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
       "bytes": 5588,
-      "sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd"
+      "sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
       "bytes": 505,
-      "sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b"
+      "sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
       "bytes": 15985,
-      "sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee"
+      "sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
       "bytes": 3305406,
-      "sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72"
+      "sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
       "bytes": 11399477,
-      "sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3"
+      "sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
       "bytes": 15197,
-      "sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0"
+      "sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
       "bytes": 22374,
-      "sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7"
+      "sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
       "bytes": 53713,
-      "sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4"
+      "sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
       "bytes": 17019,
-      "sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500"
+      "sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
       "bytes": 9487,
-      "sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54"
+      "sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
       "bytes": 4512,
-      "sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16"
+      "sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "schema": "https://schemas.datapan.dev/datapan.verification.v1.schema.json",
-      "bytes": 198309,
-      "sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671"
+      "bytes": 219831,
+      "sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 12562,
-      "sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138"
+      "bytes": 13185,
+      "sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -250,13 +250,13 @@
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "bytes": 4463,
-      "sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474"
+      "sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
-      "bytes": 3342,
-      "sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb"
+      "bytes": 3346,
+      "sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,6 +1,6 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-29T09:06:20Z
+- generated_at: 2026-06-29T09:17:25Z
 - datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
 - source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
   "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:24Z",
+  "generated_at": "2026-06-29T09:17:30Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -41,14 +41,14 @@
   },
   "evidence": {
     "present": true,
-    "generated_at": "2026-06-29T09:06:00Z",
-    "total": 276,
+    "generated_at": "2026-06-29T09:17:01Z",
+    "total": 316,
     "verified": 22,
     "failed": 87,
-    "skipped": 167,
+    "skipped": 207,
     "unknown": 0,
-    "verified_percent": 8,
-    "evidence_operation_percent": 2.3
+    "verified_percent": 7,
+    "evidence_operation_percent": 2.6
   },
   "route_evidence": {
     "present": true,
@@ -381,7 +381,7 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-29T09:06:24Z",
+    "generated_at": "2026-06-29T09:17:30Z",
     "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
@@ -21,20 +21,20 @@
     "call_capable_adapters": 21
   },
   "evidence": {
-    "total": 276,
+    "total": 316,
     "verified": 22,
     "failed": 87,
-    "skipped": 167,
+    "skipped": 207,
     "unknown": 0,
-    "coverage_percent": 2.3,
+    "coverage_percent": 2.6,
     "by_kind": [
       {
         "key": "data_go_kr_gateway",
-        "count": 10
+        "count": 20
       },
       {
         "key": "external_endpoint",
-        "count": 247
+        "count": 277
       },
       {
         "key": "service_root",
@@ -45,14 +45,14 @@
   "growth_target": {
     "target_percent": 10,
     "target_evidence_total": 1221,
-    "remaining_to_target": 945,
+    "remaining_to_target": 905,
     "status": "below_target"
   },
   "verification_plan": {
     "planned_batches": 9,
     "planned_operations": 70,
-    "uncovered_gateway_candidates": 11409,
-    "uncovered_adapter_candidates": 320,
+    "uncovered_gateway_candidates": 11399,
+    "uncovered_adapter_candidates": 290,
     "missing_adapter_hosts": 10,
     "planned_by_kind": [
       {
@@ -69,7 +69,7 @@
         "label": "gateway",
         "kind": "data_go_kr_gateway",
         "candidates": 11419,
-        "uncovered_candidates": 11409,
+        "uncovered_candidates": 11399,
         "planned_operations": 10,
         "output": ".datapan/verification/gateway-next.json"
       },
@@ -105,7 +105,7 @@
         "provider": "geoje",
         "kind": "external_endpoint",
         "candidates": 41,
-        "uncovered_candidates": 35,
+        "uncovered_candidates": 25,
         "planned_operations": 10,
         "output": ".datapan/verification/geoje-next.json"
       },
@@ -114,7 +114,7 @@
         "provider": "jeonju",
         "kind": "external_endpoint",
         "candidates": 80,
-        "uncovered_candidates": 75,
+        "uncovered_candidates": 65,
         "planned_operations": 10,
         "output": ".datapan/verification/jeonju-next.json"
       },
@@ -123,7 +123,7 @@
         "provider": "q-net",
         "kind": "external_endpoint",
         "candidates": 147,
-        "uncovered_candidates": 132,
+        "uncovered_candidates": 122,
         "planned_operations": 10,
         "output": ".datapan/verification/q-net-next.json"
       },
@@ -157,7 +157,7 @@
     {
       "kind": "runtime_evidence_below_target",
       "severity": "warning",
-      "message": "Runtime evidence coverage is 2.3% against the 10.0% target; 945 additional evidence records are needed before this target is met."
+      "message": "Runtime evidence coverage is 2.6% against the 10.0% target; 905 additional evidence records are needed before this target is met."
     }
   ]
 }

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/geoje-verification-summary.json
+++ b/reports/geoje-verification-summary.json
@@ -1,22 +1,21 @@
 {
-  "generated_at": "2026-06-24T22:23:30Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\geoje-verification.json",
+  "generated_at": "2026-06-29T09:16:46Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/geoje-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 2,
     "failed": 0,
-    "skipped": 4,
+    "skipped": 14,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 4,
+        "count": 14,
         "status": "skipped"
       },
       {
@@ -28,28 +27,33 @@
     "by_reason": [
       {
         "key": "geoje_missing_required_params",
-        "count": 4,
+        "count": 10,
         "reason": "geoje_missing_required_params"
+      },
+      {
+        "key": "missing_auth",
+        "count": 4,
+        "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "geoje",
-        "count": 6,
+        "count": 16,
         "provider": "geoje"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.geoje.go.kr",
-        "count": 6,
+        "count": 16,
         "host": "data.geoje.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 6,
+        "count": 16,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/geoje-verification.json
+++ b/reports/geoje-verification.json
@@ -1,20 +1,14 @@
 {
-  "generated_at": "2026-06-24T22:23:30Z",
+  "generated_at": "2026-06-29T09:16:46Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 6,
-  "timeout": "8s",
+  "limit": 16,
   "truncated": true,
-  "filters": {
-    "provider": "geoje",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 6,
+  "filtered_count": 16,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 2,
     "failed": 0,
-    "skipped": 4,
+    "skipped": 14,
     "unknown": 0
   },
   "results": [
@@ -132,6 +126,172 @@
       },
       "missing_params": [
         "geojeshowexhibitionId"
+      ]
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "노선별 정류장 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z"
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스노선 정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스도착 정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "ars_id": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "ars_id"
+      ]
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스정류장 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "ars_id": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "ars_id"
+      ]
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "goodshopId": ""
+      },
+      "missing_params": [
+        "goodshopId"
+      ]
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 이미지 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "goodshopId": ""
+      },
+      "missing_params": [
+        "goodshopId"
+      ]
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 목록 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 상세정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "geojefoodId": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "geojefoodId"
+      ]
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 이미지 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "geojefoodId": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "geojefoodId"
       ]
     }
   ]

--- a/reports/jeonju-verification-summary.json
+++ b/reports/jeonju-verification-summary.json
@@ -1,19 +1,23 @@
 {
-  "generated_at": "2026-06-24T15:18:45Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\jeonju-verification.json",
+  "generated_at": "2026-06-29T09:16:46Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/jeonju-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 5,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "groups": {
     "by_status": [
+      {
+        "key": "skipped",
+        "count": 10,
+        "status": "skipped"
+      },
       {
         "key": "failed",
         "count": 5,
@@ -22,9 +26,19 @@
     ],
     "by_reason": [
       {
+        "key": "missing_auth",
+        "count": 7,
+        "reason": "missing_auth"
+      },
+      {
         "key": "jeonju_http_404_not_found",
         "count": 3,
         "reason": "jeonju_http_404_not_found"
+      },
+      {
+        "key": "jeonju_missing_required_params",
+        "count": 3,
+        "reason": "jeonju_missing_required_params"
       },
       {
         "key": "jeonju_http_405_method_not_allowed",
@@ -35,21 +49,21 @@
     "by_provider": [
       {
         "key": "jeonju",
-        "count": 5,
+        "count": 15,
         "provider": "jeonju"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.jeonju.go.kr",
-        "count": 5,
+        "count": 15,
         "host": "openapi.jeonju.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 5,
+        "count": 15,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/jeonju-verification.json
+++ b/reports/jeonju-verification.json
@@ -1,20 +1,14 @@
 {
-  "generated_at": "2026-06-24T15:18:45Z",
+  "generated_at": "2026-06-29T09:16:46Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 5,
-  "timeout": "5s",
+  "limit": 15,
   "truncated": true,
-  "filters": {
-    "provider": "jeonju",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 5,
+  "filtered_count": 15,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 5,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "results": [
@@ -104,6 +98,192 @@
         "dong": "중앙동"
       },
       "body_shape": "empty"
+    },
+    {
+      "dataset_id": "15004788",
+      "title": "전북특별자치도 전주시_무선인터넷 존",
+      "operation": "무선인터넷존 위치정보 서비스 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "instfacType": "",
+        "instplaceNm": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadAdd": ""
+      }
+    },
+    {
+      "dataset_id": "15004788",
+      "title": "전북특별자치도 전주시_무선인터넷 존",
+      "operation": "현재위치에서 무선인터넷존 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "posx": "127.1480",
+        "posy": "35.8242",
+        "searchDts": "1000"
+      }
+    },
+    {
+      "dataset_id": "15004987",
+      "title": "전북특별자치도 전주시_지구대 현황",
+      "operation": "지구대현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "patrolDong": "중앙동",
+        "patrolSid": "",
+        "patrolTitle": "",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15010319",
+      "title": "전북특별자치도 전주시_무인민원발급정보",
+      "operation": "무인민원발급 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "insArea": "",
+        "newAddr": "",
+        "oldAddr": "",
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15010990",
+      "title": "전북특별자치도 전주시_어린이보호구역",
+      "operation": "어린이보호구역 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "newAddr": "",
+        "oldAddr": "",
+        "pacNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15012184",
+      "title": "전북특별자치도 전주시_자전거보관소",
+      "operation": "자전거보관소 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "centerNm": "",
+        "gu": "완산구",
+        "pageSize": "1",
+        "startPage": "1",
+        "totalCount": ""
+      }
+    },
+    {
+      "dataset_id": "15012185",
+      "title": "전북특별자치도 전주시_중개업소",
+      "operation": "중개업소 정보 서비스",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "shopAddr": "",
+        "shopNm": "",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15012201",
+      "title": "전북특별자치도 전주시_교통카드충전소",
+      "operation": "교통카드충전소 운영",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "addr": "",
+        "agencyNm�": "",
+        "franNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "agencyNm�",
+        "franNm",
+        "addr"
+      ]
+    },
+    {
+      "dataset_id": "15012203",
+      "title": "전북특별자치도 전주시_분리수거함 설치 정보",
+      "operation": "분리수거함 설치 정보",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "dong": "중앙동",
+        "gu": "완산구",
+        "insLocation": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "insLocation"
+      ]
+    },
+    {
+      "dataset_id": "15020602",
+      "title": "전북특별자치도 전주시_급식소 현황",
+      "operation": "집단급식소 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
     }
   ]
 }

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
   "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-29T09:06:41Z",
+  "generated_at": "2026-06-29T09:17:43Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -243,7 +243,7 @@
       "artifact_kind": "runtime_evidence_growth",
       "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
       "expected": 1221,
-      "actual": 276
+      "actual": 316
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -194,8 +194,8 @@
       "status": "verified",
       "expected_bytes": 7490,
       "actual_bytes": 7490,
-      "expected_sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a",
-      "actual_sha256": "a8ecd299b93acd43f6a083f996975a9c663646a4ccea822cb5a233a468f41e1a"
+      "expected_sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924",
+      "actual_sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -212,8 +212,8 @@
       "status": "verified",
       "expected_bytes": 5588,
       "actual_bytes": 5588,
-      "expected_sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd",
-      "actual_sha256": "0cc61bd229a076041535a01728f517b7d8062270151716d661e74272d79b36dd"
+      "expected_sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602",
+      "actual_sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602"
     },
     {
       "path": "reports/catalog-diff.json",
@@ -221,8 +221,8 @@
       "status": "verified",
       "expected_bytes": 505,
       "actual_bytes": 505,
-      "expected_sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b",
-      "actual_sha256": "5139d66eb1e827371c5fd3be04bcc9ee9ecd06bb2143791ae6426d73213faa2b"
+      "expected_sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31",
+      "actual_sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31"
     },
     {
       "path": "reports/catalog-audit.json",
@@ -230,8 +230,8 @@
       "status": "verified",
       "expected_bytes": 15985,
       "actual_bytes": 15985,
-      "expected_sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee",
-      "actual_sha256": "409f5fc5a135265a7fbd9dfcc7514e61f0d3d321a55194e8a9e81edd00aec4ee"
+      "expected_sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45",
+      "actual_sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45"
     },
     {
       "path": "reports/error-catalog.json",
@@ -239,8 +239,8 @@
       "status": "verified",
       "expected_bytes": 3305406,
       "actual_bytes": 3305406,
-      "expected_sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72",
-      "actual_sha256": "46d064c6a9c7979e0102dd1be243b4876d9284c0d5c41ee515ead457bdb52e72"
+      "expected_sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78",
+      "actual_sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78"
     },
     {
       "path": "reports/dependencies.json",
@@ -248,8 +248,8 @@
       "status": "verified",
       "expected_bytes": 11399477,
       "actual_bytes": 11399477,
-      "expected_sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3",
-      "actual_sha256": "ab9706ad30e8ecbe8d11dde107728fe3ff01f9cc938e52b107704d64e84474a3"
+      "expected_sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b",
+      "actual_sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b"
     },
     {
       "path": "reports/adapter-targets.json",
@@ -257,8 +257,8 @@
       "status": "verified",
       "expected_bytes": 15197,
       "actual_bytes": 15197,
-      "expected_sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0",
-      "actual_sha256": "24ca2d1147486832099008f67c99f5df35dac4b40bdbd343c57c93541f5434d0"
+      "expected_sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070",
+      "actual_sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070"
     },
     {
       "path": "reports/route-disposition.json",
@@ -266,8 +266,8 @@
       "status": "verified",
       "expected_bytes": 22374,
       "actual_bytes": 22374,
-      "expected_sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7",
-      "actual_sha256": "55b42433b95d023b74af6104ecd075d7c22e292a2b76d8331abb52b9bfec96c7"
+      "expected_sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df",
+      "actual_sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df"
     },
     {
       "path": "reports/provider-backlog.json",
@@ -275,8 +275,8 @@
       "status": "verified",
       "expected_bytes": 53713,
       "actual_bytes": 53713,
-      "expected_sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4",
-      "actual_sha256": "ab7fc67ff40a9791d6159dad660a2cdc1715ba6458b4c9058c4f71865128c3a4"
+      "expected_sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6",
+      "actual_sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6"
     },
     {
       "path": "reports/coverage.json",
@@ -284,8 +284,8 @@
       "status": "verified",
       "expected_bytes": 17019,
       "actual_bytes": 17019,
-      "expected_sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500",
-      "actual_sha256": "03d970e54b1a752dc90ec6ff3d942bd5bf1ca881645b94f2bed01c09fdd8e500"
+      "expected_sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92",
+      "actual_sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92"
     },
     {
       "path": "reports/verification-plan.json",
@@ -293,8 +293,8 @@
       "status": "verified",
       "expected_bytes": 9487,
       "actual_bytes": 9487,
-      "expected_sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54",
-      "actual_sha256": "19ed628b686dc702ec16f1e10881feb2788ce892782da3e861de54be9e65af54"
+      "expected_sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3",
+      "actual_sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
@@ -302,26 +302,26 @@
       "status": "verified",
       "expected_bytes": 4512,
       "actual_bytes": 4512,
-      "expected_sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16",
-      "actual_sha256": "30358ccf9080a9f3591e973e38ea30945a2aaacc08968d087661acfef8413f16"
+      "expected_sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822",
+      "actual_sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "status": "verified",
-      "expected_bytes": 198309,
-      "actual_bytes": 198309,
-      "expected_sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671",
-      "actual_sha256": "8f04e47b93733030e53328faa5bd33f334cdcc8c6d060c8845e128a0ccffe671"
+      "expected_bytes": 219831,
+      "actual_bytes": 219831,
+      "expected_sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20",
+      "actual_sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 12562,
-      "actual_bytes": 12562,
-      "expected_sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138",
-      "actual_sha256": "8bfb17dae20b5c63d735cd82cecf34236c7e0d60f8c4054e7e98f2a274d0d138"
+      "expected_bytes": 13185,
+      "actual_bytes": 13185,
+      "expected_sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646",
+      "actual_sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -347,17 +347,17 @@
       "status": "verified",
       "expected_bytes": 4463,
       "actual_bytes": 4463,
-      "expected_sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474",
-      "actual_sha256": "e8bc1e53a6778a95252e12d020af814342d7e38cffa8098bf155a11d68144474"
+      "expected_sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d",
+      "actual_sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "status": "verified",
-      "expected_bytes": 3342,
-      "actual_bytes": 3342,
-      "expected_sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb",
-      "actual_sha256": "c58326ce8d57c2892abbc4f1abea805b5390b7cb31f8a290f4d62f6291eaabbb"
+      "expected_bytes": 3346,
+      "actual_bytes": 3346,
+      "expected_sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45",
+      "actual_sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:06:00Z",
+  "generated_at": "2026-06-29T09:17:01Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {
-    "total": 276,
+    "total": 316,
     "verified": 22,
     "failed": 87,
-    "skipped": 167,
+    "skipped": 207,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 167,
+        "count": 207,
         "status": "skipped"
       },
       {
@@ -37,6 +37,11 @@
         "reason": "approval_required"
       },
       {
+        "key": "missing_required_params",
+        "count": 19,
+        "reason": "missing_required_params"
+      },
+      {
         "key": "tour_service_root_missing_operation_path",
         "count": 19,
         "reason": "tour_service_root_missing_operation_path"
@@ -45,6 +50,11 @@
         "key": "epost_wadl_metadata_only",
         "count": 17,
         "reason": "epost_wadl_metadata_only"
+      },
+      {
+        "key": "missing_auth",
+        "count": 17,
+        "reason": "missing_auth"
       },
       {
         "key": "ulsan_missing_required_params",
@@ -62,9 +72,9 @@
         "reason": "andong_service_not_registered"
       },
       {
-        "key": "missing_required_params",
+        "key": "geoje_missing_required_params",
         "count": 10,
-        "reason": "missing_required_params"
+        "reason": "geoje_missing_required_params"
       },
       {
         "key": "sisul_wadl_metadata_only",
@@ -142,11 +152,6 @@
         "reason": "ekape_service_key_not_registered"
       },
       {
-        "key": "geoje_missing_required_params",
-        "count": 4,
-        "reason": "geoje_missing_required_params"
-      },
-      {
         "key": "pqis_service_key_not_registered",
         "count": 4,
         "reason": "pqis_service_key_not_registered"
@@ -170,6 +175,16 @@
         "key": "jeonju_http_404_not_found",
         "count": 3,
         "reason": "jeonju_http_404_not_found"
+      },
+      {
+        "key": "jeonju_missing_required_params",
+        "count": 3,
+        "reason": "jeonju_missing_required_params"
+      },
+      {
+        "key": "qnet_missing_required_params",
+        "count": 3,
+        "reason": "qnet_missing_required_params"
       },
       {
         "key": "sisul_missing_required_params",
@@ -200,6 +215,11 @@
         "key": "jeonju_http_405_method_not_allowed",
         "count": 2,
         "reason": "jeonju_http_405_method_not_allowed"
+      },
+      {
+        "key": "qnet_separate_service_key_required",
+        "count": 2,
+        "reason": "qnet_separate_service_key_required"
       },
       {
         "key": "ekape_html_response",
@@ -269,9 +289,24 @@
         "provider": "epost"
       },
       {
+        "key": "q-net",
+        "count": 25,
+        "provider": "q-net"
+      },
+      {
+        "key": "data.go.kr",
+        "count": 20,
+        "provider": "data.go.kr"
+      },
+      {
         "key": "sisul",
         "count": 20,
         "provider": "sisul"
+      },
+      {
+        "key": "geoje",
+        "count": 16,
+        "provider": "geoje"
       },
       {
         "key": "ulsan",
@@ -289,24 +324,19 @@
         "provider": "ekape"
       },
       {
+        "key": "jeonju",
+        "count": 15,
+        "provider": "jeonju"
+      },
+      {
         "key": "korad",
         "count": 15,
         "provider": "korad"
       },
       {
-        "key": "q-net",
-        "count": 15,
-        "provider": "q-net"
-      },
-      {
         "key": "itfind",
         "count": 13,
         "provider": "itfind"
-      },
-      {
-        "key": "data.go.kr",
-        "count": 10,
-        "provider": "data.go.kr"
       },
       {
         "key": "naqs",
@@ -324,11 +354,6 @@
         "provider": "airport"
       },
       {
-        "key": "geoje",
-        "count": 6,
-        "provider": "geoje"
-      },
-      {
         "key": "kpx",
         "count": 6,
         "provider": "kpx"
@@ -342,11 +367,6 @@
         "key": "uiryeong",
         "count": 6,
         "provider": "uiryeong"
-      },
-      {
-        "key": "jeonju",
-        "count": 5,
-        "provider": "jeonju"
       },
       {
         "key": "seoul-bus",
@@ -391,14 +411,29 @@
         "host": "oneclick.law.go.kr:80"
       },
       {
+        "key": "openapi.q-net.or.kr",
+        "count": 23,
+        "host": "openapi.q-net.or.kr"
+      },
+      {
         "key": "openapi.epost.go.kr:80",
         "count": 22,
         "host": "openapi.epost.go.kr:80"
       },
       {
+        "key": "apis.data.go.kr",
+        "count": 20,
+        "host": "apis.data.go.kr"
+      },
+      {
         "key": "data.sisul.or.kr",
         "count": 20,
         "host": "data.sisul.or.kr"
+      },
+      {
+        "key": "data.geoje.go.kr",
+        "count": 16,
+        "host": "data.geoje.go.kr"
       },
       {
         "key": "openapi.its.ulsan.kr",
@@ -411,9 +446,9 @@
         "host": "data.ekape.or.kr"
       },
       {
-        "key": "openapi.q-net.or.kr",
+        "key": "openapi.jeonju.go.kr",
         "count": 15,
-        "host": "openapi.q-net.or.kr"
+        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "www.andong.go.kr",
@@ -431,11 +466,6 @@
         "host": "open.itfind.or.kr"
       },
       {
-        "key": "apis.data.go.kr",
-        "count": 10,
-        "host": "apis.data.go.kr"
-      },
-      {
         "key": "data.naqs.go.kr",
         "count": 9,
         "host": "data.naqs.go.kr"
@@ -449,11 +479,6 @@
         "key": "openapi.tour.go.kr",
         "count": 7,
         "host": "openapi.tour.go.kr"
-      },
-      {
-        "key": "data.geoje.go.kr",
-        "count": 6,
-        "host": "data.geoje.go.kr"
       },
       {
         "key": "data.uiryeong.go.kr",
@@ -474,11 +499,6 @@
         "key": "openapi.kpx.or.kr",
         "count": 6,
         "host": "openapi.kpx.or.kr"
-      },
-      {
-        "key": "openapi.jeonju.go.kr",
-        "count": 5,
-        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "ws.bus.go.kr",
@@ -521,6 +541,11 @@
         "host": "openapi.gblib.or.kr"
       },
       {
+        "key": "c.q-net.or.kr",
+        "count": 2,
+        "host": "c.q-net.or.kr"
+      },
+      {
         "key": "data.myhome.go.kr:443",
         "count": 1,
         "host": "data.myhome.go.kr:443"
@@ -529,18 +554,18 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 247,
+        "count": 277,
         "kind": "external_endpoint"
+      },
+      {
+        "key": "data_go_kr_gateway",
+        "count": 20,
+        "kind": "data_go_kr_gateway"
       },
       {
         "key": "service_root",
         "count": 19,
         "kind": "service_root"
-      },
-      {
-        "key": "data_go_kr_gateway",
-        "count": 10,
-        "kind": "data_go_kr_gateway"
       }
     ]
   }

--- a/reports/latest-verification.json
+++ b/reports/latest-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:06:00Z",
+  "generated_at": "2026-06-29T09:17:01Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 283,
+  "limit": 323,
   "truncated": true,
-  "filtered_count": 276,
+  "filtered_count": 316,
   "summary": {
-    "total": 276,
+    "total": 316,
     "verified": 22,
     "failed": 87,
-    "skipped": 167,
+    "skipped": 207,
     "unknown": 0
   },
   "results": [
@@ -6100,6 +6100,732 @@
       "missing_params": [
         "roadnm"
       ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상예비특보목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상예비특보조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상정보목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상정보문조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상특보목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "기상특보통보문조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "stnId",
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "특보코드조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "areaCode": "",
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "stnId": "",
+        "toTmFc": "",
+        "warningType": ""
+      },
+      "missing_params": [
+        "fromTmFc",
+        "toTmFc",
+        "areaCode",
+        "warningType",
+        "stnId"
+      ]
+    },
+    {
+      "dataset_id": "15000415",
+      "title": "기상청_기상특보 조회서비스",
+      "operation": "특보현황조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "params": {
+        "dataType": "json",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15000420",
+      "title": "기상청_지진정보 조회서비스",
+      "operation": "지진통보문 목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000420",
+      "title": "기상청_지진정보 조회서비스",
+      "operation": "지진통보문조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "노선별 정류장 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z"
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스노선 정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스도착 정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "ars_id": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "ars_id"
+      ]
+    },
+    {
+      "dataset_id": "15014125",
+      "title": "경상남도 거제시_버스 정보",
+      "operation": "버스정류장 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "ars_id": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "ars_id"
+      ]
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "goodshopId": ""
+      },
+      "missing_params": [
+        "goodshopId"
+      ]
+    },
+    {
+      "dataset_id": "15057807",
+      "title": "경상남도 거제시_착한가격업소",
+      "operation": "거제시 착한가격업소 이미지 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "goodshopId": ""
+      },
+      "missing_params": [
+        "goodshopId"
+      ]
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 목록 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 상세정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "geojefoodId": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "geojefoodId"
+      ]
+    },
+    {
+      "dataset_id": "15057816",
+      "title": "경상남도 거제시_거제9미전문음식점정보",
+      "operation": "거제시 전문음식점 이미지 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "geojefoodId": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "geojefoodId"
+      ]
+    },
+    {
+      "dataset_id": "15004788",
+      "title": "전북특별자치도 전주시_무선인터넷 존",
+      "operation": "무선인터넷존 위치정보 서비스 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "instfacType": "",
+        "instplaceNm": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadAdd": ""
+      }
+    },
+    {
+      "dataset_id": "15004788",
+      "title": "전북특별자치도 전주시_무선인터넷 존",
+      "operation": "현재위치에서 무선인터넷존 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "posx": "127.1480",
+        "posy": "35.8242",
+        "searchDts": "1000"
+      }
+    },
+    {
+      "dataset_id": "15004987",
+      "title": "전북특별자치도 전주시_지구대 현황",
+      "operation": "지구대현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "patrolDong": "중앙동",
+        "patrolSid": "",
+        "patrolTitle": "",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15010319",
+      "title": "전북특별자치도 전주시_무인민원발급정보",
+      "operation": "무인민원발급 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "insArea": "",
+        "newAddr": "",
+        "oldAddr": "",
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15010990",
+      "title": "전북특별자치도 전주시_어린이보호구역",
+      "operation": "어린이보호구역 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "newAddr": "",
+        "oldAddr": "",
+        "pacNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15012184",
+      "title": "전북특별자치도 전주시_자전거보관소",
+      "operation": "자전거보관소 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "centerNm": "",
+        "gu": "완산구",
+        "pageSize": "1",
+        "startPage": "1",
+        "totalCount": ""
+      }
+    },
+    {
+      "dataset_id": "15012185",
+      "title": "전북특별자치도 전주시_중개업소",
+      "operation": "중개업소 정보 서비스",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "pageSize": "1",
+        "shopAddr": "",
+        "shopNm": "",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15012201",
+      "title": "전북특별자치도 전주시_교통카드충전소",
+      "operation": "교통카드충전소 운영",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "addr": "",
+        "agencyNm�": "",
+        "franNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "agencyNm�",
+        "franNm",
+        "addr"
+      ]
+    },
+    {
+      "dataset_id": "15012203",
+      "title": "전북특별자치도 전주시_분리수거함 설치 정보",
+      "operation": "분리수거함 설치 정보",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "dong": "중앙동",
+        "gu": "완산구",
+        "insLocation": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "insLocation"
+      ]
+    },
+    {
+      "dataset_id": "15020602",
+      "title": "전북특별자치도 전주시_급식소 현황",
+      "operation": "집단급식소 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "자격취득자 연도별 연령별 수 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 연도별 실기현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 연도별 필기현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 자격취득자 연도별 성별 현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15029006",
+      "title": "한국산업인력공단_국가기술자격 대학별 학과 데이터",
+      "operation": "대학별 학과정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037354",
+      "title": "한국산업인력공단_국가자격 경력정보 제공기관 현황",
+      "operation": "경력기관 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037355",
+      "title": "한국산업인력공단_국가자격 계열별 학과 정보 데이터",
+      "operation": "계열별 학과정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z"
+    },
+    {
+      "dataset_id": "15037356",
+      "title": "한국산업인력공단_국가기술자격 학과별 직무정보",
+      "operation": "학과별 직무 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형 년도별 취득자 현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행) 연령별 취득자 현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "type": "json"
+      }
     }
   ]
 }

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/qnet-verification-summary.json
+++ b/reports/qnet-verification-summary.json
@@ -1,50 +1,69 @@
 {
-  "generated_at": "2026-06-24T00:23:41Z",
-  "source": "reports/qnet-verification.json",
+  "generated_at": "2026-06-29T09:16:46Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/qnet-verification.json",
   "provider": "data.go.kr",
-  "registry": "data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 0,
-    "skipped": 5,
+    "skipped": 15,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 5,
+        "count": 15,
         "status": "skipped"
       }
     ],
     "by_reason": [
       {
+        "key": "missing_auth",
+        "count": 5,
+        "reason": "missing_auth"
+      },
+      {
         "key": "qnet_wadl_metadata_only",
         "count": 5,
         "reason": "qnet_wadl_metadata_only"
+      },
+      {
+        "key": "qnet_missing_required_params",
+        "count": 3,
+        "reason": "qnet_missing_required_params"
+      },
+      {
+        "key": "qnet_separate_service_key_required",
+        "count": 2,
+        "reason": "qnet_separate_service_key_required"
       }
     ],
     "by_provider": [
       {
         "key": "q-net",
-        "count": 5,
+        "count": 15,
         "provider": "q-net"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.q-net.or.kr",
-        "count": 5,
+        "count": 13,
         "host": "openapi.q-net.or.kr"
+      },
+      {
+        "key": "c.q-net.or.kr",
+        "count": 2,
+        "host": "c.q-net.or.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 5,
+        "count": 15,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/qnet-verification.json
+++ b/reports/qnet-verification.json
@@ -1,19 +1,14 @@
 {
-  "generated_at": "2026-06-24T00:23:41Z",
+  "generated_at": "2026-06-29T09:16:46Z",
   "provider": "data.go.kr",
-  "registry": "data\\data-go-kr.registry.json",
-  "limit": 5,
+  "limit": 15,
   "truncated": true,
-  "filters": {
-    "provider": "q-net",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 5,
+  "filtered_count": 15,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 0,
-    "skipped": 5,
+    "skipped": 15,
     "unknown": 0
   },
   "results": [
@@ -83,6 +78,158 @@
       "status": "skipped",
       "reason": "qnet_wadl_metadata_only",
       "verified_at": "2026-06-24T00:23:41Z"
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "자격취득자 연도별 연령별 수 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 연도별 실기현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 연도별 필기현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15025329",
+      "title": "한국산업인력공단_산업인력 국가기술자격 통계 정보",
+      "operation": "종목별 자격취득자 연도별 성별 현황 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_missing_required_params",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "baseYY": "2023",
+        "jmCd": ""
+      },
+      "missing_params": [
+        "jmCd"
+      ]
+    },
+    {
+      "dataset_id": "15029006",
+      "title": "한국산업인력공단_국가기술자격 대학별 학과 데이터",
+      "operation": "대학별 학과정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037354",
+      "title": "한국산업인력공단_국가자격 경력정보 제공기관 현황",
+      "operation": "경력기관 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037355",
+      "title": "한국산업인력공단_국가자격 계열별 학과 정보 데이터",
+      "operation": "계열별 학과정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z"
+    },
+    {
+      "dataset_id": "15037356",
+      "title": "한국산업인력공단_국가기술자격 학과별 직무정보",
+      "operation": "학과별 직무 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형 년도별 취득자 현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행) 연령별 취득자 현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:15:44Z",
+      "params": {
+        "type": "json"
+      }
     }
   ]
 }

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:06:32Z",
+  "generated_at": "2026-06-29T09:17:37Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -8,9 +8,9 @@
   "timeout": "10s",
   "summary": {
     "operations": 12205,
-    "evidence_total": 276,
-    "uncovered_gateway_candidates": 11409,
-    "uncovered_adapter_candidates": 320,
+    "evidence_total": 316,
+    "uncovered_gateway_candidates": 11399,
+    "uncovered_adapter_candidates": 290,
     "missing_adapter_hosts": 10,
     "planned_batches": 9,
     "planned_operations": 70
@@ -20,7 +20,7 @@
       "label": "gateway",
       "kind": "data_go_kr_gateway",
       "candidates": 11419,
-      "uncovered_candidates": 11409,
+      "uncovered_candidates": 11399,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
       "output": ".datapan/verification/gateway-next.json"
@@ -60,7 +60,7 @@
       "provider": "geoje",
       "kind": "external_endpoint",
       "candidates": 41,
-      "uncovered_candidates": 35,
+      "uncovered_candidates": 25,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
       "output": ".datapan/verification/geoje-next.json"
@@ -70,7 +70,7 @@
       "provider": "jeonju",
       "kind": "external_endpoint",
       "candidates": 80,
-      "uncovered_candidates": 75,
+      "uncovered_candidates": 65,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
       "output": ".datapan/verification/jeonju-next.json"
@@ -80,7 +80,7 @@
       "provider": "q-net",
       "kind": "external_endpoint",
       "candidates": 147,
-      "uncovered_candidates": 132,
+      "uncovered_candidates": 122,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
       "output": ".datapan/verification/q-net-next.json"

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-29T09:06:20Z",
+  "generated_at": "2026-06-29T09:17:25Z",
   "datapan_version": "0.1.0-dev",
   "count": 20,
   "schemas": [


### PR DESCRIPTION
Closes #21

## Gap

data.go.kr runtime evidence coverage remains far below the documented 10% target. This PR continues the provider-priority evidence plan after #20 by adding the next gateway and external endpoint boundary batches.

## Changes

- Merge excluded-from-latest batches for `gateway`, `geoje`, `jeonju`, and `q-net`.
- Regenerate `geoje`, `jeonju`, and `qnet` provider reports/summaries.
- Regenerate `reports/latest-verification.json`, latest summary, release verification/readiness, runtime evidence growth, release notes, README snapshot, manifest, and schema index.
- Update the data.go.kr mastery plan and registry blueprint so #21 is recorded as continued runtime evidence growth.

## Warning Status

- Active warning remains: `runtime_evidence_growth_target` / `runtime_evidence_below_target`.
- Target: `1,221` evidence records for `10.0%` runtime evidence coverage.
- Actual: `316` evidence records (`2.6%`).
- Remaining gap: `905` additional evidence records.
- This warning is not harmless and is intentionally preserved in readiness output.

## Evidence Boundary

The new 40 records are skipped boundary evidence, not successful callable coverage.

- `gateway`: `10` new skipped records.
- `geoje`: `10` new skipped records; provider report now has `16` total, including `2` older verified records.
- `jeonju`: `10` new skipped records; provider report now has `15` total, including `5` older failed records.
- `q-net`: `10` new skipped records; provider report now has `15` total, all skipped.
- Latest evidence has `316` unique records by provider, dataset, operation, host, and dependency class.

## Validation

- `datapan catalog release draft` with materialized data.go.kr registry and latest verification evidence.
- `datapan catalog release verify --manifest manifest.json --output reports/latest-release-verification.json --json` -> `39/39` artifacts verified.
- `datapan catalog release readiness --manifest manifest.json --output reports/latest-release-readiness.json --json` -> `ready: true`, `passed: 22`, `warned: 1`, `failed: 0`.
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- README current snapshot grep check.
- `jq empty ...` over source profiles, source-scoped reports, latest verification, release reports, manifest, and schemas.
- `git diff --check`

Local release verification required temporarily materializing `data/data-go-kr.registry.json`; the tracked file was restored to the Git LFS pointer afterward. GitHub Actions checks out LFS for release verification.
