### PR TITLE
feat: Add gateway ekape geoje jeonju q-net uiryeong evidence batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ re-importing the upstream data.go.kr catalog every time.
 - Missing external adapter hosts: `10`
 - Provider split readiness: `ready`
   (`26` adapters, `26` verification-capable, `21` call-capable)
-- Runtime verification evidence: `346` bounded checks merged into
-  `reports/latest-verification.json` (`22` verified, `87` failed, `237`
+- Runtime verification evidence: `406` bounded checks merged into
+  `reports/latest-verification.json` (`22` verified, `87` failed, `297`
   skipped)
 - Missing external host probe: `28` unadapted external endpoint checks in
   `reports/unadapted-external-probe.json` (`14` HTTP 404, `7` timeout, `6`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-29T09:24:06Z`
+- generated_at: `2026-06-29T09:32:14Z`
 - provider: `data.go.kr`
 - datapan_version: `0.1.0-dev`
 - source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
@@ -24,12 +24,12 @@
 - route_disposition: `28` routes, `14` dead-route candidates, `14` transient failures, `0` parameter-blocked, `0` adapter candidates
 - route_disposition_artifact: `reports/route-disposition.json`
 - provider_backlog: `179` hosts, `10` missing-adapter hosts, `28` operations needing adapters
-- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `2.8%`, evidence-adjusted adapter candidates `0`
+- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `3.3%`, evidence-adjusted adapter candidates `0`
 - coverage_artifact: `reports/coverage.json`
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
-- verification_plan: `6` batches, `60` planned operations, `11399` gateway gaps, `260` adapter gaps
+- verification_plan: `6` batches, `60` planned operations, `11389` gateway gaps, `210` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
-- runtime_evidence_growth: `2.8%` coverage, target `10.0%`, remaining `875`, status `below_target`
+- runtime_evidence_growth: `3.3%` coverage, target `10.0%`, remaining `815`, status `below_target`
 - runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
 - runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
@@ -43,18 +43,18 @@ Top adapter targets:
 
 ## Verification Evidence
 
-- verification: `346` total, `22` verified, `87` failed, `237` skipped, `0` unknown
+- verification: `406` total, `22` verified, `87` failed, `297` skipped, `0` unknown
 - verification_artifact: `reports/latest-verification.json`
 - verification_summary_artifact: `reports/latest-verification-summary.json`
 
 Provider evidence:
 
+- `ekape`: `35`
+- `q-net`: `35`
+- `data.go.kr`: `30`
 - `oneclick-law`: `30`
 - `epost`: `28`
-- `tour`: `26`
-- `ekape`: `25`
-- `q-net`: `25`
-- `data.go.kr`: `20`
+- `geoje`: `26`
 
 - unadapted_external_probe: `28` total, `0` verified, `28` failed, `0` skipped, `0` unknown
 - unadapted_external_probe_artifact: `reports/unadapted-external-probe.json`

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -201,8 +201,10 @@ CI should fail rather than treating the checked-in summary as authoritative.
    gateway, `geoje`, `jeonju`, and `q-net` boundary batches, growing checked
    runtime evidence to `316`. Continued by Gira #23 with `ekape`, `emuseum`,
    `uiryeong`, `epost`, and `ulsan` boundary batches, growing checked runtime
-   evidence to `346`. Runtime evidence remains below the `10%` target with
-   `875` additional evidence records still required.
+   evidence to `346`. Continued by Gira #25 with gateway, `ekape`, `geoje`,
+   `jeonju`, `q-net`, and `uiryeong` boundary batches, growing checked runtime
+   evidence to `406`. Runtime evidence remains below the `10%` target with
+   `815` additional evidence records still required.
 10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -106,10 +106,10 @@ Current gaps:
   non-data.go.kr profile batch, but runtime evidence is not yet generated for
   those non-data.go.kr sources.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
-  Gira #21, and Gira #23 raise data.go.kr runtime evidence from `256` to
-  `346`, but the release readiness warning remains active: the `10%` target
-  requires `1,221` evidence records, so `875` additional records are still
-  required.
+  Gira #21, Gira #23, and Gira #25 raise data.go.kr runtime evidence from
+  `256` to `406`, but the release readiness warning remains active: the `10%`
+  target requires `1,221` evidence records, so `815` additional records are
+  still required.
 - Multi-source report grouping is designed but not implemented.
 - Impact plans are specified and a data.go.kr draft plan is checked in, but
   full `datapan-cli` generation is not implemented.
@@ -287,8 +287,9 @@ Use this order unless a production failure changes priority:
     by Gira #19 with `epost` and `ulsan` external endpoint batches and
     continued by Gira #21 with gateway, `geoje`, `jeonju`, and `q-net`
     batches, then by Gira #23 with `ekape`, `emuseum`, `uiryeong`, `epost`,
-    and `ulsan` batches; this is skipped boundary evidence growth, not proof
-    that those operations are callable.
+    and `ulsan` batches, and by Gira #25 with the next gateway, `ekape`,
+    `geoje`, `jeonju`, `q-net`, and `uiryeong` batches; this is skipped
+    boundary evidence growth, not proof that those operations are callable.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
@@ -132,7 +132,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 7490,
-      "sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5"
+      "sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -146,91 +146,91 @@
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
       "bytes": 5588,
-      "sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3"
+      "sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
       "bytes": 505,
-      "sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c"
+      "sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
       "bytes": 15985,
-      "sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b"
+      "sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
       "bytes": 3305406,
-      "sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6"
+      "sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
       "bytes": 11399477,
-      "sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044"
+      "sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
       "bytes": 15197,
-      "sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309"
+      "sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
       "bytes": 22374,
-      "sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3"
+      "sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
       "bytes": 53713,
-      "sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b"
+      "sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
       "bytes": 17021,
-      "sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119"
+      "sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
       "bytes": 7675,
-      "sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e"
+      "sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
       "bytes": 3724,
-      "sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222"
+      "sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "schema": "https://schemas.datapan.dev/datapan.verification.v1.schema.json",
-      "bytes": 234853,
-      "sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2"
+      "bytes": 266977,
+      "sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 13670,
-      "sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6"
+      "bytes": 13671,
+      "sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -250,13 +250,13 @@
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "bytes": 4463,
-      "sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a"
+      "sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
-      "bytes": 3346,
-      "sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1"
+      "bytes": 3347,
+      "sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,6 +1,6 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-29T09:24:06Z
+- generated_at: 2026-06-29T09:32:14Z
 - datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
 - source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "sample_limit": 5,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
   "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:10Z",
+  "generated_at": "2026-06-29T09:32:18Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -41,14 +41,14 @@
   },
   "evidence": {
     "present": true,
-    "generated_at": "2026-06-29T09:23:42Z",
-    "total": 346,
+    "generated_at": "2026-06-29T09:31:39Z",
+    "total": 406,
     "verified": 22,
     "failed": 87,
-    "skipped": 237,
+    "skipped": 297,
     "unknown": 0,
-    "verified_percent": 6.4,
-    "evidence_operation_percent": 2.8
+    "verified_percent": 5.4,
+    "evidence_operation_percent": 3.3
   },
   "route_evidence": {
     "present": true,
@@ -381,7 +381,7 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-29T09:24:10Z",
+    "generated_at": "2026-06-29T09:32:18Z",
     "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
@@ -21,20 +21,20 @@
     "call_capable_adapters": 21
   },
   "evidence": {
-    "total": 346,
+    "total": 406,
     "verified": 22,
     "failed": 87,
-    "skipped": 237,
+    "skipped": 297,
     "unknown": 0,
-    "coverage_percent": 2.8,
+    "coverage_percent": 3.3,
     "by_kind": [
       {
         "key": "data_go_kr_gateway",
-        "count": 20
+        "count": 30
       },
       {
         "key": "external_endpoint",
-        "count": 307
+        "count": 357
       },
       {
         "key": "service_root",
@@ -45,14 +45,14 @@
   "growth_target": {
     "target_percent": 10,
     "target_evidence_total": 1221,
-    "remaining_to_target": 875,
+    "remaining_to_target": 815,
     "status": "below_target"
   },
   "verification_plan": {
     "planned_batches": 6,
     "planned_operations": 60,
-    "uncovered_gateway_candidates": 11399,
-    "uncovered_adapter_candidates": 260,
+    "uncovered_gateway_candidates": 11389,
+    "uncovered_adapter_candidates": 210,
     "missing_adapter_hosts": 10,
     "planned_by_kind": [
       {
@@ -69,7 +69,7 @@
         "label": "gateway",
         "kind": "data_go_kr_gateway",
         "candidates": 11419,
-        "uncovered_candidates": 11399,
+        "uncovered_candidates": 11389,
         "planned_operations": 10,
         "output": ".datapan/verification/gateway-next.json"
       },
@@ -78,7 +78,7 @@
         "provider": "ekape",
         "kind": "external_endpoint",
         "candidates": 49,
-        "uncovered_candidates": 24,
+        "uncovered_candidates": 14,
         "planned_operations": 10,
         "output": ".datapan/verification/ekape-next.json"
       },
@@ -87,7 +87,7 @@
         "provider": "geoje",
         "kind": "external_endpoint",
         "candidates": 41,
-        "uncovered_candidates": 25,
+        "uncovered_candidates": 15,
         "planned_operations": 10,
         "output": ".datapan/verification/geoje-next.json"
       },
@@ -96,7 +96,7 @@
         "provider": "jeonju",
         "kind": "external_endpoint",
         "candidates": 80,
-        "uncovered_candidates": 65,
+        "uncovered_candidates": 55,
         "planned_operations": 10,
         "output": ".datapan/verification/jeonju-next.json"
       },
@@ -105,7 +105,7 @@
         "provider": "q-net",
         "kind": "external_endpoint",
         "candidates": 147,
-        "uncovered_candidates": 122,
+        "uncovered_candidates": 112,
         "planned_operations": 10,
         "output": ".datapan/verification/q-net-next.json"
       },
@@ -114,7 +114,7 @@
         "provider": "uiryeong",
         "kind": "external_endpoint",
         "candidates": 40,
-        "uncovered_candidates": 24,
+        "uncovered_candidates": 14,
         "planned_operations": 10,
         "output": ".datapan/verification/uiryeong-next.json"
       }
@@ -130,7 +130,7 @@
     {
       "kind": "runtime_evidence_below_target",
       "severity": "warning",
-      "message": "Runtime evidence coverage is 2.8% against the 10.0% target; 875 additional evidence records are needed before this target is met."
+      "message": "Runtime evidence coverage is 3.3% against the 10.0% target; 815 additional evidence records are needed before this target is met."
     }
   ]
 }

--- a/reports/ekape-verification-summary.json
+++ b/reports/ekape-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:23:11Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/ekape-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 5,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 10,
+        "count": 20,
         "status": "skipped"
       },
       {
@@ -26,14 +27,14 @@
     ],
     "by_reason": [
       {
-        "key": "missing_auth",
-        "count": 6,
-        "reason": "missing_auth"
+        "key": "ekape_missing_required_params",
+        "count": 12,
+        "reason": "ekape_missing_required_params"
       },
       {
-        "key": "ekape_missing_required_params",
-        "count": 4,
-        "reason": "ekape_missing_required_params"
+        "key": "missing_auth",
+        "count": 8,
+        "reason": "missing_auth"
       },
       {
         "key": "ekape_service_key_not_registered",
@@ -49,21 +50,21 @@
     "by_provider": [
       {
         "key": "ekape",
-        "count": 15,
+        "count": 25,
         "provider": "ekape"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.ekape.or.kr",
-        "count": 15,
+        "count": 25,
         "host": "data.ekape.or.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 15,
+        "count": 25,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/ekape-verification.json
+++ b/reports/ekape-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:23:11Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "provider": "data.go.kr",
-  "limit": 15,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 25,
   "truncated": true,
-  "filtered_count": 15,
+  "filtered_count": 25,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 5,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "results": [
@@ -297,6 +298,226 @@
       },
       "missing_params": [
         "baseYmd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 도매시장 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "kindCd": ""
+      },
+      "missing_params": [
+        "kindCd",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 등급판정(확인서) 부위별고기및 부산물 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1",
+        "weight": ""
+      },
+      "missing_params": [
+        "weight"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소도체 1++ 등급 세부경락가격 상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCode": "",
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCode",
+        "breedCd",
+        "sexCd",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "실시간 소도체 경매현황 조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": "",
+        "endNo": "",
+        "gradeCd": "",
+        "kindCd": "",
+        "sexCd": "",
+        "startNo": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd",
+        "startNo",
+        "endNo",
+        "kindCd",
+        "sexCd",
+        "gradeCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "오리 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 도매시장 소도체 1++등급 세부경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 도매시장 소도체 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 돼지도체 경락가격 상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCd",
+        "skinYn",
+        "sexCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 소도체 경락상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCode": "",
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCode",
+        "breedCd",
+        "sexCd",
+        "defectIncludeYn"
       ]
     }
   ]

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/geoje-verification-summary.json
+++ b/reports/geoje-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/geoje-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 16,
+    "total": 26,
     "verified": 2,
     "failed": 0,
-    "skipped": 14,
+    "skipped": 24,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 14,
+        "count": 24,
         "status": "skipped"
       },
       {
@@ -27,33 +28,33 @@
     "by_reason": [
       {
         "key": "geoje_missing_required_params",
-        "count": 10,
+        "count": 16,
         "reason": "geoje_missing_required_params"
       },
       {
         "key": "missing_auth",
-        "count": 4,
+        "count": 8,
         "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "geoje",
-        "count": 16,
+        "count": 26,
         "provider": "geoje"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.geoje.go.kr",
-        "count": 16,
+        "count": 26,
         "host": "data.geoje.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 16,
+        "count": 26,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/geoje-verification.json
+++ b/reports/geoje-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "provider": "data.go.kr",
-  "limit": 16,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 26,
   "truncated": true,
-  "filtered_count": 16,
+  "filtered_count": 26,
   "summary": {
-    "total": 16,
+    "total": 26,
     "verified": 2,
     "failed": 0,
-    "skipped": 14,
+    "skipped": 24,
     "unknown": 0
   },
   "results": [
@@ -293,6 +294,168 @@
       "missing_params": [
         "geojefoodId"
       ]
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojetourId": ""
+      },
+      "missing_params": [
+        "geojetourId"
+      ]
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 이미지정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojetourId": ""
+      },
+      "missing_params": [
+        "geojetourId"
+      ]
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojejumineduId": ""
+      },
+      "missing_params": [
+        "geojejumineduId"
+      ]
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 이미지정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojejumineduId": ""
+      },
+      "missing_params": [
+        "geojejumineduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화 교육 상세 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojeeduId": ""
+      },
+      "missing_params": [
+        "geojeeduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화 교육 첨부파일 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojeeduId": ""
+      },
+      "missing_params": [
+        "geojeeduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화교육 목록 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 CCTV 정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
     }
   ]
 }

--- a/reports/jeonju-verification-summary.json
+++ b/reports/jeonju-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/jeonju-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 5,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 10,
+        "count": 20,
         "status": "skipped"
       },
       {
@@ -25,6 +26,11 @@
       }
     ],
     "by_reason": [
+      {
+        "key": "jeonju_missing_required_params",
+        "count": 13,
+        "reason": "jeonju_missing_required_params"
+      },
       {
         "key": "missing_auth",
         "count": 7,
@@ -36,11 +42,6 @@
         "reason": "jeonju_http_404_not_found"
       },
       {
-        "key": "jeonju_missing_required_params",
-        "count": 3,
-        "reason": "jeonju_missing_required_params"
-      },
-      {
         "key": "jeonju_http_405_method_not_allowed",
         "count": 2,
         "reason": "jeonju_http_405_method_not_allowed"
@@ -49,21 +50,21 @@
     "by_provider": [
       {
         "key": "jeonju",
-        "count": 15,
+        "count": 25,
         "provider": "jeonju"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.jeonju.go.kr",
-        "count": 15,
+        "count": 25,
         "host": "openapi.jeonju.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 15,
+        "count": 25,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/jeonju-verification.json
+++ b/reports/jeonju-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "provider": "data.go.kr",
-  "limit": 15,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 25,
   "truncated": true,
-  "filtered_count": 15,
+  "filtered_count": 25,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 5,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "results": [
@@ -283,6 +284,202 @@
       },
       "missing_params": [
         "seq"
+      ]
+    },
+    {
+      "dataset_id": "15020604",
+      "title": "전북특별자치도 전주시_착한가격모범업소 현황",
+      "operation": "착한 가격 모법업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "address": "",
+        "chakName": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "pumName": ""
+      },
+      "missing_params": [
+        "chakName",
+        "pumName",
+        "address"
+      ]
+    },
+    {
+      "dataset_id": "15024710",
+      "title": "전북특별자치도 전주시_건설시공업체 현황",
+      "operation": "건설시공업체 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15024711",
+      "title": "전북특별자치도 전주시_청소업체 현황",
+      "operation": "저수조 청소업체  현황목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028084",
+      "title": "전북특별자치도 전주시_현수막 지정현황",
+      "operation": "현수막 지정 게시대 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028085",
+      "title": "전북특별자치도 전주시_장사시설 현황",
+      "operation": "장사시설 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028086",
+      "title": "전북특별자치도 전주시_택시현황",
+      "operation": "법인택시 면허  현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15047649",
+      "title": "전북특별자치도 전주시_아동복지시설현황 서비스",
+      "operation": "아동복지시설  목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15047707",
+      "title": "전북특별자치도 전주시_바이전주상품 정보 서비스",
+      "operation": "바이전주 상품 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15056885",
+      "title": "전북특별자치도 전주시_가로등 정보 서비스",
+      "operation": "가로등주 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "boxNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "boxNm"
+      ]
+    },
+    {
+      "dataset_id": "15056979",
+      "title": "전북특별자치도 전주시_동물판매업소 정보 현황",
+      "operation": "동물판매업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
       ]
     }
   ]

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
   "root": "/home/statpan/workspace/opensource/datapan-registry",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-29T09:24:29Z",
+  "generated_at": "2026-06-29T09:32:34Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -243,7 +243,7 @@
       "artifact_kind": "runtime_evidence_growth",
       "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
       "expected": 1221,
-      "actual": 346
+      "actual": 406
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -194,8 +194,8 @@
       "status": "verified",
       "expected_bytes": 7490,
       "actual_bytes": 7490,
-      "expected_sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5",
-      "actual_sha256": "f999a6531e4f4ab8f5e054944d519fad2e8ca6e3e58888abaf7de028d4e7fbc5"
+      "expected_sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce",
+      "actual_sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -212,8 +212,8 @@
       "status": "verified",
       "expected_bytes": 5588,
       "actual_bytes": 5588,
-      "expected_sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3",
-      "actual_sha256": "fce3efa5fea658987d6e04f82483f5ecc38c1d1d995e583a1544543b7f6c7de3"
+      "expected_sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee",
+      "actual_sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee"
     },
     {
       "path": "reports/catalog-diff.json",
@@ -221,8 +221,8 @@
       "status": "verified",
       "expected_bytes": 505,
       "actual_bytes": 505,
-      "expected_sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c",
-      "actual_sha256": "605253e5715e43d2369d0cc2b10b9d8345955d3052f245d92e1522d8da82181c"
+      "expected_sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94",
+      "actual_sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94"
     },
     {
       "path": "reports/catalog-audit.json",
@@ -230,8 +230,8 @@
       "status": "verified",
       "expected_bytes": 15985,
       "actual_bytes": 15985,
-      "expected_sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b",
-      "actual_sha256": "2eb72a8557739253dae93615dfd91e11a89d0abbf3ffca95585962d393f1332b"
+      "expected_sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6",
+      "actual_sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6"
     },
     {
       "path": "reports/error-catalog.json",
@@ -239,8 +239,8 @@
       "status": "verified",
       "expected_bytes": 3305406,
       "actual_bytes": 3305406,
-      "expected_sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6",
-      "actual_sha256": "23cf3e4dd4ac636425a9503a6d7d0f82b77be82d9b75dfa9b6b78745b6dbc0d6"
+      "expected_sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57",
+      "actual_sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57"
     },
     {
       "path": "reports/dependencies.json",
@@ -248,8 +248,8 @@
       "status": "verified",
       "expected_bytes": 11399477,
       "actual_bytes": 11399477,
-      "expected_sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044",
-      "actual_sha256": "f22f598b41ac91220da3f1a20376d9bcd264bf0973410061f700bb32b1b03044"
+      "expected_sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1",
+      "actual_sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1"
     },
     {
       "path": "reports/adapter-targets.json",
@@ -257,8 +257,8 @@
       "status": "verified",
       "expected_bytes": 15197,
       "actual_bytes": 15197,
-      "expected_sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309",
-      "actual_sha256": "3e74e00bde92ca473fba12d627669f24b0bc9b61e83186bc1d9d1b2be8981309"
+      "expected_sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5",
+      "actual_sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5"
     },
     {
       "path": "reports/route-disposition.json",
@@ -266,8 +266,8 @@
       "status": "verified",
       "expected_bytes": 22374,
       "actual_bytes": 22374,
-      "expected_sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3",
-      "actual_sha256": "cc149b12de50dfc785336bb151fd3ac5f28a2a4ce29b225cf2331d4f5166c5f3"
+      "expected_sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce",
+      "actual_sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce"
     },
     {
       "path": "reports/provider-backlog.json",
@@ -275,8 +275,8 @@
       "status": "verified",
       "expected_bytes": 53713,
       "actual_bytes": 53713,
-      "expected_sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b",
-      "actual_sha256": "64ff7be68f6c64217bca699524825877b88357e67e6a16f4422fafd26192394b"
+      "expected_sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3",
+      "actual_sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3"
     },
     {
       "path": "reports/coverage.json",
@@ -284,8 +284,8 @@
       "status": "verified",
       "expected_bytes": 17021,
       "actual_bytes": 17021,
-      "expected_sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119",
-      "actual_sha256": "19fc18300821d26725403eec94194cafcdc21bcc9d2417ee26f075f11164e119"
+      "expected_sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1",
+      "actual_sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1"
     },
     {
       "path": "reports/verification-plan.json",
@@ -293,8 +293,8 @@
       "status": "verified",
       "expected_bytes": 7675,
       "actual_bytes": 7675,
-      "expected_sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e",
-      "actual_sha256": "64fe84f0ec25f37ebce1b836418ec9600f6bbad558c77c8e5cc8646baefaf87e"
+      "expected_sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333",
+      "actual_sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
@@ -302,26 +302,26 @@
       "status": "verified",
       "expected_bytes": 3724,
       "actual_bytes": 3724,
-      "expected_sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222",
-      "actual_sha256": "4dd764f8e9ee83b6c9e72322418f96d6f1d7c85a42750f3064f7d97f1a288222"
+      "expected_sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5",
+      "actual_sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "status": "verified",
-      "expected_bytes": 234853,
-      "actual_bytes": 234853,
-      "expected_sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2",
-      "actual_sha256": "2ec8f71c19a0aa97f99622f75b6a166691ae936f337bead29d10f5bfbd5d93b2"
+      "expected_bytes": 266977,
+      "actual_bytes": 266977,
+      "expected_sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76",
+      "actual_sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 13670,
-      "actual_bytes": 13670,
-      "expected_sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6",
-      "actual_sha256": "a3d220ef5a7834b23efb0bde8e272381b2e823ed5e6439393d9c9c1366e5a4b6"
+      "expected_bytes": 13671,
+      "actual_bytes": 13671,
+      "expected_sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad",
+      "actual_sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -347,17 +347,17 @@
       "status": "verified",
       "expected_bytes": 4463,
       "actual_bytes": 4463,
-      "expected_sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a",
-      "actual_sha256": "ce3f375c8617d08851990389702092d944cbb0b54cbef6848bc8720722fca05a"
+      "expected_sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069",
+      "actual_sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "status": "verified",
-      "expected_bytes": 3346,
-      "actual_bytes": 3346,
-      "expected_sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1",
-      "actual_sha256": "ea493159928a2650101b667bf42a8ea28d6da1375cf056f81c3efc6a68db6cf1"
+      "expected_bytes": 3347,
+      "actual_bytes": 3347,
+      "expected_sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d",
+      "actual_sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:23:42Z",
+  "generated_at": "2026-06-29T09:31:39Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {
-    "total": 346,
+    "total": 406,
     "verified": 22,
     "failed": 87,
-    "skipped": 237,
+    "skipped": 297,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 237,
+        "count": 297,
         "status": "skipped"
       },
       {
@@ -33,18 +33,23 @@
     "by_reason": [
       {
         "key": "missing_auth",
-        "count": 34,
+        "count": 53,
         "reason": "missing_auth"
       },
       {
         "key": "approval_required",
-        "count": 32,
+        "count": 36,
         "reason": "approval_required"
       },
       {
         "key": "missing_required_params",
-        "count": 19,
+        "count": 22,
         "reason": "missing_required_params"
+      },
+      {
+        "key": "ekape_missing_required_params",
+        "count": 19,
+        "reason": "ekape_missing_required_params"
       },
       {
         "key": "tour_service_root_missing_operation_path",
@@ -57,14 +62,19 @@
         "reason": "epost_wadl_metadata_only"
       },
       {
+        "key": "geoje_missing_required_params",
+        "count": 16,
+        "reason": "geoje_missing_required_params"
+      },
+      {
         "key": "ulsan_missing_required_params",
         "count": 16,
         "reason": "ulsan_missing_required_params"
       },
       {
-        "key": "ekape_missing_required_params",
-        "count": 11,
-        "reason": "ekape_missing_required_params"
+        "key": "jeonju_missing_required_params",
+        "count": 13,
+        "reason": "jeonju_missing_required_params"
       },
       {
         "key": "oneclick_connection_refused",
@@ -75,11 +85,6 @@
         "key": "andong_service_not_registered",
         "count": 10,
         "reason": "andong_service_not_registered"
-      },
-      {
-        "key": "geoje_missing_required_params",
-        "count": 10,
-        "reason": "geoje_missing_required_params"
       },
       {
         "key": "sisul_wadl_metadata_only",
@@ -102,6 +107,11 @@
         "reason": "naqs_mutation_endpoint"
       },
       {
+        "key": "qnet_separate_service_key_required",
+        "count": 8,
+        "reason": "qnet_separate_service_key_required"
+      },
+      {
         "key": "humetro_service_access_denied",
         "count": 7,
         "reason": "humetro_service_access_denied"
@@ -110,6 +120,11 @@
         "key": "tour_service_key_not_registered",
         "count": 7,
         "reason": "tour_service_key_not_registered"
+      },
+      {
+        "key": "uiryeong_missing_required_params",
+        "count": 7,
+        "reason": "uiryeong_missing_required_params"
       },
       {
         "key": "itfind_missing_required_params",
@@ -177,11 +192,6 @@
         "reason": "jeonju_http_404_not_found"
       },
       {
-        "key": "jeonju_missing_required_params",
-        "count": 3,
-        "reason": "jeonju_missing_required_params"
-      },
-      {
         "key": "qnet_missing_required_params",
         "count": 3,
         "reason": "qnet_missing_required_params"
@@ -190,11 +200,6 @@
         "key": "sisul_missing_required_params",
         "count": 3,
         "reason": "sisul_missing_required_params"
-      },
-      {
-        "key": "uiryeong_missing_required_params",
-        "count": 3,
-        "reason": "uiryeong_missing_required_params"
       },
       {
         "key": "ulsan_service_key_not_registered",
@@ -225,11 +230,6 @@
         "key": "jeonju_http_405_method_not_allowed",
         "count": 2,
         "reason": "jeonju_http_405_method_not_allowed"
-      },
-      {
-        "key": "qnet_separate_service_key_required",
-        "count": 2,
-        "reason": "qnet_separate_service_key_required"
       },
       {
         "key": "ekape_html_response",
@@ -284,6 +284,21 @@
     ],
     "by_provider": [
       {
+        "key": "ekape",
+        "count": 35,
+        "provider": "ekape"
+      },
+      {
+        "key": "q-net",
+        "count": 35,
+        "provider": "q-net"
+      },
+      {
+        "key": "data.go.kr",
+        "count": 30,
+        "provider": "data.go.kr"
+      },
+      {
         "key": "oneclick-law",
         "count": 30,
         "provider": "oneclick-law"
@@ -294,24 +309,24 @@
         "provider": "epost"
       },
       {
+        "key": "geoje",
+        "count": 26,
+        "provider": "geoje"
+      },
+      {
         "key": "tour",
         "count": 26,
         "provider": "tour"
       },
       {
-        "key": "ekape",
-        "count": 25,
-        "provider": "ekape"
+        "key": "uiryeong",
+        "count": 26,
+        "provider": "uiryeong"
       },
       {
-        "key": "q-net",
+        "key": "jeonju",
         "count": 25,
-        "provider": "q-net"
-      },
-      {
-        "key": "data.go.kr",
-        "count": 20,
-        "provider": "data.go.kr"
+        "provider": "jeonju"
       },
       {
         "key": "sisul",
@@ -324,24 +339,9 @@
         "provider": "ulsan"
       },
       {
-        "key": "geoje",
-        "count": 16,
-        "provider": "geoje"
-      },
-      {
-        "key": "uiryeong",
-        "count": 16,
-        "provider": "uiryeong"
-      },
-      {
         "key": "andong",
         "count": 15,
         "provider": "andong"
-      },
-      {
-        "key": "jeonju",
-        "count": 15,
-        "provider": "jeonju"
       },
       {
         "key": "korad",
@@ -421,29 +421,44 @@
     ],
     "by_endpoint_host": [
       {
+        "key": "data.ekape.or.kr",
+        "count": 35,
+        "host": "data.ekape.or.kr"
+      },
+      {
+        "key": "apis.data.go.kr",
+        "count": 30,
+        "host": "apis.data.go.kr"
+      },
+      {
         "key": "oneclick.law.go.kr:80",
         "count": 27,
         "host": "oneclick.law.go.kr:80"
       },
       {
-        "key": "data.ekape.or.kr",
-        "count": 25,
-        "host": "data.ekape.or.kr"
+        "key": "openapi.q-net.or.kr",
+        "count": 27,
+        "host": "openapi.q-net.or.kr"
       },
       {
-        "key": "openapi.q-net.or.kr",
-        "count": 23,
-        "host": "openapi.q-net.or.kr"
+        "key": "data.geoje.go.kr",
+        "count": 26,
+        "host": "data.geoje.go.kr"
+      },
+      {
+        "key": "data.uiryeong.go.kr",
+        "count": 26,
+        "host": "data.uiryeong.go.kr"
+      },
+      {
+        "key": "openapi.jeonju.go.kr",
+        "count": 25,
+        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "openapi.epost.go.kr:80",
         "count": 22,
         "host": "openapi.epost.go.kr:80"
-      },
-      {
-        "key": "apis.data.go.kr",
-        "count": 20,
-        "host": "apis.data.go.kr"
       },
       {
         "key": "data.sisul.or.kr",
@@ -454,21 +469,6 @@
         "key": "openapi.its.ulsan.kr",
         "count": 20,
         "host": "openapi.its.ulsan.kr"
-      },
-      {
-        "key": "data.geoje.go.kr",
-        "count": 16,
-        "host": "data.geoje.go.kr"
-      },
-      {
-        "key": "data.uiryeong.go.kr",
-        "count": 16,
-        "host": "data.uiryeong.go.kr"
-      },
-      {
-        "key": "openapi.jeonju.go.kr",
-        "count": 15,
-        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "www.andong.go.kr",
@@ -489,6 +489,11 @@
         "key": "data.naqs.go.kr",
         "count": 9,
         "host": "data.naqs.go.kr"
+      },
+      {
+        "key": "c.q-net.or.kr",
+        "count": 8,
+        "host": "c.q-net.or.kr"
       },
       {
         "key": "data.humetro.busan.kr",
@@ -561,11 +566,6 @@
         "host": "www.emuseum.go.kr"
       },
       {
-        "key": "c.q-net.or.kr",
-        "count": 2,
-        "host": "c.q-net.or.kr"
-      },
-      {
         "key": "data.myhome.go.kr:443",
         "count": 1,
         "host": "data.myhome.go.kr:443"
@@ -574,12 +574,12 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 307,
+        "count": 357,
         "kind": "external_endpoint"
       },
       {
         "key": "data_go_kr_gateway",
-        "count": 20,
+        "count": 30,
         "kind": "data_go_kr_gateway"
       },
       {

--- a/reports/latest-verification.json
+++ b/reports/latest-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:23:42Z",
+  "generated_at": "2026-06-29T09:31:39Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 353,
+  "limit": 413,
   "truncated": true,
-  "filtered_count": 346,
+  "filtered_count": 406,
   "summary": {
-    "total": 346,
+    "total": 406,
     "verified": 22,
     "failed": 87,
-    "skipped": 237,
+    "skipped": 297,
     "unknown": 0
   },
   "results": [
@@ -7308,6 +7308,1056 @@
         "numOfRows": "1",
         "pageNo": "1"
       }
+    },
+    {
+      "dataset_id": "15000420",
+      "title": "기상청_지진정보 조회서비스",
+      "operation": "지진해일통보문 목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000420",
+      "title": "기상청_지진정보 조회서비스",
+      "operation": "지진해일통보문조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "dataType": "json",
+        "fromTmFc": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "toTmFc": ""
+      },
+      "missing_params": [
+        "fromTmFc",
+        "toTmFc"
+      ]
+    },
+    {
+      "dataset_id": "15000442",
+      "title": "경찰청_핸드폰 찾기 정보 조회 서비스",
+      "operation": "핸드폰 상세 정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "approval_required",
+      "params": {
+        "ATC_ID": "",
+        "FD_SN": ""
+      },
+      "missing_params": [
+        "ATC_ID",
+        "FD_SN"
+      ]
+    },
+    {
+      "dataset_id": "15000442",
+      "title": "경찰청_핸드폰 찾기 정보 조회 서비스",
+      "operation": "핸드폰 종류별, 습득 지역별, 기간별 정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "approval_required",
+      "params": {
+        "COL_CD": "",
+        "END_YMD": "",
+        "FD_LCT_CD": "",
+        "PRDT_CL_CD_02": "",
+        "START_YMD": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "COL_CD",
+        "FD_LCT_CD",
+        "START_YMD",
+        "END_YMD",
+        "PRDT_CL_CD_02"
+      ]
+    },
+    {
+      "dataset_id": "15000445",
+      "title": "국립중앙의료원_코드마스터 정보 조회 서비스",
+      "operation": "코드마스터 정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_auth"
+    },
+    {
+      "dataset_id": "15000467",
+      "title": "대전광역시 공연행사정보",
+      "operation": "대전광역시청 행사안내 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "approval_required"
+    },
+    {
+      "dataset_id": "15000467",
+      "title": "대전광역시 공연행사정보",
+      "operation": "행사안내 상세화면 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "approval_required"
+    },
+    {
+      "dataset_id": "15000480",
+      "title": "국립중앙의료원_전국 명절 비상 진료기관 정보 조회 서비스",
+      "operation": "명절 비상진료기관 FullData 내려받기목록정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15000480",
+      "title": "국립중앙의료원_전국 명절 비상 진료기관 정보 조회 서비스",
+      "operation": "명절 진료 가능한 기관 목록정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "ORD": "",
+        "Q0": "",
+        "Q1": "",
+        "QD": "",
+        "QT": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "Q0",
+        "Q1",
+        "QD",
+        "QT",
+        "ORD"
+      ]
+    },
+    {
+      "dataset_id": "15000480",
+      "title": "국립중앙의료원_전국 명절 비상 진료기관 정보 조회 서비스",
+      "operation": "명절 진료 가능한 기관 상세정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_auth"
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 도매시장 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "kindCd": ""
+      },
+      "missing_params": [
+        "kindCd",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 등급판정(확인서) 부위별고기및 부산물 정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1",
+        "weight": ""
+      },
+      "missing_params": [
+        "weight"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "소도체 1++ 등급 세부경락가격 상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCode": "",
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCode",
+        "breedCd",
+        "sexCd",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "실시간 소도체 경매현황 조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": "",
+        "endNo": "",
+        "gradeCd": "",
+        "kindCd": "",
+        "sexCd": "",
+        "startNo": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd",
+        "startNo",
+        "endNo",
+        "kindCd",
+        "sexCd",
+        "gradeCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "오리 등급판정결과(확인서)정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "issueDate": "20240101",
+        "issueNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 도매시장 소도체 1++등급 세부경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 도매시장 소도체 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 돼지도체 경락가격 상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCd": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "skinYn": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCd",
+        "skinYn",
+        "sexCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 소도체 경락상세정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "abattCode": "",
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "abattCode",
+        "breedCd",
+        "sexCd",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojetourId": ""
+      },
+      "missing_params": [
+        "geojetourId"
+      ]
+    },
+    {
+      "dataset_id": "15058133",
+      "title": "경상남도 거제시_추천관광정보",
+      "operation": "거제시 추천관광 이미지정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojetourId": ""
+      },
+      "missing_params": [
+        "geojetourId"
+      ]
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 목록정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojejumineduId": ""
+      },
+      "missing_params": [
+        "geojejumineduId"
+      ]
+    },
+    {
+      "dataset_id": "15058426",
+      "title": "경상남도 거제시_시민자치대학정보",
+      "operation": "거제시 시민자치대학 이미지정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojejumineduId": ""
+      },
+      "missing_params": [
+        "geojejumineduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화 교육 상세 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojeeduId": ""
+      },
+      "missing_params": [
+        "geojeeduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화 교육 첨부파일 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "geojeeduId": ""
+      },
+      "missing_params": [
+        "geojeeduId"
+      ]
+    },
+    {
+      "dataset_id": "15058567",
+      "title": "경상남도 거제시_정보화교육정보",
+      "operation": "거제시 정보화교육 목록 정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "pageSize": "1",
+        "startPage": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 CCTV 정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15020604",
+      "title": "전북특별자치도 전주시_착한가격모범업소 현황",
+      "operation": "착한 가격 모법업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "address": "",
+        "chakName": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "pumName": ""
+      },
+      "missing_params": [
+        "chakName",
+        "pumName",
+        "address"
+      ]
+    },
+    {
+      "dataset_id": "15024710",
+      "title": "전북특별자치도 전주시_건설시공업체 현황",
+      "operation": "건설시공업체 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15024711",
+      "title": "전북특별자치도 전주시_청소업체 현황",
+      "operation": "저수조 청소업체  현황목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028084",
+      "title": "전북특별자치도 전주시_현수막 지정현황",
+      "operation": "현수막 지정 게시대 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028085",
+      "title": "전북특별자치도 전주시_장사시설 현황",
+      "operation": "장사시설 현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15028086",
+      "title": "전북특별자치도 전주시_택시현황",
+      "operation": "법인택시 면허  현황 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15047649",
+      "title": "전북특별자치도 전주시_아동복지시설현황 서비스",
+      "operation": "아동복지시설  목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15047707",
+      "title": "전북특별자치도 전주시_바이전주상품 정보 서비스",
+      "operation": "바이전주 상품 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "seq": ""
+      },
+      "missing_params": [
+        "seq"
+      ]
+    },
+    {
+      "dataset_id": "15056885",
+      "title": "전북특별자치도 전주시_가로등 정보 서비스",
+      "operation": "가로등주 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "boxNm": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "boxNm"
+      ]
+    },
+    {
+      "dataset_id": "15056979",
+      "title": "전북특별자치도 전주시_동물판매업소 정보 현황",
+      "operation": "동물판매업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행) 취득(수료)당시 연령별 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행)평가 및 취득(수료)현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "종목별 외부평가 점수분포 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "주무부처별 취득자(수료)현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037519",
+      "title": "한국산업인력공단_국가자격 등급별 응시자격 항목 정보",
+      "operation": "등급별 응시자격 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037519",
+      "title": "한국산업인력공단_국가자격 등급별 응시자격 항목 정보",
+      "operation": "응시자격 항목 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037520",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계연보",
+      "operation": "과정평가형(일학습병행) 외부평가 유형별 합격률 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037520",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계연보",
+      "operation": "과정평가형(일학습병행) 외부평가 합격률 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "상시검정 취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "연령별 검정 취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15056844",
+      "title": "경상남도 의령군_노인복지시설",
+      "operation": "노인복지시설 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15056888",
+      "title": "경상남도 의령군_의병박물관유물",
+      "operation": "의병박물관 유물 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "uiryeongrelicsEntId": ""
+      },
+      "missing_params": [
+        "uiryeongrelicsEntId"
+      ]
+    },
+    {
+      "dataset_id": "15056888",
+      "title": "경상남도 의령군_의병박물관유물",
+      "operation": "의병박물관 유물 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057207",
+      "title": "경상남도 의령군_보호수",
+      "operation": "보호수 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057329",
+      "title": "경상남도 의령군_장애인복지시설",
+      "operation": "장애인복지시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "uiryeongdisabledDerector": ""
+      },
+      "missing_params": [
+        "uiryeongdisabledDerector"
+      ]
+    },
+    {
+      "dataset_id": "15057493",
+      "title": "경상남도 의령군_금연구역",
+      "operation": "의령 금연구역 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057883",
+      "title": "경상남도 의령군_무더위쉼터",
+      "operation": "무더위쉼터 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058260",
+      "title": "경상남도 의령군_재해위험지구",
+      "operation": "재해위험지구 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "dangerArea": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dangerArea"
+      ]
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "uiryeongculturalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongculturalEntId"
+      ]
     }
   ]
 }

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "limit": 0,

--- a/reports/qnet-verification-summary.json
+++ b/reports/qnet-verification-summary.json
@@ -1,29 +1,35 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/qnet-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 0,
-    "skipped": 15,
+    "skipped": 25,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 15,
+        "count": 25,
         "status": "skipped"
       }
     ],
     "by_reason": [
       {
         "key": "missing_auth",
-        "count": 5,
+        "count": 9,
         "reason": "missing_auth"
+      },
+      {
+        "key": "qnet_separate_service_key_required",
+        "count": 8,
+        "reason": "qnet_separate_service_key_required"
       },
       {
         "key": "qnet_wadl_metadata_only",
@@ -34,36 +40,31 @@
         "key": "qnet_missing_required_params",
         "count": 3,
         "reason": "qnet_missing_required_params"
-      },
-      {
-        "key": "qnet_separate_service_key_required",
-        "count": 2,
-        "reason": "qnet_separate_service_key_required"
       }
     ],
     "by_provider": [
       {
         "key": "q-net",
-        "count": 15,
+        "count": 25,
         "provider": "q-net"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.q-net.or.kr",
-        "count": 13,
+        "count": 17,
         "host": "openapi.q-net.or.kr"
       },
       {
         "key": "c.q-net.or.kr",
-        "count": 2,
+        "count": 8,
         "host": "c.q-net.or.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 15,
+        "count": 25,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/qnet-verification.json
+++ b/reports/qnet-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:16:46Z",
+  "generated_at": "2026-06-29T09:31:15Z",
   "provider": "data.go.kr",
-  "limit": 15,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 25,
   "truncated": true,
-  "filtered_count": 15,
+  "filtered_count": 25,
   "summary": {
-    "total": 15,
+    "total": 25,
     "verified": 0,
     "failed": 0,
-    "skipped": 15,
+    "skipped": 25,
     "unknown": 0
   },
   "results": [
@@ -229,6 +230,150 @@
       "verified_at": "2026-06-29T09:15:44Z",
       "params": {
         "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행) 취득(수료)당시 연령별 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "과정평가형(일학습병행)평가 및 취득(수료)현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "종목별 외부평가 점수분포 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037518",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계 정보",
+      "operation": "주무부처별 취득자(수료)현황 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037519",
+      "title": "한국산업인력공단_국가자격 등급별 응시자격 항목 정보",
+      "operation": "등급별 응시자격 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037519",
+      "title": "한국산업인력공단_국가자격 등급별 응시자격 항목 정보",
+      "operation": "응시자격 항목 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037520",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계연보",
+      "operation": "과정평가형(일학습병행) 외부평가 유형별 합격률 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037520",
+      "title": "한국산업인력공단_과정평가형, 일학습병행 통계연보",
+      "operation": "과정평가형(일학습병행) 외부평가 합격률 통계 정보 조회",
+      "provider": "q-net",
+      "endpoint_host": "c.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "qnet_separate_service_key_required",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "상시검정 취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "연령별 검정 취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
       }
     }
   ]

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",

--- a/reports/uiryeong-verification-summary.json
+++ b/reports/uiryeong-verification-summary.json
@@ -1,21 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:23:10Z",
+  "generated_at": "2026-06-29T09:31:16Z",
   "source": "/home/statpan/workspace/opensource/datapan-registry/reports/uiryeong-verification.json",
   "provider": "data.go.kr",
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 16,
+    "total": 26,
     "verified": 0,
     "failed": 6,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 10,
+        "count": 20,
         "status": "skipped"
       },
       {
@@ -27,38 +28,38 @@
     "by_reason": [
       {
         "key": "missing_auth",
-        "count": 7,
+        "count": 13,
         "reason": "missing_auth"
+      },
+      {
+        "key": "uiryeong_missing_required_params",
+        "count": 7,
+        "reason": "uiryeong_missing_required_params"
       },
       {
         "key": "uiryeong_service_key_not_registered",
         "count": 6,
         "reason": "uiryeong_service_key_not_registered"
-      },
-      {
-        "key": "uiryeong_missing_required_params",
-        "count": 3,
-        "reason": "uiryeong_missing_required_params"
       }
     ],
     "by_provider": [
       {
         "key": "uiryeong",
-        "count": 16,
+        "count": 26,
         "provider": "uiryeong"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.uiryeong.go.kr",
-        "count": 16,
+        "count": 26,
         "host": "data.uiryeong.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 16,
+        "count": 26,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/uiryeong-verification.json
+++ b/reports/uiryeong-verification.json
@@ -1,14 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:23:10Z",
+  "generated_at": "2026-06-29T09:31:16Z",
   "provider": "data.go.kr",
-  "limit": 16,
+  "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
+  "limit": 26,
   "truncated": true,
-  "filtered_count": 16,
+  "filtered_count": 26,
   "summary": {
-    "total": 16,
+    "total": 26,
     "verified": 0,
     "failed": 6,
-    "skipped": 10,
+    "skipped": 20,
     "unknown": 0
   },
   "results": [
@@ -311,6 +312,168 @@
         "numOfRows": "1",
         "pageNo": "1"
       }
+    },
+    {
+      "dataset_id": "15056844",
+      "title": "경상남도 의령군_노인복지시설",
+      "operation": "노인복지시설 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15056888",
+      "title": "경상남도 의령군_의병박물관유물",
+      "operation": "의병박물관 유물 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "uiryeongrelicsEntId": ""
+      },
+      "missing_params": [
+        "uiryeongrelicsEntId"
+      ]
+    },
+    {
+      "dataset_id": "15056888",
+      "title": "경상남도 의령군_의병박물관유물",
+      "operation": "의병박물관 유물 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057207",
+      "title": "경상남도 의령군_보호수",
+      "operation": "보호수 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057329",
+      "title": "경상남도 의령군_장애인복지시설",
+      "operation": "장애인복지시설 현황 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "uiryeongdisabledDerector": ""
+      },
+      "missing_params": [
+        "uiryeongdisabledDerector"
+      ]
+    },
+    {
+      "dataset_id": "15057493",
+      "title": "경상남도 의령군_금연구역",
+      "operation": "의령 금연구역 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15057883",
+      "title": "경상남도 의령군_무더위쉼터",
+      "operation": "무더위쉼터 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058260",
+      "title": "경상남도 의령군_재해위험지구",
+      "operation": "재해위험지구 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "dangerArea": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "dangerArea"
+      ]
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 사진",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "uiryeongculturalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongculturalEntId"
+      ]
     }
   ]
 }

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:24:17Z",
+  "generated_at": "2026-06-29T09:32:26Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
   "source": "release",
@@ -8,9 +8,9 @@
   "timeout": "10s",
   "summary": {
     "operations": 12205,
-    "evidence_total": 346,
-    "uncovered_gateway_candidates": 11399,
-    "uncovered_adapter_candidates": 260,
+    "evidence_total": 406,
+    "uncovered_gateway_candidates": 11389,
+    "uncovered_adapter_candidates": 210,
     "missing_adapter_hosts": 10,
     "planned_batches": 6,
     "planned_operations": 60
@@ -20,7 +20,7 @@
       "label": "gateway",
       "kind": "data_go_kr_gateway",
       "candidates": 11419,
-      "uncovered_candidates": 11399,
+      "uncovered_candidates": 11389,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
       "output": ".datapan/verification/gateway-next.json"
@@ -30,7 +30,7 @@
       "provider": "ekape",
       "kind": "external_endpoint",
       "candidates": 49,
-      "uncovered_candidates": 24,
+      "uncovered_candidates": 14,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
       "output": ".datapan/verification/ekape-next.json"
@@ -40,7 +40,7 @@
       "provider": "geoje",
       "kind": "external_endpoint",
       "candidates": 41,
-      "uncovered_candidates": 25,
+      "uncovered_candidates": 15,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
       "output": ".datapan/verification/geoje-next.json"
@@ -50,7 +50,7 @@
       "provider": "jeonju",
       "kind": "external_endpoint",
       "candidates": 80,
-      "uncovered_candidates": 65,
+      "uncovered_candidates": 55,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
       "output": ".datapan/verification/jeonju-next.json"
@@ -60,7 +60,7 @@
       "provider": "q-net",
       "kind": "external_endpoint",
       "candidates": 147,
-      "uncovered_candidates": 122,
+      "uncovered_candidates": 112,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
       "output": ".datapan/verification/q-net-next.json"
@@ -70,7 +70,7 @@
       "provider": "uiryeong",
       "kind": "external_endpoint",
       "candidates": 40,
-      "uncovered_candidates": 24,
+      "uncovered_candidates": 14,
       "planned_operations": 10,
       "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
       "output": ".datapan/verification/uiryeong-next.json"

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-29T09:24:06Z",
+  "generated_at": "2026-06-29T09:32:14Z",
   "datapan_version": "0.1.0-dev",
   "count": 20,
   "schemas": [


### PR DESCRIPTION
Closes #25

## Gap

data.go.kr runtime evidence coverage remains below the documented 10% target. This PR continues the provider-priority evidence plan by adding the next gateway and external endpoint batches after #20, #22, and #24.

## Changes

- Merge excluded-from-latest batches for `gateway`, `ekape`, `geoje`, `jeonju`, `q-net`, and `uiryeong`.
- Regenerate provider-specific reports/summaries for `ekape`, `geoje`, `jeonju`, `qnet`, and `uiryeong`.
- Regenerate `reports/latest-verification.json`, latest summary, release verification/readiness, runtime evidence growth, release notes, README snapshot, manifest, and schema index.
- Update the data.go.kr mastery plan and registry blueprint so #25 is recorded as continued runtime evidence growth.

## Warning Status

- Active warning remains: `runtime_evidence_growth_target` / `runtime_evidence_below_target`.
- Target: `1,221` evidence records for `10.0%` runtime evidence coverage.
- Actual: `406` evidence records (`3.3%`).
- Remaining gap: `815` additional evidence records.
- This warning is not harmless and is intentionally preserved in readiness output.

## Evidence Boundary

The new 60 records are skipped boundary evidence, not successful callable coverage.

- `gateway`: `10` new skipped records.
- `ekape`: `10` new skipped records; provider report now has `25` total, including `5` older failed records.
- `geoje`: `10` new skipped records; provider report now has `26` total, including `2` older verified records.
- `jeonju`: `10` new skipped records; provider report now has `25` total, including `5` older failed records.
- `q-net`: `10` new skipped records; provider report now has `25` total, all skipped.
- `uiryeong`: `10` new skipped records; provider report now has `26` total, including `6` older failed records.
- Latest evidence has `406` unique records by provider, dataset, operation, host, and dependency class.

## Validation

- `datapan catalog release draft` with materialized data.go.kr registry and latest verification evidence.
- `datapan catalog release verify --manifest manifest.json --output reports/latest-release-verification.json --json` -> `39/39` artifacts verified.
- `datapan catalog release readiness --manifest manifest.json --output reports/latest-release-readiness.json --json` -> `ready: true`, `passed: 22`, `warned: 1`, `failed: 0`.
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- README current snapshot grep check.
- `jq empty ...` over source profiles, source-scoped reports, latest verification, release reports, manifest, and schemas.
- `git diff --check`

Local release verification required temporarily materializing `data/data-go-kr.registry.json`; the tracked file was restored to the Git LFS pointer afterward. GitHub Actions checks out LFS for release verification.
