### PR TITLE
feat: Add registry impact plan rollup support

### DIFF
--- a/docs/data-go-kr-mastery-plan.md
+++ b/docs/data-go-kr-mastery-plan.md
@@ -156,6 +156,7 @@ data.go.kr mastery should produce or preserve:
 - `reports/latest-verification-summary.json`
 - `reports/data-go-kr/error-action-catalog.json`
 - `reports/data-go-kr/registry-impact-plan.json`
+- `reports/registry-impact-plan.json`
 - `reports/data-go-kr/runtime-evidence-growth.json`
 - `reports/data-go-kr/institution-api-overview.json`
 
@@ -170,6 +171,7 @@ match those roots.
 | `reports/data-go-kr/external-coverage-summary.json` | `sources/data_go_kr.json`, `reports/coverage.json`, `reports/adapter-targets.json`, `reports/route-disposition.json`, `data/provider-index.json` | `scripts/validate-external-coverage.py` validates schema and cross-checks source identity, raw coverage metrics, route evidence counts, adapter target counts, provider-index host count, and missing host counts. |
 | `reports/data-go-kr/error-action-catalog.json` | `sources/data_go_kr.json`, `reports/error-catalog.json`, `reports/route-disposition.json`, provider verification reports | `scripts/validate-error-action-catalogs.py` validates checked-in action rules; future generation should also fail on unmapped known error signatures. |
 | `reports/data-go-kr/registry-impact-plan.json` | `sources/data_go_kr.json`, catalog diff, verification evidence, route disposition, error action catalog, promoted dataset mappings | `scripts/validate-impact-plans.py` validates schema, summary counts, target counts, identity fields, and promoted/served dataset boundaries before client/server consumers act on it. |
+| `reports/registry-impact-plan.json` | checked-in `reports/*/registry-impact-plan.json` source plans | `scripts/generate-impact-plan-rollup.py` generates the release-wide rollup, and `scripts/validate-impact-plans.py` validates mixed-source release scope while preserving strict source scope for source-specific plans. |
 | `reports/data-go-kr/runtime-evidence-growth.json` | `reports/coverage.json`, `reports/latest-verification.json`, `reports/latest-verification-summary.json`, `reports/verification-plan.json`, `data/provider-index.json` | `scripts/validate-runtime-evidence-growth.py` validates current evidence totals, evidence coverage percent, 10% target gap, provider split readiness, and next planned verification batches. |
 | `reports/data-go-kr/institution-api-overview.json` | `data/data-go-kr.registry.json`, `reports/dependencies.json`, `reports/latest-verification.json`, `reports/coverage.json`, `data/provider-index.json` | `scripts/validate-institution-api-overview.py` regenerates the overview and fails CI when institution API counts, operation counts, adapter status counts, or runtime evidence counts drift from checked-in artifacts. |
 
@@ -222,6 +224,8 @@ CI should fail rather than treating the checked-in summary as authoritative.
    boundaries in CI. Done in PR #4.
 11. Generate future data.go.kr impact plans directly from catalog diff,
    verification evidence, route disposition, and promoted dataset mappings.
+12. Add a release-wide registry impact plan rollup generated from checked-in
+   source-scoped impact plans. Tracked by Gira #47.
 
 ## Done Criteria
 

--- a/docs/registry-impact-plan.md
+++ b/docs/registry-impact-plan.md
@@ -38,11 +38,17 @@ PR #4 adds a checked-in data.go.kr draft at
 `reports/data-go-kr/registry-impact-plan.json` and validates every checked-in
 impact plan with `scripts/validate-impact-plans.py`.
 
+Gira #47 adds `scripts/generate-impact-plan-rollup.py`, which generates the
+root rollup from checked-in `reports/*/registry-impact-plan.json` source plans.
+The root rollup uses `scope: "release"` so change identities can keep their
+original source-specific `provider` and `source_id` values. Source-scoped plans
+keep the stricter default `scope: "source"` validation, where every change
+identity must match the plan's top-level provider and source id.
+
 The schema is checked in at
-`schemas/datapan.registry-impact-plan.v1.schema.json`, but the current release
-manifest is not updated by this design step. The schema and checked-in draft
-plans should be added to `schemas/index.json` and `manifest.json` by a future
-generated release draft.
+`schemas/datapan.registry-impact-plan.v1.schema.json`. Full `datapan-cli`
+generation from catalog diffs, verification evidence, route disposition, error
+action catalogs, and promoted dataset mappings is still future work.
 
 ## Stable Identity
 
@@ -202,9 +208,10 @@ Promoted response shape change:
 evidence, provider profiles, and promoted dataset mappings supplied by
 downstream repositories.
 
-Until generation is implemented, checked-in draft plans are allowed only when
-the validator proves their summary counts, target counts, identity fields, and
-promoted/served dataset boundaries are internally consistent.
+Until full diff-based generation is implemented, checked-in source plans and
+the generated root rollup are allowed only when the validator proves their
+summary counts, target counts, identity fields, and promoted/served dataset
+boundaries are internally consistent.
 
 `datapan-data` should consume the plan as input to collector/parser/schema
 review. It should not be required to parse the full registry release to decide

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -83,6 +83,9 @@ Current strengths:
   adapter coverage from evidence-adjusted adapter candidates.
 - `reports/data-go-kr/registry-impact-plan.json` validates downstream action
   hints for the current data.go.kr registry-only changes.
+- `reports/registry-impact-plan.json` is generated from checked-in
+  source-scoped impact plans and validates as the release-wide client/server
+  action rollup.
 - `reports/source-reference-drift.json` validates a manual baseline for
   official source references from every checked-in source profile.
 - `reports/data-go-kr/runtime-evidence-growth.json` measures current runtime
@@ -113,8 +116,10 @@ Current gaps:
   requires `1,221` evidence records, so `555` additional records are still
   required.
 - Multi-source report grouping is designed but not implemented.
-- Impact plans are specified and a data.go.kr draft plan is checked in, but
-  full `datapan-cli` generation is not implemented.
+- Impact plans are specified, a data.go.kr draft plan is checked in, and a
+  release-wide rollup can be generated from source-scoped plans, but full
+  `datapan-cli` generation from catalog diffs, verification evidence, route
+  disposition, and promoted dataset mappings is not implemented.
 - Live drift checks for official source documentation are not implemented, but
   checked-in source reference baselines are now validated against source
   profiles.
@@ -220,9 +225,10 @@ Done when:
   verification evidence, route disposition, and promoted dataset mappings;
 - checked-in impact plans validate in CI before client/server consumers act on
   them;
-- `reports/registry-impact-plan.json` is generated from registry diffs,
-  verification evidence, source profiles, error action catalogs, and promoted
-  dataset mappings;
+- `reports/registry-impact-plan.json` is generated from checked-in
+  source-scoped impact plans, and future CLI generation can replace that rollup
+  with output derived from registry diffs, verification evidence, source
+  profiles, error action catalogs, and promoted dataset mappings;
 - registry-only additions can explicitly produce `no_action`;
 - promoted dataset schema changes can explicitly produce
   `db_migration_review`;
@@ -299,6 +305,10 @@ Use this order unless a production failure changes priority:
     then by Gira #39, Gira #41, Gira #43, and Gira #45 with the next gateway
     batches; this is skipped boundary evidence growth, not proof that those
     operations are callable.
+15. Add a release-wide registry impact plan rollup generated from checked-in
+    source-scoped impact plans. Tracked by Gira #47; this establishes the
+    client/server artifact path but does not complete full datapan-cli
+    catalog-diff-based generation.
 
 ## Measurement Rules
 

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": "datapan.registry-impact-plan.v1",
+  "generated_at": "2026-06-29T00:00:00Z",
+  "datapan_version": "v0.1.29",
+  "scope": "release",
+  "provider": "datapan-registry",
+  "source_id": "registry",
+  "registry_version_from": "v0.1.29",
+  "registry_version_to": "pr-4-draft",
+  "previous_registry": "reports/*/registry-impact-plan.json",
+  "current_registry": "reports/registry-impact-plan.json",
+  "summary": {
+    "total": 3,
+    "by_category": [
+      {
+        "category": "added",
+        "count": 3
+      }
+    ],
+    "by_target": [
+      {
+        "target": "datapan-cli",
+        "count": 2
+      },
+      {
+        "target": "datapan-data",
+        "count": 3
+      },
+      {
+        "target": "dataset-api",
+        "count": 3
+      },
+      {
+        "target": "mcp",
+        "count": 3
+      },
+      {
+        "target": "registry-release",
+        "count": 2
+      },
+      {
+        "target": "sdk",
+        "count": 3
+      }
+    ],
+    "requires_manual_review": 0,
+    "requires_db_migration_review": 0,
+    "requires_served_contract_regeneration": 0
+  },
+  "changes": [
+    {
+      "identity": {
+        "provider": "data.go.kr",
+        "source_id": "data_go_kr",
+        "endpoint_id": "data_go_kr:source-profile"
+      },
+      "category": "added",
+      "severity": "info",
+      "promoted_dataset": false,
+      "served_dataset": false,
+      "actions": [
+        {
+          "target": "datapan-cli",
+          "action": "refresh_verification",
+          "automation": "automated",
+          "reason": "CLI release verification should validate the checked-in data.go.kr source profile."
+        },
+        {
+          "target": "datapan-data",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Source profile metadata does not create or change a promoted data block."
+        },
+        {
+          "target": "dataset-api",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "No served dataset contract changes are introduced by source profile metadata."
+        },
+        {
+          "target": "sdk",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "No served SDK contract changes are introduced by source profile metadata."
+        },
+        {
+          "target": "mcp",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "No served MCP tool contract changes are introduced by source profile metadata."
+        }
+      ],
+      "notes": "Registry-only source profile addition."
+    },
+    {
+      "identity": {
+        "provider": "data.go.kr",
+        "source_id": "data_go_kr",
+        "endpoint_id": "data_go_kr:external-coverage-summary"
+      },
+      "category": "added",
+      "severity": "info",
+      "promoted_dataset": false,
+      "served_dataset": false,
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "automated",
+          "reason": "External coverage summary must match coverage, adapter-target, route-disposition, and provider-index root reports."
+        },
+        {
+          "target": "datapan-data",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Coverage evidence does not create or change a promoted data block."
+        },
+        {
+          "target": "dataset-api",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Coverage evidence does not change served dataset API contracts."
+        },
+        {
+          "target": "sdk",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Coverage evidence does not change SDK contracts."
+        },
+        {
+          "target": "mcp",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Coverage evidence does not change MCP contracts."
+        }
+      ],
+      "notes": "Registry evidence addition with no promoted or served dataset impact."
+    },
+    {
+      "identity": {
+        "provider": "data.go.kr",
+        "source_id": "data_go_kr",
+        "endpoint_id": "data_go_kr:external-endpoint-operational-gate"
+      },
+      "category": "added",
+      "severity": "info",
+      "promoted_dataset": false,
+      "served_dataset": false,
+      "actions": [
+        {
+          "target": "datapan-cli",
+          "action": "refresh_verification",
+          "automation": "automated",
+          "reason": "CLI validation should fail releases with unclassified missing external routes."
+        },
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "automated",
+          "reason": "Registry release readiness should preserve the external endpoint operational gate."
+        },
+        {
+          "target": "datapan-data",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "External endpoint gate does not change promoted collector, parser, or schema contracts."
+        },
+        {
+          "target": "dataset-api",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "External endpoint gate does not change served dataset API contracts."
+        },
+        {
+          "target": "sdk",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "External endpoint gate does not change SDK contracts."
+        },
+        {
+          "target": "mcp",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "External endpoint gate does not change MCP contracts."
+        }
+      ],
+      "notes": "Adapter work remains blocked unless route disposition produces adapter_candidate evidence."
+    }
+  ]
+}

--- a/schemas/datapan.registry-impact-plan.v1.schema.json
+++ b/schemas/datapan.registry-impact-plan.v1.schema.json
@@ -27,6 +27,10 @@
       "type": "string",
       "minLength": 1
     },
+    "scope": {
+      "enum": ["source", "release"],
+      "description": "source plans enforce one provider/source identity; release rollups may contain changes from multiple source plans."
+    },
     "provider": {
       "type": "string",
       "minLength": 1

--- a/scripts/generate-impact-plan-rollup.py
+++ b/scripts/generate-impact-plan-rollup.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Generate the release-wide registry impact plan rollup."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+
+
+CLIENT_SERVER_TARGETS = {"dataset-api", "sdk", "mcp"}
+
+
+def load_json(path: pathlib.Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def source_plan_paths(reports_dir: pathlib.Path, output: pathlib.Path) -> list[pathlib.Path]:
+    return [
+        path
+        for path in sorted(reports_dir.glob("*/registry-impact-plan.json"))
+        if path.resolve() != output.resolve()
+    ]
+
+
+def count_entries(changes: list[dict[str, object]]) -> dict[str, object]:
+    category_counts: collections.Counter[str] = collections.Counter()
+    target_counts: collections.Counter[str] = collections.Counter()
+    manual_review = 0
+    db_migration_review = 0
+    served_contract_regeneration = 0
+
+    for change in changes:
+        category = change.get("category")
+        if isinstance(category, str):
+            category_counts[category] += 1
+        actions = change.get("actions", [])
+        if not isinstance(actions, list):
+            continue
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            target = action.get("target")
+            action_kind = action.get("action")
+            automation = action.get("automation")
+            if isinstance(target, str):
+                target_counts[target] += 1
+            if automation in {"manual_review", "blocked"}:
+                manual_review += 1
+            if action_kind == "db_migration_review":
+                db_migration_review += 1
+            if target in CLIENT_SERVER_TARGETS and action_kind == "regenerate":
+                served_contract_regeneration += 1
+
+    return {
+        "total": len(changes),
+        "by_category": [
+            {"category": key, "count": category_counts[key]}
+            for key in sorted(category_counts)
+        ],
+        "by_target": [
+            {"target": key, "count": target_counts[key]}
+            for key in sorted(target_counts)
+        ],
+        "requires_manual_review": manual_review,
+        "requires_db_migration_review": db_migration_review,
+        "requires_served_contract_regeneration": served_contract_regeneration,
+    }
+
+
+def common_value(plans: list[dict[str, object]], key: str, fallback: str) -> str:
+    values = {plan.get(key) for plan in plans if isinstance(plan.get(key), str)}
+    if len(values) == 1:
+        return next(iter(values))
+    return fallback
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reports-dir", type=pathlib.Path, default=pathlib.Path("reports"))
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("reports/registry-impact-plan.json"),
+    )
+    args = parser.parse_args()
+
+    paths = source_plan_paths(args.reports_dir, args.output)
+    if not paths:
+        raise SystemExit("no source-scoped registry impact plans found")
+
+    plans = [load_json(path) for path in paths]
+    changes: list[dict[str, object]] = []
+    generated_at_values: list[str] = []
+    for plan in plans:
+        generated_at = plan.get("generated_at")
+        if isinstance(generated_at, str):
+            generated_at_values.append(generated_at)
+        plan_changes = plan.get("changes")
+        if not isinstance(plan_changes, list):
+            raise ValueError("source plan changes must be an array")
+        for change in plan_changes:
+            if not isinstance(change, dict):
+                raise ValueError("source plan changes must contain objects")
+            changes.append(change)
+
+    rollup = {
+        "schema_version": "datapan.registry-impact-plan.v1",
+        "generated_at": max(generated_at_values),
+        "datapan_version": common_value(plans, "datapan_version", "mixed"),
+        "scope": "release",
+        "provider": "datapan-registry",
+        "source_id": "registry",
+        "registry_version_from": common_value(plans, "registry_version_from", "mixed"),
+        "registry_version_to": common_value(plans, "registry_version_to", "mixed"),
+        "previous_registry": "reports/*/registry-impact-plan.json",
+        "current_registry": str(args.output),
+        "summary": count_entries(changes),
+        "changes": changes,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(rollup, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    print(f"wrote {args.output} ({len(changes)} changes from {len(paths)} source plans)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-impact-plans.py
+++ b/scripts/validate-impact-plans.py
@@ -54,12 +54,15 @@ def count_summary(entries: object, key: str) -> dict[str, int]:
 
 
 def validate_consistency(path: pathlib.Path, plan: dict[str, object]) -> None:
+    scope = plan.get("scope", "source")
     provider = plan.get("provider")
     source_id = plan.get("source_id")
     summary = as_dict(plan.get("summary"), path)
     changes = plan.get("changes")
     if not isinstance(changes, list):
         raise ValueError("changes must be an array")
+    if scope not in {"source", "release"}:
+        raise ValueError("scope must be source or release")
 
     category_counts: collections.Counter[str] = collections.Counter()
     target_counts: collections.Counter[str] = collections.Counter()
@@ -71,9 +74,9 @@ def validate_consistency(path: pathlib.Path, plan: dict[str, object]) -> None:
         if not isinstance(raw_change, dict):
             raise ValueError(f"changes[{index}] must be an object")
         identity = as_dict(raw_change.get("identity"), path)
-        if identity.get("provider") != provider:
+        if scope == "source" and identity.get("provider") != provider:
             raise ValueError(f"changes[{index}].identity.provider does not match plan provider")
-        if identity.get("source_id") != source_id:
+        if scope == "source" and identity.get("source_id") != source_id:
             raise ValueError(f"changes[{index}].identity.source_id does not match plan source_id")
 
         category = raw_change.get("category")


### PR DESCRIPTION
Closes #47

## Summary
- Added `scripts/generate-impact-plan-rollup.py` to generate release-wide `reports/registry-impact-plan.json` from checked-in source-scoped impact plans.
- Extended `datapan.registry-impact-plan.v1` with optional `scope`: source-scoped plans keep strict provider/source identity matching, while `scope: "release"` rollups can preserve mixed source identities inside changes.
- Added the generated root rollup artifact and updated blueprint/impact-plan/mastery docs without claiming full datapan-cli catalog-diff generation is complete.

## Impact Gate
- Root rollup: `reports/registry-impact-plan.json`
- Scope: `release`
- Changes: `3`
- Client/server regeneration requests: `0`
- DB migration review requests: `0`
- Source plan strict identity check remains active; a temporary source_id mismatch input failed validation as expected.

## Warning Status
- Active warning remains: `runtime_evidence_growth_target`
- Expected: `1221`
- Actual: `666`
- Remaining to target: `555`
- Coverage: `5.5%` against the `10%` release target

This PR advances the client/server impact-plan gate only. It does not increase runtime evidence and does not complete full datapan-cli diff-based impact generation.

## Local Validation
- `python3 scripts/generate-impact-plan-rollup.py`
- `python3 scripts/validate-impact-plans.py`
- strict source-scope negative check failed as expected for mismatched source_id
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with materialized registry, then restored the LFS pointer
- release verify/readiness with materialized registry, then restored the LFS pointer
- `jq empty data/provider-index.json manifest.json reports/*.json reports/data-go-kr/*.json schemas/*.json`
- `git diff --check`
