### PR TITLE
feat: Add ekape emuseum uiryeong epost ulsan runtime evidence batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ re-importing the upstream data.go.kr catalog every time.
 - Missing external adapter hosts: `10`
 - Provider split readiness: `ready`
   (`26` adapters, `26` verification-capable, `21` call-capable)
-- Runtime verification evidence: `316` bounded checks merged into
-  `reports/latest-verification.json` (`22` verified, `87` failed, `207`
+- Runtime verification evidence: `346` bounded checks merged into
+  `reports/latest-verification.json` (`22` verified, `87` failed, `237`
   skipped)
 - Missing external host probe: `28` unadapted external endpoint checks in
   `reports/unadapted-external-probe.json` (`14` HTTP 404, `7` timeout, `6`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-29T09:17:25Z`
+- generated_at: `2026-06-29T09:24:06Z`
 - provider: `data.go.kr`
 - datapan_version: `0.1.0-dev`
 - source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
@@ -24,12 +24,12 @@
 - route_disposition: `28` routes, `14` dead-route candidates, `14` transient failures, `0` parameter-blocked, `0` adapter candidates
 - route_disposition_artifact: `reports/route-disposition.json`
 - provider_backlog: `179` hosts, `10` missing-adapter hosts, `28` operations needing adapters
-- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.6%`, evidence-adjusted adapter candidates `0`
+- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.8%`, evidence-adjusted adapter candidates `0`
 - coverage_artifact: `reports/coverage.json`
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
-- verification_plan: `9` batches, `70` planned operations, `11399` gateway gaps, `290` adapter gaps
+- verification_plan: `6` batches, `60` planned operations, `11399` gateway gaps, `260` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
-- runtime_evidence_growth: `2.6%` coverage, target `10.0%`, remaining `905`, status `below_target`
+- runtime_evidence_growth: `2.8%` coverage, target `10.0%`, remaining `875`, status `below_target`
 - runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
 - runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
@@ -43,18 +43,18 @@ Top adapter targets:
 
 ## Verification Evidence
 
-- verification: `316` total, `22` verified, `87` failed, `207` skipped, `0` unknown
+- verification: `346` total, `22` verified, `87` failed, `237` skipped, `0` unknown
 - verification_artifact: `reports/latest-verification.json`
 - verification_summary_artifact: `reports/latest-verification-summary.json`
 
 Provider evidence:
 
 - `oneclick-law`: `30`
+- `epost`: `28`
 - `tour`: `26`
-- `epost`: `25`
+- `ekape`: `25`
 - `q-net`: `25`
 - `data.go.kr`: `20`
-- `sisul`: `20`
 
 - unadapted_external_probe: `28` total, `0` verified, `28` failed, `0` skipped, `0` unknown
 - unadapted_external_probe_artifact: `reports/unadapted-external-probe.json`

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -199,8 +199,10 @@ CI should fail rather than treating the checked-in summary as authoritative.
    evidence from `256` to `276`, but the new records are skipped boundary
    evidence, not successful callable coverage. Continued by Gira #21 with
    gateway, `geoje`, `jeonju`, and `q-net` boundary batches, growing checked
-   runtime evidence to `316`. Runtime evidence remains below the `10%` target
-   with `905` additional evidence records still required.
+   runtime evidence to `316`. Continued by Gira #23 with `ekape`, `emuseum`,
+   `uiryeong`, `epost`, and `ulsan` boundary batches, growing checked runtime
+   evidence to `346`. Runtime evidence remains below the `10%` target with
+   `875` additional evidence records still required.
 10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -105,10 +105,11 @@ Current gaps:
 - Error inventory has draft action routing for data.go.kr and the first
   non-data.go.kr profile batch, but runtime evidence is not yet generated for
   those non-data.go.kr sources.
-- Runtime evidence coverage is much lower than callable coverage. Gira #19 and
-  Gira #21 raise data.go.kr runtime evidence from `256` to `316`, but the
-  release readiness warning remains active: the `10%` target requires `1,221`
-  evidence records, so `905` additional records are still required.
+- Runtime evidence coverage is much lower than callable coverage. Gira #19,
+  Gira #21, and Gira #23 raise data.go.kr runtime evidence from `256` to
+  `346`, but the release readiness warning remains active: the `10%` target
+  requires `1,221` evidence records, so `875` additional records are still
+  required.
 - Multi-source report grouping is designed but not implemented.
 - Impact plans are specified and a data.go.kr draft plan is checked in, but
   full `datapan-cli` generation is not implemented.
@@ -285,8 +286,9 @@ Use this order unless a production failure changes priority:
 14. Expand runtime verification evidence by source/provider priority. Started
     by Gira #19 with `epost` and `ulsan` external endpoint batches and
     continued by Gira #21 with gateway, `geoje`, `jeonju`, and `q-net`
-    batches; this is skipped boundary evidence growth, not proof that those
-    operations are callable.
+    batches, then by Gira #23 with `ekape`, `emuseum`, `uiryeong`, `epost`,
+    and `ulsan` batches; this is skipped boundary evidence growth, not proof
+    that those operations are callable.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
@@ -132,7 +132,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 7490,
-      "sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924"
+      "sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -146,91 +146,91 @@
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
       "bytes": 5588,
-      "sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602"
+      "sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
       "bytes": 505,
-      "sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31"
+      "sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
       "bytes": 15985,
-      "sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45"
+      "sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
       "bytes": 3305406,
-      "sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78"
+      "sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
       "bytes": 11399477,
-      "sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b"
+      "sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
       "bytes": 15197,
-      "sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070"
+      "sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
       "bytes": 22374,
-      "sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df"
+      "sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
       "bytes": 53713,
-      "sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6"
+      "sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
-      "bytes": 17019,
-      "sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92"
+      "bytes": 17021,
+      "sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
-      "bytes": 9487,
-      "sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3"
+      "bytes": 7675,
+      "sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
-      "bytes": 4512,
-      "sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822"
+      "bytes": 3724,
+      "sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "schema": "https://schemas.datapan.dev/datapan.verification.v1.schema.json",
-      "bytes": 219831,
-      "sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20"
+      "bytes": 234853,
+      "sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 13185,
-      "sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646"
+      "bytes": 13670,
+      "sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -250,13 +250,13 @@
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "bytes": 4463,
-      "sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d"
+      "sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "bytes": 3346,
-      "sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45"
+      "sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,6 +1,6 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-29T09:17:25Z
+- generated_at: 2026-06-29T09:24:06Z
 - datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
 - source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
   "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:30Z",
+  "generated_at": "2026-06-29T09:24:10Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -41,14 +41,14 @@
   },
   "evidence": {
     "present": true,
-    "generated_at": "2026-06-29T09:17:01Z",
-    "total": 316,
+    "generated_at": "2026-06-29T09:23:42Z",
+    "total": 346,
     "verified": 22,
     "failed": 87,
-    "skipped": 207,
+    "skipped": 237,
     "unknown": 0,
-    "verified_percent": 7,
-    "evidence_operation_percent": 2.6
+    "verified_percent": 6.4,
+    "evidence_operation_percent": 2.8
   },
   "route_evidence": {
     "present": true,
@@ -381,7 +381,7 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-29T09:17:30Z",
+    "generated_at": "2026-06-29T09:24:10Z",
     "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
@@ -21,12 +21,12 @@
     "call_capable_adapters": 21
   },
   "evidence": {
-    "total": 316,
+    "total": 346,
     "verified": 22,
     "failed": 87,
-    "skipped": 207,
+    "skipped": 237,
     "unknown": 0,
-    "coverage_percent": 2.6,
+    "coverage_percent": 2.8,
     "by_kind": [
       {
         "key": "data_go_kr_gateway",
@@ -34,7 +34,7 @@
       },
       {
         "key": "external_endpoint",
-        "count": 277
+        "count": 307
       },
       {
         "key": "service_root",
@@ -45,14 +45,14 @@
   "growth_target": {
     "target_percent": 10,
     "target_evidence_total": 1221,
-    "remaining_to_target": 905,
+    "remaining_to_target": 875,
     "status": "below_target"
   },
   "verification_plan": {
-    "planned_batches": 9,
-    "planned_operations": 70,
+    "planned_batches": 6,
+    "planned_operations": 60,
     "uncovered_gateway_candidates": 11399,
-    "uncovered_adapter_candidates": 290,
+    "uncovered_adapter_candidates": 260,
     "missing_adapter_hosts": 10,
     "planned_by_kind": [
       {
@@ -61,7 +61,7 @@
       },
       {
         "key": "external_endpoint",
-        "count": 60
+        "count": 50
       }
     ],
     "batches": [
@@ -78,27 +78,9 @@
         "provider": "ekape",
         "kind": "external_endpoint",
         "candidates": 49,
-        "uncovered_candidates": 34,
+        "uncovered_candidates": 24,
         "planned_operations": 10,
         "output": ".datapan/verification/ekape-next.json"
-      },
-      {
-        "label": "emuseum",
-        "provider": "emuseum",
-        "kind": "external_endpoint",
-        "candidates": 3,
-        "uncovered_candidates": 3,
-        "planned_operations": 3,
-        "output": ".datapan/verification/emuseum-next.json"
-      },
-      {
-        "label": "epost",
-        "provider": "epost",
-        "kind": "external_endpoint",
-        "candidates": 28,
-        "uncovered_candidates": 3,
-        "planned_operations": 3,
-        "output": ".datapan/verification/epost-next.json"
       },
       {
         "label": "geoje",
@@ -132,18 +114,9 @@
         "provider": "uiryeong",
         "kind": "external_endpoint",
         "candidates": 40,
-        "uncovered_candidates": 34,
+        "uncovered_candidates": 24,
         "planned_operations": 10,
         "output": ".datapan/verification/uiryeong-next.json"
-      },
-      {
-        "label": "ulsan",
-        "provider": "ulsan",
-        "kind": "external_endpoint",
-        "candidates": 20,
-        "uncovered_candidates": 4,
-        "planned_operations": 4,
-        "output": ".datapan/verification/ulsan-next.json"
       }
     ]
   },
@@ -157,7 +130,7 @@
     {
       "kind": "runtime_evidence_below_target",
       "severity": "warning",
-      "message": "Runtime evidence coverage is 2.6% against the 10.0% target; 905 additional evidence records are needed before this target is met."
+      "message": "Runtime evidence coverage is 2.8% against the 10.0% target; 875 additional evidence records are needed before this target is met."
     }
   ]
 }

--- a/reports/ekape-verification-summary.json
+++ b/reports/ekape-verification-summary.json
@@ -1,19 +1,23 @@
 {
-  "generated_at": "2026-06-24T00:54:09Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\ekape-verification.json",
+  "generated_at": "2026-06-29T09:23:11Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/ekape-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 5,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "groups": {
     "by_status": [
+      {
+        "key": "skipped",
+        "count": 10,
+        "status": "skipped"
+      },
       {
         "key": "failed",
         "count": 5,
@@ -21,6 +25,16 @@
       }
     ],
     "by_reason": [
+      {
+        "key": "missing_auth",
+        "count": 6,
+        "reason": "missing_auth"
+      },
+      {
+        "key": "ekape_missing_required_params",
+        "count": 4,
+        "reason": "ekape_missing_required_params"
+      },
       {
         "key": "ekape_service_key_not_registered",
         "count": 4,
@@ -35,21 +49,21 @@
     "by_provider": [
       {
         "key": "ekape",
-        "count": 5,
+        "count": 15,
         "provider": "ekape"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.ekape.or.kr",
-        "count": 5,
+        "count": 15,
         "host": "data.ekape.or.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 5,
+        "count": 15,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/ekape-verification.json
+++ b/reports/ekape-verification.json
@@ -1,19 +1,14 @@
 {
-  "generated_at": "2026-06-24T00:54:09Z",
+  "generated_at": "2026-06-29T09:23:11Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 5,
+  "limit": 15,
   "truncated": true,
-  "filters": {
-    "provider": "ekape",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 5,
+  "filtered_count": 15,
   "summary": {
-    "total": 5,
+    "total": 15,
     "verified": 0,
     "failed": 5,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "results": [
@@ -135,6 +130,174 @@
         "standYm": "202401"
       },
       "body_shape": "xml_notice"
+    },
+    {
+      "dataset_id": "15057912",
+      "title": "축산물품질평가원_축산물경락가격정보",
+      "operation": "제주 돼지도체 등급별 경락가격 정보 조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "endYmd": "20240101",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "skinYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "계란 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "닭 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돈육대표가격 현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 권역별 경락가격 현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "baseYmd": ""
+      },
+      "missing_params": [
+        "baseYmd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 등급판정 부위별고기및부산물 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 등급판정결과(확인서) 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지도체 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "egradeExceptYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "skinYn",
+        "sexCd",
+        "egradeExceptYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "말 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 권역별 경락가격현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "baseYmd": ""
+      },
+      "missing_params": [
+        "baseYmd"
+      ]
     }
   ]
 }

--- a/reports/emuseum-verification-summary.json
+++ b/reports/emuseum-verification-summary.json
@@ -1,22 +1,21 @@
 {
-  "generated_at": "2026-06-25T04:44:53Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\emuseum-verification.json",
+  "generated_at": "2026-06-29T09:23:10Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/emuseum-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 3,
+    "total": 6,
     "verified": 0,
     "failed": 1,
-    "skipped": 2,
+    "skipped": 5,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 2,
+        "count": 5,
         "status": "skipped"
       },
       {
@@ -28,33 +27,38 @@
     "by_reason": [
       {
         "key": "emuseum_missing_required_params",
-        "count": 2,
+        "count": 4,
         "reason": "emuseum_missing_required_params"
       },
       {
         "key": "emuseum_service_key_not_registered",
         "count": 1,
         "reason": "emuseum_service_key_not_registered"
+      },
+      {
+        "key": "missing_auth",
+        "count": 1,
+        "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "emuseum",
-        "count": 3,
+        "count": 6,
         "provider": "emuseum"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "www.emuseum.go.kr",
-        "count": 3,
+        "count": 6,
         "host": "www.emuseum.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 3,
+        "count": 6,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/emuseum-verification.json
+++ b/reports/emuseum-verification.json
@@ -1,20 +1,14 @@
 {
-  "generated_at": "2026-06-25T04:44:53Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 3,
-  "timeout": "20s",
+  "limit": 6,
   "truncated": false,
-  "filters": {
-    "provider": "emuseum",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 3,
+  "filtered_count": 6,
   "summary": {
-    "total": 3,
+    "total": 6,
     "verified": 0,
     "failed": 1,
-    "skipped": 2,
+    "skipped": 5,
     "unknown": 0
   },
   "results": [
@@ -71,6 +65,57 @@
       "status": "skipped",
       "reason": "emuseum_missing_required_params",
       "verified_at": "2026-06-25T04:44:53Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "parentCode"
+      ]
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "소장품 목록 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "소장품 상세 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "emuseum_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "id"
+      ]
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "코드 목록 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "emuseum_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
       "params": {
         "numOfRows": "1",
         "pageNo": "1"

--- a/reports/epost-verification-summary.json
+++ b/reports/epost-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:04:28Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/epost-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 15,
+    "total": 18,
     "verified": 0,
     "failed": 0,
-    "skipped": 15,
+    "skipped": 18,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 15,
+        "count": 18,
         "status": "skipped"
       }
     ],
@@ -26,20 +27,25 @@
         "reason": "epost_wadl_metadata_only"
       },
       {
+        "key": "epost_missing_required_params",
+        "count": 2,
+        "reason": "epost_missing_required_params"
+      },
+      {
         "key": "epost_unsupported_protocol",
         "count": 2,
         "reason": "epost_unsupported_protocol"
       },
       {
-        "key": "epost_missing_required_params",
-        "count": 1,
-        "reason": "epost_missing_required_params"
+        "key": "missing_auth",
+        "count": 2,
+        "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "epost",
-        "count": 15,
+        "count": 18,
         "provider": "epost"
       }
     ],
@@ -51,14 +57,14 @@
       },
       {
         "key": "openapi.epost.go.kr",
-        "count": 1,
+        "count": 4,
         "host": "openapi.epost.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 15,
+        "count": 18,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/epost-verification.json
+++ b/reports/epost-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:04:28Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "provider": "data.go.kr",
-  "limit": 15,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 18,
   "truncated": true,
-  "filtered_count": 15,
+  "filtered_count": 18,
   "summary": {
-    "total": 15,
+    "total": 18,
     "verified": 0,
     "failed": 0,
-    "skipped": 15,
+    "skipped": 18,
     "unknown": 0
   },
   "results": [
@@ -384,6 +385,47 @@
         "districtEngName",
         "keyword"
       ]
+    },
+    {
+      "dataset_id": "15059081",
+      "title": "과학기술정보통신부 우정사업본부_우편접수용 우편번호조회",
+      "operation": "우편접수용 우편번호조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "countPerPage": "1",
+        "currentPage": "1",
+        "srchwrd": ""
+      },
+      "missing_params": [
+        "srchwrd"
+      ]
+    },
+    {
+      "dataset_id": "15075270",
+      "title": "과학기술정보통신부 우정사업본부_우체국알뜰폰 요금제 조회 서비스",
+      "operation": "우체국알뜰폰 요금제 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15075271",
+      "title": "과학기술정보통신부 우정사업본부_우체국알뜰폰 단말기 조회 서비스",
+      "operation": "우체국알뜰폰 단말기",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
     }
   ]
 }

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
   "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-29T09:17:43Z",
+  "generated_at": "2026-06-29T09:24:29Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -243,7 +243,7 @@
       "artifact_kind": "runtime_evidence_growth",
       "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
       "expected": 1221,
-      "actual": 316
+      "actual": 346
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -194,8 +194,8 @@
       "status": "verified",
       "expected_bytes": 7490,
       "actual_bytes": 7490,
-      "expected_sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924",
-      "actual_sha256": "f337261e95621725b960c6922073fe991bd54f36b8b395dd0597d076d46e3924"
+      "expected_sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5",
+      "actual_sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -212,8 +212,8 @@
       "status": "verified",
       "expected_bytes": 5588,
       "actual_bytes": 5588,
-      "expected_sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602",
-      "actual_sha256": "c1623b74507f9073a0b561921be88e6b2f976102d7a8138432d93b5c753fc602"
+      "expected_sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3",
+      "actual_sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3"
     },
     {
       "path": "reports/catalog-diff.json",
@@ -221,8 +221,8 @@
       "status": "verified",
       "expected_bytes": 505,
       "actual_bytes": 505,
-      "expected_sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31",
-      "actual_sha256": "41bab0df83619910619f62f1a5f02274a823fc77532bd4a63df911b08d83cc31"
+      "expected_sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c",
+      "actual_sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c"
     },
     {
       "path": "reports/catalog-audit.json",
@@ -230,8 +230,8 @@
       "status": "verified",
       "expected_bytes": 15985,
       "actual_bytes": 15985,
-      "expected_sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45",
-      "actual_sha256": "21c95619f39144998ddbc98c405087dc3e563715450d031ef6b952d0b43c6f45"
+      "expected_sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b",
+      "actual_sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b"
     },
     {
       "path": "reports/error-catalog.json",
@@ -239,8 +239,8 @@
       "status": "verified",
       "expected_bytes": 3305406,
       "actual_bytes": 3305406,
-      "expected_sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78",
-      "actual_sha256": "526fd08ea6ee597092f9a866ac18d89108d60864f960ba349765920f59d62b78"
+      "expected_sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6",
+      "actual_sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6"
     },
     {
       "path": "reports/dependencies.json",
@@ -248,8 +248,8 @@
       "status": "verified",
       "expected_bytes": 11399477,
       "actual_bytes": 11399477,
-      "expected_sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b",
-      "actual_sha256": "639d327106938352f21ed9e2f285ef3bf0cd451d24ee74f926c689430040265b"
+      "expected_sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044",
+      "actual_sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044"
     },
     {
       "path": "reports/adapter-targets.json",
@@ -257,8 +257,8 @@
       "status": "verified",
       "expected_bytes": 15197,
       "actual_bytes": 15197,
-      "expected_sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070",
-      "actual_sha256": "32083b2964d4771e8bae86b5c98cf8f5037140edb12c5247ac5236ff70e75070"
+      "expected_sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309",
+      "actual_sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309"
     },
     {
       "path": "reports/route-disposition.json",
@@ -266,8 +266,8 @@
       "status": "verified",
       "expected_bytes": 22374,
       "actual_bytes": 22374,
-      "expected_sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df",
-      "actual_sha256": "5514c77122abb8c6662dcfffe4754e6e0f55a033b9814a9f0f3047a6b5f3e8df"
+      "expected_sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3",
+      "actual_sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3"
     },
     {
       "path": "reports/provider-backlog.json",
@@ -275,53 +275,53 @@
       "status": "verified",
       "expected_bytes": 53713,
       "actual_bytes": 53713,
-      "expected_sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6",
-      "actual_sha256": "5299f5c6b75fd4e045046d4ca34b510cbbc4897dffe07a8cab8ea0b5fd80b4c6"
+      "expected_sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b",
+      "actual_sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "status": "verified",
-      "expected_bytes": 17019,
-      "actual_bytes": 17019,
-      "expected_sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92",
-      "actual_sha256": "d7784dfd91eb76131d2c27244dc32e26e39433fcba97d7835f5564d7c9fcab92"
+      "expected_bytes": 17021,
+      "actual_bytes": 17021,
+      "expected_sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119",
+      "actual_sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "status": "verified",
-      "expected_bytes": 9487,
-      "actual_bytes": 9487,
-      "expected_sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3",
-      "actual_sha256": "1d4ae5606c43270b65cd25660d647fc56b2d1312362250963fa32f79ed1d08b3"
+      "expected_bytes": 7675,
+      "actual_bytes": 7675,
+      "expected_sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e",
+      "actual_sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "status": "verified",
-      "expected_bytes": 4512,
-      "actual_bytes": 4512,
-      "expected_sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822",
-      "actual_sha256": "ada883958de988e69747324d361f29d1d3376aaad6b5aec57f55abb2a41c8822"
+      "expected_bytes": 3724,
+      "actual_bytes": 3724,
+      "expected_sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222",
+      "actual_sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "status": "verified",
-      "expected_bytes": 219831,
-      "actual_bytes": 219831,
-      "expected_sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20",
-      "actual_sha256": "28402c24f31dfe38b97dd543cf5525ab0447824064058cfaf63133a1b9540b20"
+      "expected_bytes": 234853,
+      "actual_bytes": 234853,
+      "expected_sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2",
+      "actual_sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 13185,
-      "actual_bytes": 13185,
-      "expected_sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646",
-      "actual_sha256": "fe21d52e2fdc1e47adbdfee5fef10cb777fb88e1af0f86f59c39666b67a34646"
+      "expected_bytes": 13670,
+      "actual_bytes": 13670,
+      "expected_sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6",
+      "actual_sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -347,8 +347,8 @@
       "status": "verified",
       "expected_bytes": 4463,
       "actual_bytes": 4463,
-      "expected_sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d",
-      "actual_sha256": "a28f5a2c49c36194b6fc083d5d01ac43a2b0870c33af22c38316308c517bb50d"
+      "expected_sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a",
+      "actual_sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a"
     },
     {
       "path": "RELEASE_NOTES.md",
@@ -356,8 +356,8 @@
       "status": "verified",
       "expected_bytes": 3346,
       "actual_bytes": 3346,
-      "expected_sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45",
-      "actual_sha256": "21d4b132058fa2cde9872439fa7071ed002b271d24117d4796706bb6b3f02a45"
+      "expected_sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1",
+      "actual_sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:17:01Z",
+  "generated_at": "2026-06-29T09:23:42Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {
-    "total": 316,
+    "total": 346,
     "verified": 22,
     "failed": 87,
-    "skipped": 207,
+    "skipped": 237,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 207,
+        "count": 237,
         "status": "skipped"
       },
       {
@@ -31,6 +31,11 @@
       }
     ],
     "by_reason": [
+      {
+        "key": "missing_auth",
+        "count": 34,
+        "reason": "missing_auth"
+      },
       {
         "key": "approval_required",
         "count": 32,
@@ -52,14 +57,14 @@
         "reason": "epost_wadl_metadata_only"
       },
       {
-        "key": "missing_auth",
-        "count": 17,
-        "reason": "missing_auth"
+        "key": "ulsan_missing_required_params",
+        "count": 16,
+        "reason": "ulsan_missing_required_params"
       },
       {
-        "key": "ulsan_missing_required_params",
-        "count": 13,
-        "reason": "ulsan_missing_required_params"
+        "key": "ekape_missing_required_params",
+        "count": 11,
+        "reason": "ekape_missing_required_params"
       },
       {
         "key": "oneclick_connection_refused",
@@ -95,11 +100,6 @@
         "key": "naqs_mutation_endpoint",
         "count": 8,
         "reason": "naqs_mutation_endpoint"
-      },
-      {
-        "key": "ekape_missing_required_params",
-        "count": 7,
-        "reason": "ekape_missing_required_params"
       },
       {
         "key": "humetro_service_access_denied",
@@ -152,6 +152,11 @@
         "reason": "ekape_service_key_not_registered"
       },
       {
+        "key": "epost_missing_required_params",
+        "count": 4,
+        "reason": "epost_missing_required_params"
+      },
+      {
         "key": "pqis_service_key_not_registered",
         "count": 4,
         "reason": "pqis_service_key_not_registered"
@@ -160,11 +165,6 @@
         "key": "seoul_bus_service_key_not_registered",
         "count": 4,
         "reason": "seoul_bus_service_key_not_registered"
-      },
-      {
-        "key": "epost_missing_required_params",
-        "count": 3,
-        "reason": "epost_missing_required_params"
       },
       {
         "key": "itfind_endpoint_not_found",
@@ -192,6 +192,11 @@
         "reason": "sisul_missing_required_params"
       },
       {
+        "key": "uiryeong_missing_required_params",
+        "count": 3,
+        "reason": "uiryeong_missing_required_params"
+      },
+      {
         "key": "ulsan_service_key_not_registered",
         "count": 3,
         "reason": "ulsan_service_key_not_registered"
@@ -200,6 +205,11 @@
         "key": "airport_missing_required_params",
         "count": 2,
         "reason": "airport_missing_required_params"
+      },
+      {
+        "key": "emuseum_missing_required_params",
+        "count": 2,
+        "reason": "emuseum_missing_required_params"
       },
       {
         "key": "gblib_service_key_not_registered",
@@ -279,14 +289,19 @@
         "provider": "oneclick-law"
       },
       {
+        "key": "epost",
+        "count": 28,
+        "provider": "epost"
+      },
+      {
         "key": "tour",
         "count": 26,
         "provider": "tour"
       },
       {
-        "key": "epost",
+        "key": "ekape",
         "count": 25,
-        "provider": "epost"
+        "provider": "ekape"
       },
       {
         "key": "q-net",
@@ -304,24 +319,24 @@
         "provider": "sisul"
       },
       {
+        "key": "ulsan",
+        "count": 20,
+        "provider": "ulsan"
+      },
+      {
         "key": "geoje",
         "count": 16,
         "provider": "geoje"
       },
       {
-        "key": "ulsan",
+        "key": "uiryeong",
         "count": 16,
-        "provider": "ulsan"
+        "provider": "uiryeong"
       },
       {
         "key": "andong",
         "count": 15,
         "provider": "andong"
-      },
-      {
-        "key": "ekape",
-        "count": 15,
-        "provider": "ekape"
       },
       {
         "key": "jeonju",
@@ -364,11 +379,6 @@
         "provider": "lh-ebid"
       },
       {
-        "key": "uiryeong",
-        "count": 6,
-        "provider": "uiryeong"
-      },
-      {
         "key": "seoul-bus",
         "count": 5,
         "provider": "seoul-bus"
@@ -387,6 +397,11 @@
         "key": "pqis",
         "count": 4,
         "provider": "pqis"
+      },
+      {
+        "key": "emuseum",
+        "count": 3,
+        "provider": "emuseum"
       },
       {
         "key": "folk",
@@ -411,6 +426,11 @@
         "host": "oneclick.law.go.kr:80"
       },
       {
+        "key": "data.ekape.or.kr",
+        "count": 25,
+        "host": "data.ekape.or.kr"
+      },
+      {
         "key": "openapi.q-net.or.kr",
         "count": 23,
         "host": "openapi.q-net.or.kr"
@@ -431,19 +451,19 @@
         "host": "data.sisul.or.kr"
       },
       {
+        "key": "openapi.its.ulsan.kr",
+        "count": 20,
+        "host": "openapi.its.ulsan.kr"
+      },
+      {
         "key": "data.geoje.go.kr",
         "count": 16,
         "host": "data.geoje.go.kr"
       },
       {
-        "key": "openapi.its.ulsan.kr",
+        "key": "data.uiryeong.go.kr",
         "count": 16,
-        "host": "openapi.its.ulsan.kr"
-      },
-      {
-        "key": "data.ekape.or.kr",
-        "count": 15,
-        "host": "data.ekape.or.kr"
+        "host": "data.uiryeong.go.kr"
       },
       {
         "key": "openapi.jeonju.go.kr",
@@ -481,11 +501,6 @@
         "host": "openapi.tour.go.kr"
       },
       {
-        "key": "data.uiryeong.go.kr",
-        "count": 6,
-        "host": "data.uiryeong.go.kr"
-      },
-      {
         "key": "openapi.airport.co.kr",
         "count": 6,
         "host": "openapi.airport.co.kr"
@@ -494,6 +509,11 @@
         "key": "openapi.ebid.lh.or.kr",
         "count": 6,
         "host": "openapi.ebid.lh.or.kr"
+      },
+      {
+        "key": "openapi.epost.go.kr",
+        "count": 6,
+        "host": "openapi.epost.go.kr"
       },
       {
         "key": "openapi.kpx.or.kr",
@@ -531,14 +551,14 @@
         "host": "oneclick.law.go.kr"
       },
       {
-        "key": "openapi.epost.go.kr",
-        "count": 3,
-        "host": "openapi.epost.go.kr"
-      },
-      {
         "key": "openapi.gblib.or.kr",
         "count": 3,
         "host": "openapi.gblib.or.kr"
+      },
+      {
+        "key": "www.emuseum.go.kr",
+        "count": 3,
+        "host": "www.emuseum.go.kr"
       },
       {
         "key": "c.q-net.or.kr",
@@ -554,7 +574,7 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 277,
+        "count": 307,
         "kind": "external_endpoint"
       },
       {

--- a/reports/latest-verification.json
+++ b/reports/latest-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:17:01Z",
+  "generated_at": "2026-06-29T09:23:42Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 323,
+  "limit": 353,
   "truncated": true,
-  "filtered_count": 316,
+  "filtered_count": 346,
   "summary": {
-    "total": 316,
+    "total": 346,
     "verified": 22,
     "failed": 87,
-    "skipped": 207,
+    "skipped": 237,
     "unknown": 0
   },
   "results": [
@@ -6825,6 +6825,488 @@
       "verified_at": "2026-06-29T09:15:44Z",
       "params": {
         "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15057912",
+      "title": "축산물품질평가원_축산물경락가격정보",
+      "operation": "제주 돼지도체 등급별 경락가격 정보 조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "endYmd": "20240101",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "skinYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "계란 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "닭 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돈육대표가격 현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 권역별 경락가격 현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "baseYmd": ""
+      },
+      "missing_params": [
+        "baseYmd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 등급판정 부위별고기및부산물 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지 등급판정결과(확인서) 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "돼지도체 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "egradeExceptYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "skinYn",
+        "sexCd",
+        "egradeExceptYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "말 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 권역별 경락가격현황",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "baseYmd": ""
+      },
+      "missing_params": [
+        "baseYmd"
+      ]
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "소장품 목록 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "소장품 상세 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "emuseum_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "id"
+      ]
+    },
+    {
+      "dataset_id": "3036708",
+      "title": "문화체육관광부 국립중앙박물관_전국 박물관 유물정보",
+      "operation": "코드 목록 조회",
+      "provider": "emuseum",
+      "endpoint_host": "www.emuseum.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "emuseum_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "parentCode"
+      ]
+    },
+    {
+      "dataset_id": "15008909",
+      "title": "경상남도 의령군_민박/펜션업소",
+      "operation": "민박/펜션업소 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "uiryeongstayEntId": ""
+      },
+      "missing_params": [
+        "uiryeongstayEntId"
+      ]
+    },
+    {
+      "dataset_id": "15008921",
+      "title": "경상남도 의령군_농어촌체험마을",
+      "operation": "농어촌체험마을 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15017664",
+      "title": "경상남도 의령군_체육시설",
+      "operation": "체육시설 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "uiryeongphysicalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongphysicalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15017664",
+      "title": "경상남도 의령군_체육시설",
+      "operation": "체육시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15017665",
+      "title": "경상남도 의령군_의료기관",
+      "operation": "의료기관 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "uiryeonghospitalEntId": ""
+      },
+      "missing_params": [
+        "uiryeonghospitalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15017665",
+      "title": "경상남도 의령군_의료기관",
+      "operation": "의료기관 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15017666",
+      "title": "경상남도_의령군_자동차정비업체",
+      "operation": "운송/정비사업체 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15017667",
+      "title": "경상남도 의령군_주유소/LPG",
+      "operation": "주유소/LPG충전소 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15053067",
+      "title": "경상남도 의령군_여관모텔",
+      "operation": "여관모텔 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15056736",
+      "title": "경상남도 의령군_여성복지시설",
+      "operation": "여성복지시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15059081",
+      "title": "과학기술정보통신부 우정사업본부_우편접수용 우편번호조회",
+      "operation": "우편접수용 우편번호조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "epost_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "countPerPage": "1",
+        "currentPage": "1",
+        "srchwrd": ""
+      },
+      "missing_params": [
+        "srchwrd"
+      ]
+    },
+    {
+      "dataset_id": "15075270",
+      "title": "과학기술정보통신부 우정사업본부_우체국알뜰폰 요금제 조회 서비스",
+      "operation": "우체국알뜰폰 요금제 조회",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15075271",
+      "title": "과학기술정보통신부 우정사업본부_우체국알뜰폰 단말기 조회 서비스",
+      "operation": "우체국알뜰폰 단말기",
+      "provider": "epost",
+      "endpoint_host": "openapi.epost.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨3교통정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨4 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨4교통정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "주차장 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
       }
     }
   ]

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",

--- a/reports/uiryeong-verification-summary.json
+++ b/reports/uiryeong-verification-summary.json
@@ -1,19 +1,23 @@
 {
-  "generated_at": "2026-06-24T23:32:13Z",
-  "source": "C:\\workspace\\datapan-registry\\reports\\uiryeong-verification.json",
+  "generated_at": "2026-06-29T09:23:10Z",
+  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/uiryeong-verification.json",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 0,
     "failed": 6,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "groups": {
     "by_status": [
+      {
+        "key": "skipped",
+        "count": 10,
+        "status": "skipped"
+      },
       {
         "key": "failed",
         "count": 6,
@@ -22,29 +26,39 @@
     ],
     "by_reason": [
       {
+        "key": "missing_auth",
+        "count": 7,
+        "reason": "missing_auth"
+      },
+      {
         "key": "uiryeong_service_key_not_registered",
         "count": 6,
         "reason": "uiryeong_service_key_not_registered"
+      },
+      {
+        "key": "uiryeong_missing_required_params",
+        "count": 3,
+        "reason": "uiryeong_missing_required_params"
       }
     ],
     "by_provider": [
       {
         "key": "uiryeong",
-        "count": 6,
+        "count": 16,
         "provider": "uiryeong"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.uiryeong.go.kr",
-        "count": 6,
+        "count": 16,
         "host": "data.uiryeong.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 6,
+        "count": 16,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/uiryeong-verification.json
+++ b/reports/uiryeong-verification.json
@@ -1,20 +1,14 @@
 {
-  "generated_at": "2026-06-24T23:32:13Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "provider": "data.go.kr",
-  "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
-  "limit": 6,
-  "timeout": "8s",
+  "limit": 16,
   "truncated": true,
-  "filters": {
-    "provider": "uiryeong",
-    "kind": "external_endpoint"
-  },
-  "filtered_count": 6,
+  "filtered_count": 16,
   "summary": {
-    "total": 6,
+    "total": 16,
     "verified": 0,
     "failed": 6,
-    "skipped": 0,
+    "skipped": 10,
     "unknown": 0
   },
   "results": [
@@ -167,6 +161,156 @@
         "pageNo": "1"
       },
       "body_shape": "xml_status"
+    },
+    {
+      "dataset_id": "15008909",
+      "title": "경상남도 의령군_민박/펜션업소",
+      "operation": "민박/펜션업소 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "uiryeongstayEntId": ""
+      },
+      "missing_params": [
+        "uiryeongstayEntId"
+      ]
+    },
+    {
+      "dataset_id": "15008921",
+      "title": "경상남도 의령군_농어촌체험마을",
+      "operation": "농어촌체험마을 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15017664",
+      "title": "경상남도 의령군_체육시설",
+      "operation": "체육시설 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "uiryeongphysicalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongphysicalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15017664",
+      "title": "경상남도 의령군_체육시설",
+      "operation": "체육시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15017665",
+      "title": "경상남도 의령군_의료기관",
+      "operation": "의료기관 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "uiryeonghospitalEntId": ""
+      },
+      "missing_params": [
+        "uiryeonghospitalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15017665",
+      "title": "경상남도 의령군_의료기관",
+      "operation": "의료기관 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z"
+    },
+    {
+      "dataset_id": "15017666",
+      "title": "경상남도_의령군_자동차정비업체",
+      "operation": "운송/정비사업체 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15017667",
+      "title": "경상남도 의령군_주유소/LPG",
+      "operation": "주유소/LPG충전소 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15053067",
+      "title": "경상남도 의령군_여관모텔",
+      "operation": "여관모텔 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15056736",
+      "title": "경상남도 의령군_여성복지시설",
+      "operation": "여성복지시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
     }
   ]
 }

--- a/reports/ulsan-verification-summary.json
+++ b/reports/ulsan-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:04:28Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/ulsan-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 16,
+    "total": 20,
     "verified": 0,
     "failed": 3,
-    "skipped": 13,
+    "skipped": 17,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 13,
+        "count": 17,
         "status": "skipped"
       },
       {
@@ -27,33 +28,38 @@
     "by_reason": [
       {
         "key": "ulsan_missing_required_params",
-        "count": 13,
+        "count": 16,
         "reason": "ulsan_missing_required_params"
       },
       {
         "key": "ulsan_service_key_not_registered",
         "count": 3,
         "reason": "ulsan_service_key_not_registered"
+      },
+      {
+        "key": "missing_auth",
+        "count": 1,
+        "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "ulsan",
-        "count": 16,
+        "count": 20,
         "provider": "ulsan"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.its.ulsan.kr",
-        "count": 16,
+        "count": 20,
         "host": "openapi.its.ulsan.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 16,
+        "count": 20,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/ulsan-verification.json
+++ b/reports/ulsan-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:04:28Z",
+  "generated_at": "2026-06-29T09:23:10Z",
   "provider": "data.go.kr",
-  "limit": 16,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 20,
   "truncated": true,
-  "filtered_count": 16,
+  "filtered_count": 20,
   "summary": {
-    "total": 16,
+    "total": 20,
     "verified": 0,
     "failed": 3,
-    "skipped": 13,
+    "skipped": 17,
     "unknown": 0
   },
   "results": [
@@ -353,6 +354,78 @@
       "missing_params": [
         "roadnm"
       ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨3교통정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨4 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "구간레벨4교통정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ulsan_missing_required_params",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadnm": ""
+      },
+      "missing_params": [
+        "roadnm"
+      ]
+    },
+    {
+      "dataset_id": "3057773",
+      "title": "울산광역시 교통시스템 정보",
+      "operation": "주차장 정보 조회",
+      "provider": "ulsan",
+      "endpoint_host": "openapi.its.ulsan.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:22:07Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
     }
   ]
 }

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:17:37Z",
+  "generated_at": "2026-06-29T09:24:17Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -8,12 +8,12 @@
   "timeout": "10s",
   "summary": {
     "operations": 12205,
-    "evidence_total": 316,
+    "evidence_total": 346,
     "uncovered_gateway_candidates": 11399,
-    "uncovered_adapter_candidates": 290,
+    "uncovered_adapter_candidates": 260,
     "missing_adapter_hosts": 10,
-    "planned_batches": 9,
-    "planned_operations": 70
+    "planned_batches": 6,
+    "planned_operations": 60
   },
   "batches": [
     {
@@ -30,30 +30,10 @@
       "provider": "ekape",
       "kind": "external_endpoint",
       "candidates": 49,
-      "uncovered_candidates": 34,
+      "uncovered_candidates": 24,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
       "output": ".datapan/verification/ekape-next.json"
-    },
-    {
-      "label": "emuseum",
-      "provider": "emuseum",
-      "kind": "external_endpoint",
-      "candidates": 3,
-      "uncovered_candidates": 3,
-      "planned_operations": 3,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider emuseum --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/emuseum-next.json --json",
-      "output": ".datapan/verification/emuseum-next.json"
-    },
-    {
-      "label": "epost",
-      "provider": "epost",
-      "kind": "external_endpoint",
-      "candidates": 28,
-      "uncovered_candidates": 3,
-      "planned_operations": 3,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider epost --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/epost-next.json --json",
-      "output": ".datapan/verification/epost-next.json"
     },
     {
       "label": "geoje",
@@ -90,20 +70,10 @@
       "provider": "uiryeong",
       "kind": "external_endpoint",
       "candidates": 40,
-      "uncovered_candidates": 34,
+      "uncovered_candidates": 24,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
       "output": ".datapan/verification/uiryeong-next.json"
-    },
-    {
-      "label": "ulsan",
-      "provider": "ulsan",
-      "kind": "external_endpoint",
-      "candidates": 20,
-      "uncovered_candidates": 4,
-      "planned_operations": 4,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ulsan --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ulsan-next.json --json",
-      "output": ".datapan/verification/ulsan-next.json"
     }
   ],
   "gaps": {

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-29T09:17:25Z",
+  "generated_at": "2026-06-29T09:24:06Z",
   "datapan_version": "0.1.0-dev",
   "count": 20,
   "schemas": [


### PR DESCRIPTION
Closes #23

## Gap

data.go.kr runtime evidence coverage remains far below the documented 10% target. This PR continues the provider-priority evidence plan after #20 and #22 by adding the next external endpoint tail and provider batches.

## Changes

- Merge excluded-from-latest batches for `ekape`, `emuseum`, `uiryeong`, `epost`, and `ulsan`.
- Regenerate provider-specific reports/summaries for those providers.
- Regenerate `reports/latest-verification.json`, latest summary, release verification/readiness, runtime evidence growth, release notes, README snapshot, manifest, and schema index.
- Update the data.go.kr mastery plan and registry blueprint so #23 is recorded as continued runtime evidence growth.

## Warning Status

- Active warning remains: `runtime_evidence_growth_target` / `runtime_evidence_below_target`.
- Target: `1,221` evidence records for `10.0%` runtime evidence coverage.
- Actual: `346` evidence records (`2.8%`).
- Remaining gap: `875` additional evidence records.
- This warning is not harmless and is intentionally preserved in readiness output.

## Evidence Boundary

The new 30 records are skipped boundary evidence, not successful callable coverage.

- `ekape`: `10` new skipped records; provider report now has `15` total, including `5` older failed records.
- `emuseum`: `3` new skipped records; provider report now has `6` total, including `1` older failed record.
- `uiryeong`: `10` new skipped records; provider report now has `16` total, including `6` older failed records.
- `epost`: `3` new skipped records; provider report now has `18` total, all skipped.
- `ulsan`: `4` new skipped records; provider report now has `20` total, including `3` older failed records.
- Latest evidence has `346` unique records by provider, dataset, operation, host, and dependency class.

## Validation

- `datapan catalog release draft` with materialized data.go.kr registry and latest verification evidence.
- `datapan catalog release verify --manifest manifest.json --output reports/latest-release-verification.json --json` -> `39/39` artifacts verified.
- `datapan catalog release readiness --manifest manifest.json --output reports/latest-release-readiness.json --json` -> `ready: true`, `passed: 22`, `warned: 1`, `failed: 0`.
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- README current snapshot grep check.
- `jq empty ...` over source profiles, source-scoped reports, latest verification, release reports, manifest, and schemas.
- `git diff --check`

Local release verification required temporarily materializing `data/data-go-kr.registry.json`; the tracked file was restored to the Git LFS pointer afterward. GitHub Actions checks out LFS for release verification.
