### PR TITLE
feat: Add next gateway and external endpoint evidence batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ re-importing the upstream data.go.kr catalog every time.
 - Missing external adapter hosts: `10`
 - Provider split readiness: `ready`
   (`26` adapters, `26` verification-capable, `21` call-capable)
-- Runtime verification evidence: `406` bounded checks merged into
-  `reports/latest-verification.json` (`22` verified, `87` failed, `297`
+- Runtime verification evidence: `466` bounded checks merged into
+  `reports/latest-verification.json` (`22` verified, `87` failed, `357`
   skipped)
+- Runtime evidence growth target: `3.8%` checked evidence against the `10%`
+  release target; `755` additional records are still required.
 - Missing external host probe: `28` unadapted external endpoint checks in
   `reports/unadapted-external-probe.json` (`14` HTTP 404, `7` timeout, `6`
   request/DNS errors, `1` HTTP 503)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
 # Datapan Registry Release
 
-- generated_at: `2026-06-29T09:32:14Z`
+- generated_at: `2026-06-29T09:40:38Z`
 - provider: `data.go.kr`
 - datapan_version: `0.1.0-dev`
-- source_registry: `/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json`
-- previous_registry: `/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json`
+- source_registry: `data/data-go-kr.registry.json`
+- previous_registry: `data/data-go-kr.registry.json`
 - release_manifest: `manifest.json`
 
 ## Registry
@@ -24,12 +24,12 @@
 - route_disposition: `28` routes, `14` dead-route candidates, `14` transient failures, `0` parameter-blocked, `0` adapter candidates
 - route_disposition_artifact: `reports/route-disposition.json`
 - provider_backlog: `179` hosts, `10` missing-adapter hosts, `28` operations needing adapters
-- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `3.3%`, evidence-adjusted adapter candidates `0`
+- coverage: `12063` callable operations (`98.8%`), external adapter coverage `95.4%`, verification evidence coverage `3.8%`, evidence-adjusted adapter candidates `0`
 - coverage_artifact: `reports/coverage.json`
 - coverage_goals: callable `99%`, external adapters `98%`, verification evidence `10%`, call-capable adapters `25`, missing-adapter operations `<=10`
-- verification_plan: `6` batches, `60` planned operations, `11389` gateway gaps, `210` adapter gaps
+- verification_plan: `6` batches, `43` planned operations, `11379` gateway gaps, `160` adapter gaps
 - verification_plan_artifact: `reports/verification-plan.json`
-- runtime_evidence_growth: `3.3%` coverage, target `10.0%`, remaining `815`, status `below_target`
+- runtime_evidence_growth: `3.8%` coverage, target `10.0%`, remaining `755`, status `below_target`
 - runtime_evidence_growth_artifact: `reports/data-go-kr/runtime-evidence-growth.json`
 - runtime_evidence_warning: `warning` `runtime_evidence_below_target`
 
@@ -43,18 +43,18 @@ Top adapter targets:
 
 ## Verification Evidence
 
-- verification: `406` total, `22` verified, `87` failed, `297` skipped, `0` unknown
+- verification: `466` total, `22` verified, `87` failed, `357` skipped, `0` unknown
 - verification_artifact: `reports/latest-verification.json`
 - verification_summary_artifact: `reports/latest-verification-summary.json`
 
 Provider evidence:
 
-- `ekape`: `35`
-- `q-net`: `35`
-- `data.go.kr`: `30`
-- `oneclick-law`: `30`
-- `epost`: `28`
-- `geoje`: `26`
+- `ekape`: `45`
+- `q-net`: `45`
+- `data.go.kr`: `40`
+- `geoje`: `36`
+- `uiryeong`: `36`
+- `jeonju`: `35`
 
 - unadapted_external_probe: `28` total, `0` verified, `28` failed, `0` skipped, `0` unknown
 - unadapted_external_probe_artifact: `reports/unadapted-external-probe.json`

--- a/data/provider-index.json
+++ b/data/provider-index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "datapan_version": "0.1.0-dev",
   "adapter_count": 26,
   "host_count": 30,

--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -203,8 +203,10 @@ CI should fail rather than treating the checked-in summary as authoritative.
    `uiryeong`, `epost`, and `ulsan` boundary batches, growing checked runtime
    evidence to `346`. Continued by Gira #25 with gateway, `ekape`, `geoje`,
    `jeonju`, `q-net`, and `uiryeong` boundary batches, growing checked runtime
-   evidence to `406`. Runtime evidence remains below the `10%` target with
-   `815` additional evidence records still required.
+   evidence to `406`. Continued by Gira #27 with the next gateway, `ekape`,
+   `geoje`, `jeonju`, `q-net`, and `uiryeong` boundary batches, growing checked
+   runtime evidence to `466`. Runtime evidence remains below the `10%` target
+   with `755` additional evidence records still required.
 10. Add a data.go.kr draft impact plan and validate its client/server action
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -106,10 +106,10 @@ Current gaps:
   non-data.go.kr profile batch, but runtime evidence is not yet generated for
   those non-data.go.kr sources.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
-  Gira #21, Gira #23, and Gira #25 raise data.go.kr runtime evidence from
-  `256` to `406`, but the release readiness warning remains active: the `10%`
-  target requires `1,221` evidence records, so `815` additional records are
-  still required.
+  Gira #21, Gira #23, Gira #25, and Gira #27 raise data.go.kr runtime evidence
+  from `256` to `466`, but the release readiness warning remains active: the
+  `10%` target requires `1,221` evidence records, so `755` additional records
+  are still required.
 - Multi-source report grouping is designed but not implemented.
 - Impact plans are specified and a data.go.kr draft plan is checked in, but
   full `datapan-cli` generation is not implemented.
@@ -287,9 +287,11 @@ Use this order unless a production failure changes priority:
     by Gira #19 with `epost` and `ulsan` external endpoint batches and
     continued by Gira #21 with gateway, `geoje`, `jeonju`, and `q-net`
     batches, then by Gira #23 with `ekape`, `emuseum`, `uiryeong`, `epost`,
-    and `ulsan` batches, and by Gira #25 with the next gateway, `ekape`,
-    `geoje`, `jeonju`, `q-net`, and `uiryeong` batches; this is skipped
-    boundary evidence growth, not proof that those operations are callable.
+    and `ulsan` batches, by Gira #25 with the next gateway, `ekape`, `geoje`,
+    `jeonju`, `q-net`, and `uiryeong` batches, and by Gira #27 with the next
+    gateway, `ekape`, `geoje`, `jeonju`, `q-net`, and `uiryeong` batches; this
+    is skipped boundary evidence growth, not proof that those operations are
+    callable.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
-  "source_registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
-  "output_dir": "/home/statpan/workspace/opensource/datapan-registry",
+  "source_registry": "data/data-go-kr.registry.json",
+  "output_dir": ".",
   "artifact_count": 39,
   "artifacts": [
     {
@@ -132,7 +132,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 7490,
-      "sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce"
+      "sha256": "45086f8aa0f03809ba8c69ac82714b49046e8041ad1bd259e3256b1cc96bc989"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -146,91 +146,91 @@
       "kind": "provider_index",
       "schema": "https://schemas.datapan.dev/datapan.provider-index.v1.schema.json",
       "bytes": 5588,
-      "sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee"
+      "sha256": "8962a63d396b3d7823dd701608825ef606e208b7eaafab06f08dceafa17b34cb"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "schema": "https://schemas.datapan.dev/datapan.catalog-diff.v1.schema.json",
-      "bytes": 505,
-      "sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94"
+      "bytes": 390,
+      "sha256": "b0f02b1743dfd5f71bf5eb8c70e7a0b23c591d2a59472a37fe9413e66792b48a"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "schema": "https://schemas.datapan.dev/datapan.catalog-audit.v1.schema.json",
-      "bytes": 15985,
-      "sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6"
+      "bytes": 15935,
+      "sha256": "cd1e637e3798b50e9ef7e834a50dbc35f55a8605479e9f3db7ca82669be57289"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "schema": "https://schemas.datapan.dev/datapan.error-catalog.v1.schema.json",
-      "bytes": 3305406,
-      "sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57"
+      "bytes": 3305356,
+      "sha256": "1bbbb3321293d0a1fcdf1645872dfe7fa538512f45ac2bed28f90588d2df3be3"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "schema": "https://schemas.datapan.dev/datapan.dependencies.v1.schema.json",
-      "bytes": 11399477,
-      "sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1"
+      "bytes": 11399427,
+      "sha256": "509550c94d1f48a1b7e7ec951433567006896eda7f7a39872aeca3d67f35c38f"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "schema": "https://schemas.datapan.dev/datapan.adapter-targets.v1.schema.json",
-      "bytes": 15197,
-      "sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5"
+      "bytes": 15147,
+      "sha256": "70118eaa83492804e77772028fe72632dffb846a837f299574c43cfa09624bd2"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "schema": "https://schemas.datapan.dev/datapan.route-disposition.v1.schema.json",
-      "bytes": 22374,
-      "sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce"
+      "bytes": 22274,
+      "sha256": "40bfc228268a53461679f23f56055e81a9490120b719b63f7b6a8268e053aea2"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "schema": "https://schemas.datapan.dev/datapan.providers.v1.schema.json",
-      "bytes": 53713,
-      "sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3"
+      "bytes": 53663,
+      "sha256": "d46a9cb17986e889616f572264eb2be6f86c692bc8c75a77834cc18bc4c95475"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "schema": "https://schemas.datapan.dev/datapan.coverage.v1.schema.json",
-      "bytes": 17021,
-      "sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1"
+      "bytes": 16521,
+      "sha256": "bb261bd178621678d933b182497fcc15fb67722eca507b17fb4cc902fd879013"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.verification-plan.v1.schema.json",
-      "bytes": 7675,
-      "sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333"
+      "bytes": 6869,
+      "sha256": "af57abd2c471be36b1896cd366d76f2b774e227510d621b3ac999eaf181103c2"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "schema": "https://schemas.datapan.dev/datapan.runtime-evidence-growth.v1.schema.json",
-      "bytes": 3724,
-      "sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5"
+      "bytes": 3718,
+      "sha256": "b6c3b2e0ec65e172c0c4ea6b11d9ed5924ae89ba7ef2ae6813eb988d48930a02"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "schema": "https://schemas.datapan.dev/datapan.verification.v1.schema.json",
-      "bytes": 266977,
-      "sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76"
+      "bytes": 301152,
+      "sha256": "4915542d6093dbe67aab88c8c5346d22fbe1e24260bfa9fca1d29276b211a4be"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 13671,
-      "sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad"
+      "bytes": 13622,
+      "sha256": "b2102738c485f116ff9792338a82f8153eb9eda56f072e975712a77eaae5e317"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -243,20 +243,20 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "schema": "https://schemas.datapan.dev/datapan.verification-summary.v1.schema.json",
-      "bytes": 2453,
-      "sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
+      "bytes": 2403,
+      "sha256": "d37b6d23859ca2bc62b8505c1a10026725a71bf95d7d37993aaf126590791901"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
-      "bytes": 4463,
-      "sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069"
+      "bytes": 2460,
+      "sha256": "87e432155600e9492e48e0ed4f7be900163134af95ee008d675d80c3f2719d16"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
-      "bytes": 3347,
-      "sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d"
+      "bytes": 3227,
+      "sha256": "22ddadb9309d157b22b12a62098655c5e62b35f0fed69fb11dc47d7e3ee796fa"
     }
   ]
 }

--- a/provenance/data-go-kr.md
+++ b/provenance/data-go-kr.md
@@ -1,31 +1,31 @@
 # data.go.kr Release Provenance
 
-- generated_at: 2026-06-29T09:32:14Z
+- generated_at: 2026-06-29T09:40:38Z
 - datapan_version: 0.1.0-dev
 - source_provider: data.go.kr
-- source_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
-- previous_registry: /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json
-- release_registry: /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json
+- source_registry: data/data-go-kr.registry.json
+- previous_registry: data/data-go-kr.registry.json
+- release_registry: ./data/data-go-kr.registry.json
 - provider_limit: 0
-- verification_source: /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json
-- unadapted_external_probe_source: /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json
+- verification_source: reports/latest-verification.json
+- unadapted_external_probe_source: ./reports/unadapted-external-probe.json
 
 ## Commands
 
 ```bash
-datapan catalog release draft --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output-dir /home/statpan/workspace/opensource/datapan-registry --provider-limit 0 --previous-registry /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
-# provider index: /home/statpan/workspace/opensource/datapan-registry/data/provider-index.json
-datapan catalog diff --old /home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json --new /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-diff.json --json
-datapan catalog audit --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/catalog-audit.json --json
-datapan catalog errors --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --output /home/statpan/workspace/opensource/datapan-registry/reports/error-catalog.json --json
-datapan catalog dependencies --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/dependencies.json --json
-datapan catalog adapter-targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/adapter-targets.json --json
-datapan catalog route-disposition --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --probe /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json
-datapan catalog providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 0 --output /home/statpan/workspace/opensource/datapan-registry/reports/provider-backlog.json --json
-datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json
-datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification-summary.json --json
-datapan catalog verify --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --json
-datapan catalog verify summary --input /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json --output /home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe-summary.json --json
-datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --output /home/statpan/workspace/opensource/datapan-registry/reports/coverage.json --json
-datapan catalog verify plan --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --output /home/statpan/workspace/opensource/datapan-registry/reports/verification-plan.json --json
+datapan catalog release draft --registry data/data-go-kr.registry.json --output-dir . --provider-limit 0 --previous-registry data/data-go-kr.registry.json --verification reports/latest-verification.json --json
+# provider index: ./data/provider-index.json
+datapan catalog diff --old data/data-go-kr.registry.json --new ./data/data-go-kr.registry.json --limit 0 --output ./reports/catalog-diff.json --json
+datapan catalog audit --registry ./data/data-go-kr.registry.json --output ./reports/catalog-audit.json --json
+datapan catalog errors --registry ./data/data-go-kr.registry.json --output ./reports/error-catalog.json --json
+datapan catalog dependencies --registry ./data/data-go-kr.registry.json --limit 0 --output ./reports/dependencies.json --json
+datapan catalog adapter-targets --registry ./data/data-go-kr.registry.json --limit 0 --output ./reports/adapter-targets.json --json
+datapan catalog route-disposition --registry ./data/data-go-kr.registry.json --probe ./reports/unadapted-external-probe.json --limit 0 --output ./reports/route-disposition.json --json
+datapan catalog providers --registry ./data/data-go-kr.registry.json --limit 0 --output ./reports/provider-backlog.json --json
+datapan catalog verify --input ./reports/latest-verification.json --json
+datapan catalog verify summary --input ./reports/latest-verification.json --output ./reports/latest-verification-summary.json --json
+datapan catalog verify --input ./reports/unadapted-external-probe.json --json
+datapan catalog verify summary --input ./reports/unadapted-external-probe.json --output ./reports/unadapted-external-probe-summary.json --json
+datapan catalog coverage --registry ./data/data-go-kr.registry.json --verification ./reports/latest-verification.json --route-disposition ./reports/route-disposition.json --output ./reports/coverage.json --json
+datapan catalog verify plan --registry ./data/data-go-kr.registry.json --verification ./reports/latest-verification.json --output ./reports/verification-plan.json --json
 ```

--- a/reports/adapter-targets.json
+++ b/reports/adapter-targets.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 10,

--- a/reports/catalog-audit.json
+++ b/reports/catalog-audit.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "sample_limit": 5,
   "audit": {
     "specs_total": 12060,

--- a/reports/catalog-diff.json
+++ b/reports/catalog-diff.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "old": "/home/statpan/workspace/opensource/datapan-registry/.datapan/previous/data-go-kr.registry.json",
-  "new": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "old": "data/data-go-kr.registry.json",
+  "new": "./data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "counts": {

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-06-29T09:32:18Z",
+  "generated_at": "2026-06-29T09:40:43Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
-  "route_disposition": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
+  "verification": "./reports/latest-verification.json",
+  "route_disposition": "./reports/route-disposition.json",
   "summary": {
     "specs": 12060,
     "operations": 12205,
@@ -41,18 +41,18 @@
   },
   "evidence": {
     "present": true,
-    "generated_at": "2026-06-29T09:31:39Z",
-    "total": 406,
+    "generated_at": "2026-06-29T09:40:10Z",
+    "total": 466,
     "verified": 22,
     "failed": 87,
-    "skipped": 297,
+    "skipped": 357,
     "unknown": 0,
-    "verified_percent": 5.4,
-    "evidence_operation_percent": 3.3
+    "verified_percent": 4.7,
+    "evidence_operation_percent": 3.8
   },
   "route_evidence": {
     "present": true,
-    "report": "/home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json",
+    "report": "./reports/route-disposition.json",
     "routes_total": 28,
     "with_probe_evidence": 28,
     "dead_route_candidates": 14,
@@ -381,7 +381,7 @@
     ]
   },
   "adapters": {
-    "generated_at": "2026-06-29T09:32:18Z",
+    "generated_at": "2026-06-29T09:40:43Z",
     "datapan_version": "0.1.0-dev",
     "adapter_count": 26,
     "host_count": 30,
@@ -688,19 +688,19 @@
   "next": [
     {
       "label": "missing adapters",
-      "command": "datapan providers --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --gaps --limit 20 --json"
+      "command": "datapan providers --registry ./data/data-go-kr.registry.json --gaps --limit 20 --json"
     },
     {
       "label": "adapter targets",
-      "command": "datapan targets --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --limit 20 --json"
+      "command": "datapan targets --registry ./data/data-go-kr.registry.json --limit 20 --json"
     },
     {
       "label": "coverage report",
-      "command": "datapan coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --route-disposition /home/statpan/workspace/opensource/datapan-registry/reports/route-disposition.json --json"
+      "command": "datapan coverage --registry ./data/data-go-kr.registry.json --verification ./reports/latest-verification.json --route-disposition ./reports/route-disposition.json --json"
     },
     {
       "label": "verify forest",
-      "command": "datapan verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
+      "command": "datapan verify --registry ./data/data-go-kr.registry.json --provider forest --kind external_endpoint --limit 4 --timeout 10s --json"
     }
   ]
 }

--- a/reports/data-go-kr/runtime-evidence-growth.json
+++ b/reports/data-go-kr/runtime-evidence-growth.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.runtime-evidence-growth.v1",
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_id": "data_go_kr",
@@ -21,20 +21,20 @@
     "call_capable_adapters": 21
   },
   "evidence": {
-    "total": 406,
+    "total": 466,
     "verified": 22,
     "failed": 87,
-    "skipped": 297,
+    "skipped": 357,
     "unknown": 0,
-    "coverage_percent": 3.3,
+    "coverage_percent": 3.8,
     "by_kind": [
       {
         "key": "data_go_kr_gateway",
-        "count": 30
+        "count": 40
       },
       {
         "key": "external_endpoint",
-        "count": 357
+        "count": 407
       },
       {
         "key": "service_root",
@@ -45,14 +45,14 @@
   "growth_target": {
     "target_percent": 10,
     "target_evidence_total": 1221,
-    "remaining_to_target": 815,
+    "remaining_to_target": 755,
     "status": "below_target"
   },
   "verification_plan": {
     "planned_batches": 6,
-    "planned_operations": 60,
-    "uncovered_gateway_candidates": 11389,
-    "uncovered_adapter_candidates": 210,
+    "planned_operations": 43,
+    "uncovered_gateway_candidates": 11379,
+    "uncovered_adapter_candidates": 160,
     "missing_adapter_hosts": 10,
     "planned_by_kind": [
       {
@@ -61,7 +61,7 @@
       },
       {
         "key": "external_endpoint",
-        "count": 50
+        "count": 33
       }
     ],
     "batches": [
@@ -69,7 +69,7 @@
         "label": "gateway",
         "kind": "data_go_kr_gateway",
         "candidates": 11419,
-        "uncovered_candidates": 11389,
+        "uncovered_candidates": 11379,
         "planned_operations": 10,
         "output": ".datapan/verification/gateway-next.json"
       },
@@ -78,8 +78,8 @@
         "provider": "ekape",
         "kind": "external_endpoint",
         "candidates": 49,
-        "uncovered_candidates": 14,
-        "planned_operations": 10,
+        "uncovered_candidates": 4,
+        "planned_operations": 4,
         "output": ".datapan/verification/ekape-next.json"
       },
       {
@@ -87,8 +87,8 @@
         "provider": "geoje",
         "kind": "external_endpoint",
         "candidates": 41,
-        "uncovered_candidates": 15,
-        "planned_operations": 10,
+        "uncovered_candidates": 5,
+        "planned_operations": 5,
         "output": ".datapan/verification/geoje-next.json"
       },
       {
@@ -96,7 +96,7 @@
         "provider": "jeonju",
         "kind": "external_endpoint",
         "candidates": 80,
-        "uncovered_candidates": 55,
+        "uncovered_candidates": 45,
         "planned_operations": 10,
         "output": ".datapan/verification/jeonju-next.json"
       },
@@ -105,7 +105,7 @@
         "provider": "q-net",
         "kind": "external_endpoint",
         "candidates": 147,
-        "uncovered_candidates": 112,
+        "uncovered_candidates": 102,
         "planned_operations": 10,
         "output": ".datapan/verification/q-net-next.json"
       },
@@ -114,8 +114,8 @@
         "provider": "uiryeong",
         "kind": "external_endpoint",
         "candidates": 40,
-        "uncovered_candidates": 14,
-        "planned_operations": 10,
+        "uncovered_candidates": 4,
+        "planned_operations": 4,
         "output": ".datapan/verification/uiryeong-next.json"
       }
     ]
@@ -130,7 +130,7 @@
     {
       "kind": "runtime_evidence_below_target",
       "severity": "warning",
-      "message": "Runtime evidence coverage is 3.3% against the 10.0% target; 815 additional evidence records are needed before this target is met."
+      "message": "Runtime evidence coverage is 3.8% against the 10.0% target; 755 additional evidence records are needed before this target is met."
     }
   ]
 }

--- a/reports/ekape-verification-summary.json
+++ b/reports/ekape-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/ekape-verification.json",
+  "generated_at": "2026-06-29T09:39:57Z",
+  "source": "reports/ekape-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 5,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 20,
+        "count": 30,
         "status": "skipped"
       },
       {
@@ -28,12 +28,12 @@
     "by_reason": [
       {
         "key": "ekape_missing_required_params",
-        "count": 12,
+        "count": 19,
         "reason": "ekape_missing_required_params"
       },
       {
         "key": "missing_auth",
-        "count": 8,
+        "count": 11,
         "reason": "missing_auth"
       },
       {
@@ -50,21 +50,21 @@
     "by_provider": [
       {
         "key": "ekape",
-        "count": 25,
+        "count": 35,
         "provider": "ekape"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.ekape.or.kr",
-        "count": 25,
+        "count": 35,
         "host": "data.ekape.or.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 25,
+        "count": 35,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/ekape-verification.json
+++ b/reports/ekape-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
+  "generated_at": "2026-06-29T09:39:57Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 25,
+  "limit": 35,
   "truncated": true,
-  "filtered_count": 25,
+  "filtered_count": 35,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 5,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "results": [
@@ -519,6 +519,212 @@
         "sexCd",
         "defectIncludeYn"
       ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 소도체 육질육량 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 경매시황중계정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "auctDate": "",
+        "auctFlag": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "auctFlag"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 돼지도체 경매세부현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": "",
+        "endNo": "",
+        "gradeCd": "",
+        "sexCd": "",
+        "skinYn": "",
+        "startNo": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd",
+        "startNo",
+        "endNo",
+        "skinYn",
+        "sexCd",
+        "gradeCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 돼지도체 등급별경매현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 소도체 등급별경매현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15059251",
+      "title": "축산물품질평가원_계란등급판정정보",
+      "operation": "계란등급판정결과조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "eggshellNo": "",
+        "judgeYmd": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "eggshellNo",
+        "judgeYmd"
+      ]
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "계란 일일가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101",
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "산란계(노계) 가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "periodType": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "periodType"
+      ]
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "산란계(병아리) 가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101"
+      }
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "오리 일일가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101",
+        "type": "json"
+      }
     }
   ]
 }

--- a/reports/error-catalog.json
+++ b/reports/error-catalog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/geoje-verification-summary.json
+++ b/reports/geoje-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/geoje-verification.json",
+  "generated_at": "2026-06-29T09:39:57Z",
+  "source": "reports/geoje-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 26,
+    "total": 36,
     "verified": 2,
     "failed": 0,
-    "skipped": 24,
+    "skipped": 34,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 24,
+        "count": 34,
         "status": "skipped"
       },
       {
@@ -28,33 +28,33 @@
     "by_reason": [
       {
         "key": "geoje_missing_required_params",
-        "count": 16,
+        "count": 22,
         "reason": "geoje_missing_required_params"
       },
       {
         "key": "missing_auth",
-        "count": 8,
+        "count": 12,
         "reason": "missing_auth"
       }
     ],
     "by_provider": [
       {
         "key": "geoje",
-        "count": 26,
+        "count": 36,
         "provider": "geoje"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.geoje.go.kr",
-        "count": 26,
+        "count": 36,
         "host": "data.geoje.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 26,
+        "count": 36,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/geoje-verification.json
+++ b/reports/geoje-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
+  "generated_at": "2026-06-29T09:39:57Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 26,
+  "limit": 36,
   "truncated": true,
-  "filtered_count": 26,
+  "filtered_count": 36,
   "summary": {
-    "total": 26,
+    "total": 36,
     "verified": 2,
     "failed": 0,
-    "skipped": 24,
+    "skipped": 34,
     "unknown": 0
   },
   "results": [
@@ -456,6 +456,180 @@
         "numOfRows": "1",
         "pageNo": "1"
       }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 도로전광판 표출메시지 정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 돌발정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 시간별구간소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endDate": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startDate": ""
+      },
+      "missing_params": [
+        "startDate",
+        "endDate"
+      ]
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 월별구간소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endDate": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startDate": ""
+      },
+      "missing_params": [
+        "startDate",
+        "endDate"
+      ]
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 정체정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065532",
+      "title": "경상남도 거제시 도서정보",
+      "operation": "거제시 도서 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "geojebooksBookKey": ""
+      },
+      "missing_params": [
+        "geojebooksBookKey"
+      ]
+    },
+    {
+      "dataset_id": "3065532",
+      "title": "경상남도 거제시 도서정보",
+      "operation": "거제시 도서정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "geojebooksAuthor": "",
+        "geojebooksPub": "",
+        "geojebooksTitle": ""
+      },
+      "missing_params": [
+        "geojebooksTitle",
+        "geojebooksAuthor",
+        "geojebooksPub"
+      ]
+    },
+    {
+      "dataset_id": "3079223",
+      "title": "경상남도 거제시_숙박업 등록현황",
+      "operation": "숙박 객실 목록 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "lodgeId": ""
+      },
+      "missing_params": [
+        "lodgeId"
+      ]
+    },
+    {
+      "dataset_id": "3079223",
+      "title": "경상남도 거제시_숙박업 등록현황",
+      "operation": "숙박 목록 상세 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "lodgeId": ""
+      },
+      "missing_params": [
+        "lodgeId"
+      ]
     }
   ]
 }

--- a/reports/jeonju-verification-summary.json
+++ b/reports/jeonju-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/jeonju-verification.json",
+  "generated_at": "2026-06-29T09:39:57Z",
+  "source": "reports/jeonju-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 5,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 20,
+        "count": 30,
         "status": "skipped"
       },
       {
@@ -28,7 +28,7 @@
     "by_reason": [
       {
         "key": "jeonju_missing_required_params",
-        "count": 13,
+        "count": 23,
         "reason": "jeonju_missing_required_params"
       },
       {
@@ -50,21 +50,21 @@
     "by_provider": [
       {
         "key": "jeonju",
-        "count": 25,
+        "count": 35,
         "provider": "jeonju"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.jeonju.go.kr",
-        "count": 25,
+        "count": 35,
         "host": "openapi.jeonju.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 25,
+        "count": 35,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/jeonju-verification.json
+++ b/reports/jeonju-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
+  "generated_at": "2026-06-29T09:39:57Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 25,
+  "limit": 35,
   "truncated": true,
-  "filtered_count": 25,
+  "filtered_count": 35,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 5,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "results": [
@@ -480,6 +480,223 @@
       "missing_params": [
         "address",
         "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15057130",
+      "title": "전북특별자치도 전주시_민방위 급수 시설 정보 서비스",
+      "operation": "민방위 급수 시설 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "addr": "",
+        "gu": "완산구",
+        "pacNm": "",
+        "pageSize": "1",
+        "startPage": "1",
+        "waterQua": ""
+      },
+      "missing_params": [
+        "addr",
+        "waterQua"
+      ]
+    },
+    {
+      "dataset_id": "15057163",
+      "title": "전북특별자치도 전주시_보안등 정보 서비스",
+      "operation": "보안등 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "bDong": "",
+        "gu": "완산구",
+        "hDong": "",
+        "kepcoCustom": "",
+        "newAddr": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "hDong",
+        "bDong",
+        "kepcoCustom"
+      ]
+    },
+    {
+      "dataset_id": "15057573",
+      "title": "전북특별자치도 전주시_민방위 대피시설 정보 서비스",
+      "operation": "민방위 대피 시설 정보",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "civilDefenseNm": "",
+        "civilDefenseType": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadAdd": ""
+      },
+      "missing_params": [
+        "civilDefenseNm",
+        "civilDefenseType"
+      ]
+    },
+    {
+      "dataset_id": "15057822",
+      "title": "전북특별자치도 전주시_유기동물보호소 정보 현황",
+      "operation": "유기동물보호소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "yugiName": ""
+      },
+      "missing_params": [
+        "address",
+        "yugiName"
+      ]
+    },
+    {
+      "dataset_id": "15058084",
+      "title": "전북특별자치도 전주시_동물병원 정보 현황",
+      "operation": "동물병원 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15058184",
+      "title": "전북특별자치도 전주시_동물등록제 대행업소 정보 현황",
+      "operation": "동물등록제 대행업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15058560",
+      "title": "전북특별자치도 전주시_동물약국 정보 현황",
+      "operation": "동물약국정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "막걸리집 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "백반집목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "전주비빔밥목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
       ]
     }
   ]

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -1,8 +1,8 @@
 {
-  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
-  "root": "/home/statpan/workspace/opensource/datapan-registry",
+  "manifest": "manifest.json",
+  "root": ".",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-29T09:32:34Z",
+  "generated_at": "2026-06-29T09:40:57Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -243,7 +243,7 @@
       "artifact_kind": "runtime_evidence_growth",
       "artifact_path": "reports/data-go-kr/runtime-evidence-growth.json",
       "expected": 1221,
-      "actual": 406
+      "actual": 466
     }
   ]
 }

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -1,6 +1,6 @@
 {
-  "manifest": "/home/statpan/workspace/opensource/datapan-registry/manifest.json",
-  "root": "/home/statpan/workspace/opensource/datapan-registry",
+  "manifest": "manifest.json",
+  "root": ".",
   "schema_version": "datapan.release-verification.v1",
   "manifest_schema_version": "datapan.release-manifest.v1",
   "artifact_count": 39,
@@ -194,8 +194,8 @@
       "status": "verified",
       "expected_bytes": 7490,
       "actual_bytes": 7490,
-      "expected_sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce",
-      "actual_sha256": "c1f45313905c381cf55ac3947767819a8dbcd224df78734a97ad6ff01788b4ce"
+      "expected_sha256": "45086f8aa0f03809ba8c69ac82714b49046e8041ad1bd259e3256b1cc96bc989",
+      "actual_sha256": "45086f8aa0f03809ba8c69ac82714b49046e8041ad1bd259e3256b1cc96bc989"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -212,116 +212,116 @@
       "status": "verified",
       "expected_bytes": 5588,
       "actual_bytes": 5588,
-      "expected_sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee",
-      "actual_sha256": "a3aa7116dc7194e4f4d80dfb86bd5ad1533945523d43f1fa25665dc3cb4fc7ee"
+      "expected_sha256": "8962a63d396b3d7823dd701608825ef606e208b7eaafab06f08dceafa17b34cb",
+      "actual_sha256": "8962a63d396b3d7823dd701608825ef606e208b7eaafab06f08dceafa17b34cb"
     },
     {
       "path": "reports/catalog-diff.json",
       "kind": "catalog_diff",
       "status": "verified",
-      "expected_bytes": 505,
-      "actual_bytes": 505,
-      "expected_sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94",
-      "actual_sha256": "f54ecaf2a5bac4b5b278ec852bf7ddbea8ceea26b28b5ebdb140a656faeefd94"
+      "expected_bytes": 390,
+      "actual_bytes": 390,
+      "expected_sha256": "b0f02b1743dfd5f71bf5eb8c70e7a0b23c591d2a59472a37fe9413e66792b48a",
+      "actual_sha256": "b0f02b1743dfd5f71bf5eb8c70e7a0b23c591d2a59472a37fe9413e66792b48a"
     },
     {
       "path": "reports/catalog-audit.json",
       "kind": "catalog_audit",
       "status": "verified",
-      "expected_bytes": 15985,
-      "actual_bytes": 15985,
-      "expected_sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6",
-      "actual_sha256": "ddfe4420b326bf86b9b10f7ca891797178804437b1a4725836cd353a01d9f2b6"
+      "expected_bytes": 15935,
+      "actual_bytes": 15935,
+      "expected_sha256": "cd1e637e3798b50e9ef7e834a50dbc35f55a8605479e9f3db7ca82669be57289",
+      "actual_sha256": "cd1e637e3798b50e9ef7e834a50dbc35f55a8605479e9f3db7ca82669be57289"
     },
     {
       "path": "reports/error-catalog.json",
       "kind": "error_catalog",
       "status": "verified",
-      "expected_bytes": 3305406,
-      "actual_bytes": 3305406,
-      "expected_sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57",
-      "actual_sha256": "6c94dcae01d375ac1c37ab046e546aa239c7f124ba82c7e9e79c15de19368f57"
+      "expected_bytes": 3305356,
+      "actual_bytes": 3305356,
+      "expected_sha256": "1bbbb3321293d0a1fcdf1645872dfe7fa538512f45ac2bed28f90588d2df3be3",
+      "actual_sha256": "1bbbb3321293d0a1fcdf1645872dfe7fa538512f45ac2bed28f90588d2df3be3"
     },
     {
       "path": "reports/dependencies.json",
       "kind": "dependencies",
       "status": "verified",
-      "expected_bytes": 11399477,
-      "actual_bytes": 11399477,
-      "expected_sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1",
-      "actual_sha256": "691bf53d46c4c2afefe63fe93d6f6a02951cc4205df29856bf3b88f1b40e25f1"
+      "expected_bytes": 11399427,
+      "actual_bytes": 11399427,
+      "expected_sha256": "509550c94d1f48a1b7e7ec951433567006896eda7f7a39872aeca3d67f35c38f",
+      "actual_sha256": "509550c94d1f48a1b7e7ec951433567006896eda7f7a39872aeca3d67f35c38f"
     },
     {
       "path": "reports/adapter-targets.json",
       "kind": "adapter_targets",
       "status": "verified",
-      "expected_bytes": 15197,
-      "actual_bytes": 15197,
-      "expected_sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5",
-      "actual_sha256": "264c33913c490339bf462ea9dacfe1ed61d2335c01dbb1a49af09e06d42405e5"
+      "expected_bytes": 15147,
+      "actual_bytes": 15147,
+      "expected_sha256": "70118eaa83492804e77772028fe72632dffb846a837f299574c43cfa09624bd2",
+      "actual_sha256": "70118eaa83492804e77772028fe72632dffb846a837f299574c43cfa09624bd2"
     },
     {
       "path": "reports/route-disposition.json",
       "kind": "route_disposition",
       "status": "verified",
-      "expected_bytes": 22374,
-      "actual_bytes": 22374,
-      "expected_sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce",
-      "actual_sha256": "e58e576772cba59eef43238643f84758d3c68d145fc490571cf06629302bfdce"
+      "expected_bytes": 22274,
+      "actual_bytes": 22274,
+      "expected_sha256": "40bfc228268a53461679f23f56055e81a9490120b719b63f7b6a8268e053aea2",
+      "actual_sha256": "40bfc228268a53461679f23f56055e81a9490120b719b63f7b6a8268e053aea2"
     },
     {
       "path": "reports/provider-backlog.json",
       "kind": "provider_backlog",
       "status": "verified",
-      "expected_bytes": 53713,
-      "actual_bytes": 53713,
-      "expected_sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3",
-      "actual_sha256": "fb9f82c9d8129480080de4cb21b6ef63d4e43c8d46e8ee9937dd5c53ca53d5e3"
+      "expected_bytes": 53663,
+      "actual_bytes": 53663,
+      "expected_sha256": "d46a9cb17986e889616f572264eb2be6f86c692bc8c75a77834cc18bc4c95475",
+      "actual_sha256": "d46a9cb17986e889616f572264eb2be6f86c692bc8c75a77834cc18bc4c95475"
     },
     {
       "path": "reports/coverage.json",
       "kind": "coverage",
       "status": "verified",
-      "expected_bytes": 17021,
-      "actual_bytes": 17021,
-      "expected_sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1",
-      "actual_sha256": "8deb604b7a84045eb038c7f90ce569cf6dcbaa520a3b67141fe9f800bc2d8da1"
+      "expected_bytes": 16521,
+      "actual_bytes": 16521,
+      "expected_sha256": "bb261bd178621678d933b182497fcc15fb67722eca507b17fb4cc902fd879013",
+      "actual_sha256": "bb261bd178621678d933b182497fcc15fb67722eca507b17fb4cc902fd879013"
     },
     {
       "path": "reports/verification-plan.json",
       "kind": "verification_plan",
       "status": "verified",
-      "expected_bytes": 7675,
-      "actual_bytes": 7675,
-      "expected_sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333",
-      "actual_sha256": "0113843496963c92ed9fc4c9fe10ca69681dcc3c4f4495a511f47ada1b5df333"
+      "expected_bytes": 6869,
+      "actual_bytes": 6869,
+      "expected_sha256": "af57abd2c471be36b1896cd366d76f2b774e227510d621b3ac999eaf181103c2",
+      "actual_sha256": "af57abd2c471be36b1896cd366d76f2b774e227510d621b3ac999eaf181103c2"
     },
     {
       "path": "reports/data-go-kr/runtime-evidence-growth.json",
       "kind": "runtime_evidence_growth",
       "status": "verified",
-      "expected_bytes": 3724,
-      "actual_bytes": 3724,
-      "expected_sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5",
-      "actual_sha256": "4da1f552a0a0a34d11027dd783fcd65570a892c1bf0b56fc52d0a4f91aa21cb5"
+      "expected_bytes": 3718,
+      "actual_bytes": 3718,
+      "expected_sha256": "b6c3b2e0ec65e172c0c4ea6b11d9ed5924ae89ba7ef2ae6813eb988d48930a02",
+      "actual_sha256": "b6c3b2e0ec65e172c0c4ea6b11d9ed5924ae89ba7ef2ae6813eb988d48930a02"
     },
     {
       "path": "reports/latest-verification.json",
       "kind": "verification",
       "status": "verified",
-      "expected_bytes": 266977,
-      "actual_bytes": 266977,
-      "expected_sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76",
-      "actual_sha256": "8798018ace8e642439a3435b989da9affeb4695d400040134a9eeb39f2195b76"
+      "expected_bytes": 301152,
+      "actual_bytes": 301152,
+      "expected_sha256": "4915542d6093dbe67aab88c8c5346d22fbe1e24260bfa9fca1d29276b211a4be",
+      "actual_sha256": "4915542d6093dbe67aab88c8c5346d22fbe1e24260bfa9fca1d29276b211a4be"
     },
     {
       "path": "reports/latest-verification-summary.json",
       "kind": "verification_summary",
       "status": "verified",
-      "expected_bytes": 13671,
-      "actual_bytes": 13671,
-      "expected_sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad",
-      "actual_sha256": "48540f1f4bcb8f8c498eb41c36f97591b2482d294a9e6feace456c82912da8ad"
+      "expected_bytes": 13622,
+      "actual_bytes": 13622,
+      "expected_sha256": "b2102738c485f116ff9792338a82f8153eb9eda56f072e975712a77eaae5e317",
+      "actual_sha256": "b2102738c485f116ff9792338a82f8153eb9eda56f072e975712a77eaae5e317"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -336,28 +336,28 @@
       "path": "reports/unadapted-external-probe-summary.json",
       "kind": "unadapted_external_probe_summary",
       "status": "verified",
-      "expected_bytes": 2453,
-      "actual_bytes": 2453,
-      "expected_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312",
-      "actual_sha256": "166d67f4113ea54941d3da2933248b819328d1cfa3cc1fac17d82dc3f1908312"
+      "expected_bytes": 2403,
+      "actual_bytes": 2403,
+      "expected_sha256": "d37b6d23859ca2bc62b8505c1a10026725a71bf95d7d37993aaf126590791901",
+      "actual_sha256": "d37b6d23859ca2bc62b8505c1a10026725a71bf95d7d37993aaf126590791901"
     },
     {
       "path": "provenance/data-go-kr.md",
       "kind": "provenance",
       "status": "verified",
-      "expected_bytes": 4463,
-      "actual_bytes": 4463,
-      "expected_sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069",
-      "actual_sha256": "bd2736440aaf096aa98e6fa7bb3aa544f72bfe7f2c9cd964eb643bf4684d9069"
+      "expected_bytes": 2460,
+      "actual_bytes": 2460,
+      "expected_sha256": "87e432155600e9492e48e0ed4f7be900163134af95ee008d675d80c3f2719d16",
+      "actual_sha256": "87e432155600e9492e48e0ed4f7be900163134af95ee008d675d80c3f2719d16"
     },
     {
       "path": "RELEASE_NOTES.md",
       "kind": "release_notes",
       "status": "verified",
-      "expected_bytes": 3347,
-      "actual_bytes": 3347,
-      "expected_sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d",
-      "actual_sha256": "3245f39beb69ef0276ca2cde21c75485f447821cec26046a12dd47aa1807f92d"
+      "expected_bytes": 3227,
+      "actual_bytes": 3227,
+      "expected_sha256": "22ddadb9309d157b22b12a62098655c5e62b35f0fed69fb11dc47d7e3ee796fa",
+      "actual_sha256": "22ddadb9309d157b22b12a62098655c5e62b35f0fed69fb11dc47d7e3ee796fa"
     }
   ]
 }

--- a/reports/latest-verification-summary.json
+++ b/reports/latest-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:31:39Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
+  "generated_at": "2026-06-29T09:40:10Z",
+  "source": "./reports/latest-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "summary": {
-    "total": 406,
+    "total": 466,
     "verified": 22,
     "failed": 87,
-    "skipped": 297,
+    "skipped": 357,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 297,
+        "count": 357,
         "status": "skipped"
       },
       {
@@ -33,7 +33,7 @@
     "by_reason": [
       {
         "key": "missing_auth",
-        "count": 53,
+        "count": 72,
         "reason": "missing_auth"
       },
       {
@@ -43,13 +43,23 @@
       },
       {
         "key": "missing_required_params",
-        "count": 22,
+        "count": 31,
         "reason": "missing_required_params"
       },
       {
         "key": "ekape_missing_required_params",
-        "count": 19,
+        "count": 26,
         "reason": "ekape_missing_required_params"
+      },
+      {
+        "key": "jeonju_missing_required_params",
+        "count": 23,
+        "reason": "jeonju_missing_required_params"
+      },
+      {
+        "key": "geoje_missing_required_params",
+        "count": 22,
+        "reason": "geoje_missing_required_params"
       },
       {
         "key": "tour_service_root_missing_operation_path",
@@ -62,19 +72,14 @@
         "reason": "epost_wadl_metadata_only"
       },
       {
-        "key": "geoje_missing_required_params",
+        "key": "uiryeong_missing_required_params",
         "count": 16,
-        "reason": "geoje_missing_required_params"
+        "reason": "uiryeong_missing_required_params"
       },
       {
         "key": "ulsan_missing_required_params",
         "count": 16,
         "reason": "ulsan_missing_required_params"
-      },
-      {
-        "key": "jeonju_missing_required_params",
-        "count": 13,
-        "reason": "jeonju_missing_required_params"
       },
       {
         "key": "oneclick_connection_refused",
@@ -120,11 +125,6 @@
         "key": "tour_service_key_not_registered",
         "count": 7,
         "reason": "tour_service_key_not_registered"
-      },
-      {
-        "key": "uiryeong_missing_required_params",
-        "count": 7,
-        "reason": "uiryeong_missing_required_params"
       },
       {
         "key": "itfind_missing_required_params",
@@ -285,18 +285,33 @@
     "by_provider": [
       {
         "key": "ekape",
-        "count": 35,
+        "count": 45,
         "provider": "ekape"
       },
       {
         "key": "q-net",
-        "count": 35,
+        "count": 45,
         "provider": "q-net"
       },
       {
         "key": "data.go.kr",
-        "count": 30,
+        "count": 40,
         "provider": "data.go.kr"
+      },
+      {
+        "key": "geoje",
+        "count": 36,
+        "provider": "geoje"
+      },
+      {
+        "key": "uiryeong",
+        "count": 36,
+        "provider": "uiryeong"
+      },
+      {
+        "key": "jeonju",
+        "count": 35,
+        "provider": "jeonju"
       },
       {
         "key": "oneclick-law",
@@ -309,24 +324,9 @@
         "provider": "epost"
       },
       {
-        "key": "geoje",
-        "count": 26,
-        "provider": "geoje"
-      },
-      {
         "key": "tour",
         "count": 26,
         "provider": "tour"
-      },
-      {
-        "key": "uiryeong",
-        "count": 26,
-        "provider": "uiryeong"
-      },
-      {
-        "key": "jeonju",
-        "count": 25,
-        "provider": "jeonju"
       },
       {
         "key": "sisul",
@@ -422,38 +422,38 @@
     "by_endpoint_host": [
       {
         "key": "data.ekape.or.kr",
-        "count": 35,
+        "count": 45,
         "host": "data.ekape.or.kr"
       },
       {
         "key": "apis.data.go.kr",
-        "count": 30,
+        "count": 40,
         "host": "apis.data.go.kr"
+      },
+      {
+        "key": "openapi.q-net.or.kr",
+        "count": 37,
+        "host": "openapi.q-net.or.kr"
+      },
+      {
+        "key": "data.geoje.go.kr",
+        "count": 36,
+        "host": "data.geoje.go.kr"
+      },
+      {
+        "key": "data.uiryeong.go.kr",
+        "count": 36,
+        "host": "data.uiryeong.go.kr"
+      },
+      {
+        "key": "openapi.jeonju.go.kr",
+        "count": 35,
+        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "oneclick.law.go.kr:80",
         "count": 27,
         "host": "oneclick.law.go.kr:80"
-      },
-      {
-        "key": "openapi.q-net.or.kr",
-        "count": 27,
-        "host": "openapi.q-net.or.kr"
-      },
-      {
-        "key": "data.geoje.go.kr",
-        "count": 26,
-        "host": "data.geoje.go.kr"
-      },
-      {
-        "key": "data.uiryeong.go.kr",
-        "count": 26,
-        "host": "data.uiryeong.go.kr"
-      },
-      {
-        "key": "openapi.jeonju.go.kr",
-        "count": 25,
-        "host": "openapi.jeonju.go.kr"
       },
       {
         "key": "openapi.epost.go.kr:80",
@@ -574,12 +574,12 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 357,
+        "count": 407,
         "kind": "external_endpoint"
       },
       {
         "key": "data_go_kr_gateway",
-        "count": 30,
+        "count": 40,
         "kind": "data_go_kr_gateway"
       },
       {

--- a/reports/latest-verification.json
+++ b/reports/latest-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:39Z",
+  "generated_at": "2026-06-29T09:40:10Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 413,
+  "limit": 473,
   "truncated": true,
-  "filtered_count": 406,
+  "filtered_count": 466,
   "summary": {
-    "total": 406,
+    "total": 466,
     "verified": 22,
     "failed": 87,
-    "skipped": 297,
+    "skipped": 357,
     "unknown": 0
   },
   "results": [
@@ -8357,6 +8357,1167 @@
       },
       "missing_params": [
         "uiryeongculturalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15000480",
+      "title": "국립중앙의료원_전국 명절 비상 진료기관 정보 조회 서비스",
+      "operation": "명절 진료 가능한 기관 위치정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_auth"
+    },
+    {
+      "dataset_id": "15000504",
+      "title": "외교부_여행금지제도",
+      "operation": "여행금지제도 단일조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "id": ""
+      },
+      "missing_params": [
+        "id"
+      ]
+    },
+    {
+      "dataset_id": "15000504",
+      "title": "외교부_여행금지제도",
+      "operation": "여행금지제도 목록조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "countryEnName": "",
+        "countryName": "",
+        "isoCode1": "",
+        "isoCode10": "",
+        "isoCode2": "",
+        "isoCode3": "",
+        "isoCode4": "",
+        "isoCode5": "",
+        "isoCode6": "",
+        "isoCode7": "",
+        "isoCode8": "",
+        "isoCode9": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "countryName",
+        "countryEnName",
+        "isoCode1",
+        "isoCode2",
+        "isoCode3",
+        "isoCode4",
+        "isoCode5",
+        "isoCode6",
+        "isoCode7",
+        "isoCode8",
+        "isoCode9",
+        "isoCode10"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "외상센터 기본정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "HPID": "",
+        "QN": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "HPID",
+        "QN"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "외상센터 목록정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "ORD": "",
+        "Q0": "",
+        "Q1": "",
+        "QD": "",
+        "QN": "",
+        "QT": "",
+        "QZ": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "Q0",
+        "Q1",
+        "QT",
+        "QZ",
+        "QD",
+        "QN",
+        "ORD"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "외상센터 위치정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "WGS84_LAT": "",
+        "WGS84_LON": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "WGS84_LON",
+        "WGS84_LAT"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "응급실 및 중증질환 메시지 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "HPID": "",
+        "Q0": "",
+        "Q1": "",
+        "QN": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "HPID",
+        "QN",
+        "Q0",
+        "Q1"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "응급실 실시간 가용병상정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "STAGE1": "",
+        "STAGE2": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "STAGE1",
+        "STAGE2"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "응급의료기관 기본정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "HPID": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "HPID"
+      ]
+    },
+    {
+      "dataset_id": "15000563",
+      "title": "국립중앙의료원_전국 응급의료기관 정보 조회 서비스",
+      "operation": "응급의료기관 목록정보 조회",
+      "provider": "data.go.kr",
+      "endpoint_host": "apis.data.go.kr",
+      "dependency_class": "data_go_kr_gateway",
+      "status": "skipped",
+      "reason": "missing_required_params",
+      "params": {
+        "ORD": "",
+        "Q0": "",
+        "Q1": "",
+        "QD": "",
+        "QN": "",
+        "QT": "",
+        "QZ": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "Q0",
+        "Q1",
+        "QT",
+        "QZ",
+        "QD",
+        "QN",
+        "ORD"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 소도체 육질육량 등급별 경락가격정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "breedCd": "",
+        "defectIncludeYn": "",
+        "endYmd": "20240101",
+        "qgradeYn": "",
+        "sexCd": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "breedCd",
+        "sexCd",
+        "qgradeYn",
+        "defectIncludeYn"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 경매시황중계정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "auctDate": "",
+        "auctFlag": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "auctFlag"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 돼지도체 경매세부현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": "",
+        "endNo": "",
+        "gradeCd": "",
+        "sexCd": "",
+        "skinYn": "",
+        "startNo": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd",
+        "startNo",
+        "endNo",
+        "skinYn",
+        "sexCd",
+        "gradeCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 돼지도체 등급별경매현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15058822",
+      "title": "축산물품질평가원_축산물등급판정정보",
+      "operation": "축산물 실시간 소도체 등급별경매현황정보",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "abattCd": "",
+        "auctDate": ""
+      },
+      "missing_params": [
+        "auctDate",
+        "abattCd"
+      ]
+    },
+    {
+      "dataset_id": "15059251",
+      "title": "축산물품질평가원_계란등급판정정보",
+      "operation": "계란등급판정결과조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "eggshellNo": "",
+        "judgeYmd": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "eggshellNo",
+        "judgeYmd"
+      ]
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "계란 일일가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101",
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "산란계(노계) 가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "ekape_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "periodType": "",
+        "startYmd": "20240101"
+      },
+      "missing_params": [
+        "periodType"
+      ]
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "산란계(병아리) 가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101"
+      }
+    },
+    {
+      "dataset_id": "15073985",
+      "title": "축산물품질평가원_가금산물 일일거래가격정보",
+      "operation": "오리 일일가격조회",
+      "provider": "ekape",
+      "endpoint_host": "data.ekape.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endYmd": "20240101",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startYmd": "20240101",
+        "type": "json"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 도로전광판 표출메시지 정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 돌발정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 시간별구간소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endDate": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startDate": ""
+      },
+      "missing_params": [
+        "startDate",
+        "endDate"
+      ]
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 월별구간소통정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "endDate": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "startDate": ""
+      },
+      "missing_params": [
+        "startDate",
+        "endDate"
+      ]
+    },
+    {
+      "dataset_id": "3065177",
+      "title": "경상남도 거제시_교통 정보",
+      "operation": "거제시 차량 정체정보 조회",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "3065532",
+      "title": "경상남도 거제시 도서정보",
+      "operation": "거제시 도서 상세정보",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "geojebooksBookKey": ""
+      },
+      "missing_params": [
+        "geojebooksBookKey"
+      ]
+    },
+    {
+      "dataset_id": "3065532",
+      "title": "경상남도 거제시 도서정보",
+      "operation": "거제시 도서정보 목록",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "geojebooksAuthor": "",
+        "geojebooksPub": "",
+        "geojebooksTitle": ""
+      },
+      "missing_params": [
+        "geojebooksTitle",
+        "geojebooksAuthor",
+        "geojebooksPub"
+      ]
+    },
+    {
+      "dataset_id": "3079223",
+      "title": "경상남도 거제시_숙박업 등록현황",
+      "operation": "숙박 객실 목록 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "lodgeId": ""
+      },
+      "missing_params": [
+        "lodgeId"
+      ]
+    },
+    {
+      "dataset_id": "3079223",
+      "title": "경상남도 거제시_숙박업 등록현황",
+      "operation": "숙박 목록 상세 정보 서비스",
+      "provider": "geoje",
+      "endpoint_host": "data.geoje.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "geoje_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "lodgeId": ""
+      },
+      "missing_params": [
+        "lodgeId"
+      ]
+    },
+    {
+      "dataset_id": "15057130",
+      "title": "전북특별자치도 전주시_민방위 급수 시설 정보 서비스",
+      "operation": "민방위 급수 시설 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "addr": "",
+        "gu": "완산구",
+        "pacNm": "",
+        "pageSize": "1",
+        "startPage": "1",
+        "waterQua": ""
+      },
+      "missing_params": [
+        "addr",
+        "waterQua"
+      ]
+    },
+    {
+      "dataset_id": "15057163",
+      "title": "전북특별자치도 전주시_보안등 정보 서비스",
+      "operation": "보안등 현황",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "bDong": "",
+        "gu": "완산구",
+        "hDong": "",
+        "kepcoCustom": "",
+        "newAddr": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "hDong",
+        "bDong",
+        "kepcoCustom"
+      ]
+    },
+    {
+      "dataset_id": "15057573",
+      "title": "전북특별자치도 전주시_민방위 대피시설 정보 서비스",
+      "operation": "민방위 대피 시설 정보",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "civilDefenseNm": "",
+        "civilDefenseType": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "roadAdd": ""
+      },
+      "missing_params": [
+        "civilDefenseNm",
+        "civilDefenseType"
+      ]
+    },
+    {
+      "dataset_id": "15057822",
+      "title": "전북특별자치도 전주시_유기동물보호소 정보 현황",
+      "operation": "유기동물보호소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "numOfRows": "1",
+        "pageNo": "1",
+        "yugiName": ""
+      },
+      "missing_params": [
+        "address",
+        "yugiName"
+      ]
+    },
+    {
+      "dataset_id": "15058084",
+      "title": "전북특별자치도 전주시_동물병원 정보 현황",
+      "operation": "동물병원 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15058184",
+      "title": "전북특별자치도 전주시_동물등록제 대행업소 정보 현황",
+      "operation": "동물등록제 대행업소 정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "15058560",
+      "title": "전북특별자치도 전주시_동물약국 정보 현황",
+      "operation": "동물약국정보 조회",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "address": "",
+        "dongName": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "address",
+        "dongName"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "막걸리집 목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "백반집목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
+      ]
+    },
+    {
+      "dataset_id": "3036596",
+      "title": "전북특별자치도 전주시_전주음식",
+      "operation": "전주비빔밥목록",
+      "provider": "jeonju",
+      "endpoint_host": "openapi.jeonju.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "jeonju_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "foodUid": "",
+        "keyword": "",
+        "pageSize": "1",
+        "startPage": "1"
+      },
+      "missing_params": [
+        "keyword",
+        "foodUid"
+      ]
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "학력별 자격취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037522",
+      "title": "한국산업인력공단_국가자격 응시자격 관련 현황 데이터",
+      "operation": "실기합격자 응시자격현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037522",
+      "title": "한국산업인력공단_국가자격 응시자격 관련 현황 데이터",
+      "operation": "응시자격조항별 접수및합격현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "기술(서비스)분야 등급별 종목현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 응시자격 검정현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 접수상위 종목현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 취득 상위종목 현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "타등급 자격취득 현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037524",
+      "title": "한국산업인력공단_국가자격 통계연보 정보",
+      "operation": "국가기술자격소지자현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037524",
+      "title": "한국산업인력공단_국가자격 통계연보 정보",
+      "operation": "연도별자격취득현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "uiryeongculturalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongculturalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15058926",
+      "title": "경상남도 의령군_세차장",
+      "operation": "세차장 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15063439",
+      "title": "경상남도 의령군_가로수길정보",
+      "operation": "가로수길 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "sttree_stret_nm": ""
+      },
+      "missing_params": [
+        "sttree_stret_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063440",
+      "title": "경상남도 의령군_무료와이파이",
+      "operation": "무료와이파이 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "instl_place_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "instl_place_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063444",
+      "title": "경상남도 의령군_민방위대피시설",
+      "operation": "민방위대피시설 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "clns_shunt_fclty_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "clns_shunt_fclty_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063446",
+      "title": "경상남도 의령군_보안등정보",
+      "operation": "보안등정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "chrstn_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "chrstn_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063448",
+      "title": "경상남도 의령군_소규모공공시설위험지정정보",
+      "operation": "소규모공공시설위험지정정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "fclty_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "fclty_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063451",
+      "title": "경상남도 의령군_자동심장충격기",
+      "operation": "자동심장충격기 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "instl_instt_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "instl_instt_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063452",
+      "title": "경상남도 의령군_전기차충전소",
+      "operation": "전기차충전소 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "chrstn_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "chrstn_nm"
+      ]
+    },
+    {
+      "dataset_id": "3034299",
+      "title": "경상남도 의령군_행정기관정보",
+      "operation": "행정기관 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "deptNm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "deptNm"
       ]
     }
   ]

--- a/reports/provider-backlog.json
+++ b/reports/provider-backlog.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "limit": 0,
   "truncated": false,
   "filtered_count": 179,

--- a/reports/qnet-verification-summary.json
+++ b/reports/qnet-verification-summary.json
@@ -1,29 +1,29 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/qnet-verification.json",
+  "generated_at": "2026-06-29T09:39:57Z",
+  "source": "reports/qnet-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 0,
-    "skipped": 25,
+    "skipped": 35,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 25,
+        "count": 35,
         "status": "skipped"
       }
     ],
     "by_reason": [
       {
         "key": "missing_auth",
-        "count": 9,
+        "count": 19,
         "reason": "missing_auth"
       },
       {
@@ -45,14 +45,14 @@
     "by_provider": [
       {
         "key": "q-net",
-        "count": 25,
+        "count": 35,
         "provider": "q-net"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "openapi.q-net.or.kr",
-        "count": 17,
+        "count": 27,
         "host": "openapi.q-net.or.kr"
       },
       {
@@ -64,7 +64,7 @@
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 25,
+        "count": 35,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/qnet-verification.json
+++ b/reports/qnet-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:15Z",
+  "generated_at": "2026-06-29T09:39:57Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 25,
+  "limit": 35,
   "truncated": true,
-  "filtered_count": 25,
+  "filtered_count": 35,
   "summary": {
-    "total": 25,
+    "total": 35,
     "verified": 0,
     "failed": 0,
-    "skipped": 25,
+    "skipped": 35,
     "unknown": 0
   },
   "results": [
@@ -370,6 +370,158 @@
       "status": "skipped",
       "reason": "missing_auth",
       "verified_at": "2026-06-29T09:30:13Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037521",
+      "title": "한국산업인력공단_국가자격 취득자 관련 통계 정보",
+      "operation": "학력별 자격취득자 현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037522",
+      "title": "한국산업인력공단_국가자격 응시자격 관련 현황 데이터",
+      "operation": "실기합격자 응시자격현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037522",
+      "title": "한국산업인력공단_국가자격 응시자격 관련 현황 데이터",
+      "operation": "응시자격조항별 접수및합격현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "기술(서비스)분야 등급별 종목현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 응시자격 검정현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 접수상위 종목현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "등급별 취득 상위종목 현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023",
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15037523",
+      "title": "한국산업인력공단_국가자격 등급별 현황 정보",
+      "operation": "타등급 자격취득 현황 정보",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037524",
+      "title": "한국산업인력공단_국가자격 통계연보 정보",
+      "operation": "국가기술자격소지자현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "baseYY": "2023"
+      }
+    },
+    {
+      "dataset_id": "15037524",
+      "title": "한국산업인력공단_국가자격 통계연보 정보",
+      "operation": "연도별자격취득현황",
+      "provider": "q-net",
+      "endpoint_host": "openapi.q-net.or.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
       "params": {
         "baseYY": "2023",
         "numOfRows": "1",

--- a/reports/route-disposition.json
+++ b/reports/route-disposition.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
-  "probe": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
+  "registry": "./data/data-go-kr.registry.json",
+  "probe": "./reports/unadapted-external-probe.json",
   "limit": 0,
   "truncated": false,
   "summary": {

--- a/reports/uiryeong-verification-summary.json
+++ b/reports/uiryeong-verification-summary.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-06-29T09:31:16Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/uiryeong-verification.json",
+  "generated_at": "2026-06-29T09:39:58Z",
+  "source": "reports/uiryeong-verification.json",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
   "limit": 20,
   "truncated": false,
   "summary": {
-    "total": 26,
+    "total": 36,
     "verified": 0,
     "failed": 6,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "groups": {
     "by_status": [
       {
         "key": "skipped",
-        "count": 20,
+        "count": 30,
         "status": "skipped"
       },
       {
@@ -27,14 +27,14 @@
     ],
     "by_reason": [
       {
-        "key": "missing_auth",
-        "count": 13,
-        "reason": "missing_auth"
+        "key": "uiryeong_missing_required_params",
+        "count": 16,
+        "reason": "uiryeong_missing_required_params"
       },
       {
-        "key": "uiryeong_missing_required_params",
-        "count": 7,
-        "reason": "uiryeong_missing_required_params"
+        "key": "missing_auth",
+        "count": 14,
+        "reason": "missing_auth"
       },
       {
         "key": "uiryeong_service_key_not_registered",
@@ -45,21 +45,21 @@
     "by_provider": [
       {
         "key": "uiryeong",
-        "count": 26,
+        "count": 36,
         "provider": "uiryeong"
       }
     ],
     "by_endpoint_host": [
       {
         "key": "data.uiryeong.go.kr",
-        "count": 26,
+        "count": 36,
         "host": "data.uiryeong.go.kr"
       }
     ],
     "by_kind": [
       {
         "key": "external_endpoint",
-        "count": 26,
+        "count": 36,
         "kind": "external_endpoint"
       }
     ]

--- a/reports/uiryeong-verification.json
+++ b/reports/uiryeong-verification.json
@@ -1,15 +1,15 @@
 {
-  "generated_at": "2026-06-29T09:31:16Z",
+  "generated_at": "2026-06-29T09:39:58Z",
   "provider": "data.go.kr",
   "registry": "/home/statpan/workspace/opensource/datapan-registry/.datapan/data-go-kr.registry.json",
-  "limit": 26,
+  "limit": 36,
   "truncated": true,
-  "filtered_count": 26,
+  "filtered_count": 36,
   "summary": {
-    "total": 26,
+    "total": 36,
     "verified": 0,
     "failed": 6,
-    "skipped": 20,
+    "skipped": 30,
     "unknown": 0
   },
   "results": [
@@ -473,6 +473,190 @@
       },
       "missing_params": [
         "uiryeongculturalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15058579",
+      "title": "경상남도 의령군 문화재",
+      "operation": "문화재 상세정보",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "uiryeongculturalEntId": ""
+      },
+      "missing_params": [
+        "uiryeongculturalEntId"
+      ]
+    },
+    {
+      "dataset_id": "15058926",
+      "title": "경상남도 의령군_세차장",
+      "operation": "세차장 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "missing_auth",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1"
+      }
+    },
+    {
+      "dataset_id": "15063439",
+      "title": "경상남도 의령군_가로수길정보",
+      "operation": "가로수길 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "numOfRows": "1",
+        "pageNo": "1",
+        "sttree_stret_nm": ""
+      },
+      "missing_params": [
+        "sttree_stret_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063440",
+      "title": "경상남도 의령군_무료와이파이",
+      "operation": "무료와이파이 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "instl_place_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "instl_place_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063444",
+      "title": "경상남도 의령군_민방위대피시설",
+      "operation": "민방위대피시설 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "clns_shunt_fclty_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "clns_shunt_fclty_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063446",
+      "title": "경상남도 의령군_보안등정보",
+      "operation": "보안등정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "chrstn_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "chrstn_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063448",
+      "title": "경상남도 의령군_소규모공공시설위험지정정보",
+      "operation": "소규모공공시설위험지정정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "fclty_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "fclty_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063451",
+      "title": "경상남도 의령군_자동심장충격기",
+      "operation": "자동심장충격기 정보 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "instl_instt_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "instl_instt_nm"
+      ]
+    },
+    {
+      "dataset_id": "15063452",
+      "title": "경상남도 의령군_전기차충전소",
+      "operation": "전기차충전소 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "chrstn_nm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "chrstn_nm"
+      ]
+    },
+    {
+      "dataset_id": "3034299",
+      "title": "경상남도 의령군_행정기관정보",
+      "operation": "행정기관 목록",
+      "provider": "uiryeong",
+      "endpoint_host": "data.uiryeong.go.kr",
+      "dependency_class": "external_endpoint",
+      "status": "skipped",
+      "reason": "uiryeong_missing_required_params",
+      "verified_at": "2026-06-29T09:39:29Z",
+      "params": {
+        "deptNm": "",
+        "numOfRows": "1",
+        "pageNo": "1"
+      },
+      "missing_params": [
+        "deptNm"
       ]
     }
   ]

--- a/reports/unadapted-external-probe-summary.json
+++ b/reports/unadapted-external-probe-summary.json
@@ -1,6 +1,6 @@
 {
   "generated_at": "2026-06-25T05:21:35Z",
-  "source": "/home/statpan/workspace/opensource/datapan-registry/reports/unadapted-external-probe.json",
+  "source": "./reports/unadapted-external-probe.json",
   "provider": "data.go.kr",
   "registry": "C:\\workspace\\datapan-registry\\data\\data-go-kr.registry.json",
   "limit": 0,

--- a/reports/verification-plan.json
+++ b/reports/verification-plan.json
@@ -1,28 +1,28 @@
 {
-  "generated_at": "2026-06-29T09:32:26Z",
+  "generated_at": "2026-06-29T09:40:50Z",
   "provider": "data.go.kr",
-  "registry": "/home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json",
+  "registry": "./data/data-go-kr.registry.json",
   "source": "release",
-  "verification": "/home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json",
+  "verification": "./reports/latest-verification.json",
   "batch_size": 10,
   "timeout": "10s",
   "summary": {
     "operations": 12205,
-    "evidence_total": 406,
-    "uncovered_gateway_candidates": 11389,
-    "uncovered_adapter_candidates": 210,
+    "evidence_total": 466,
+    "uncovered_gateway_candidates": 11379,
+    "uncovered_adapter_candidates": 160,
     "missing_adapter_hosts": 10,
     "planned_batches": 6,
-    "planned_operations": 60
+    "planned_operations": 43
   },
   "batches": [
     {
       "label": "gateway",
       "kind": "data_go_kr_gateway",
       "candidates": 11419,
-      "uncovered_candidates": 11389,
+      "uncovered_candidates": 11379,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --kind data_go_kr_gateway --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/gateway-next.json --json",
       "output": ".datapan/verification/gateway-next.json"
     },
     {
@@ -30,9 +30,9 @@
       "provider": "ekape",
       "kind": "external_endpoint",
       "candidates": 49,
-      "uncovered_candidates": 14,
-      "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
+      "uncovered_candidates": 4,
+      "planned_operations": 4,
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --provider ekape --kind external_endpoint --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/ekape-next.json --json",
       "output": ".datapan/verification/ekape-next.json"
     },
     {
@@ -40,9 +40,9 @@
       "provider": "geoje",
       "kind": "external_endpoint",
       "candidates": 41,
-      "uncovered_candidates": 15,
-      "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
+      "uncovered_candidates": 5,
+      "planned_operations": 5,
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --provider geoje --kind external_endpoint --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/geoje-next.json --json",
       "output": ".datapan/verification/geoje-next.json"
     },
     {
@@ -50,9 +50,9 @@
       "provider": "jeonju",
       "kind": "external_endpoint",
       "candidates": 80,
-      "uncovered_candidates": 55,
+      "uncovered_candidates": 45,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --provider jeonju --kind external_endpoint --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/jeonju-next.json --json",
       "output": ".datapan/verification/jeonju-next.json"
     },
     {
@@ -60,9 +60,9 @@
       "provider": "q-net",
       "kind": "external_endpoint",
       "candidates": 147,
-      "uncovered_candidates": 112,
+      "uncovered_candidates": 102,
       "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --provider q-net --kind external_endpoint --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/q-net-next.json --json",
       "output": ".datapan/verification/q-net-next.json"
     },
     {
@@ -70,9 +70,9 @@
       "provider": "uiryeong",
       "kind": "external_endpoint",
       "candidates": 40,
-      "uncovered_candidates": 14,
-      "planned_operations": 10,
-      "command": "datapan catalog verify --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
+      "uncovered_candidates": 4,
+      "planned_operations": 4,
+      "command": "datapan catalog verify --registry ./data/data-go-kr.registry.json --provider uiryeong --kind external_endpoint --exclude-input ./reports/latest-verification.json --limit 10 --timeout 10s --output .datapan/verification/uiryeong-next.json --json",
       "output": ".datapan/verification/uiryeong-next.json"
     }
   ],
@@ -219,7 +219,7 @@
   "next": [
     {
       "label": "coverage",
-      "command": "datapan catalog coverage --registry /home/statpan/workspace/opensource/datapan-registry/data/data-go-kr.registry.json --verification /home/statpan/workspace/opensource/datapan-registry/reports/latest-verification.json --json"
+      "command": "datapan catalog coverage --registry ./data/data-go-kr.registry.json --verification ./reports/latest-verification.json --json"
     }
   ]
 }

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-29T09:32:14Z",
+  "generated_at": "2026-06-29T09:40:38Z",
   "datapan_version": "0.1.0-dev",
   "count": 20,
   "schemas": [


### PR DESCRIPTION
Closes #27

## Gap

data.go.kr runtime evidence coverage remains below the documented 10% release target. This PR executes the next registry-generated provider-priority batch after #26 and keeps the remaining readiness warning explicit.

## Changes

- Merge the next excluded-from-latest `gateway`, `ekape`, `geoje`, `jeonju`, `q-net`, and `uiryeong` verification batches.
- Regenerate provider-specific reports/summaries for `ekape`, `geoje`, `jeonju`, `qnet`, and `uiryeong`.
- Regenerate `reports/latest-verification.json`, latest summary, runtime evidence growth, release verification/readiness, release notes, README snapshot, manifest, and schema index.
- Update the data.go.kr mastery plan and registry blueprint so #27 is recorded as continued runtime evidence growth.

## Warning Status

- Active warning remains: `runtime_evidence_growth_target` / `runtime_evidence_below_target`.
- Target: `1,221` evidence records for `10.0%` runtime evidence coverage.
- Actual: `466` evidence records (`3.8%`).
- Remaining gap: `755` additional evidence records.
- This warning is not harmless and is intentionally preserved in readiness output.

## Evidence Boundary

The new 60 records are skipped boundary evidence, not successful callable coverage.

- `gateway`: `10` new skipped records.
- `ekape`: `10` new skipped records; provider report now has `35` total, including `5` older failed records.
- `geoje`: `10` new skipped records; provider report now has `36` total, including `2` older verified records.
- `jeonju`: `10` new skipped records; provider report now has `35` total, including `5` older failed records.
- `q-net`: `10` new skipped records; provider report now has `35` total, all skipped.
- `uiryeong`: `10` new skipped records; provider report now has `36` total, including `6` older failed records.
- Latest evidence has `466` unique records by provider, dataset, operation, host, and dependency class.

## Validation

- `datapan catalog release draft` with materialized data.go.kr registry and latest verification evidence.
- `datapan catalog release verify --manifest manifest.json --output reports/latest-release-verification.json --json` -> `39/39` artifacts verified.
- `datapan catalog release readiness --manifest manifest.json --output reports/latest-release-readiness.json --json` -> `ready: true`, `passed: 22`, `warned: 1`, `failed: 0`.
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- README current snapshot check.
- Latest evidence uniqueness check: `466` total, `466` unique, `0` duplicates.
- `jq empty ...` over generated JSON reports, manifest, and schemas.
- `git diff --check`

Local release verification required temporarily materializing `data/data-go-kr.registry.json`; the tracked file was restored to the Git LFS pointer afterward. GitHub Actions checks out LFS for release verification.