### PR TITLE
feat: Add source runtime evidence rollup

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -84,6 +84,7 @@ jobs:
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
           python scripts/validate-source-runtime-evidence-plans.py
+          python scripts/validate-source-runtime-evidence-rollup.py
           python scripts/validate-runtime-evidence-growth.py
           python scripts/validate-institution-api-overview.py
 

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -57,6 +57,7 @@ jobs:
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
           python scripts/validate-source-runtime-evidence-plans.py
+          python scripts/validate-source-runtime-evidence-rollup.py
           python scripts/validate-runtime-evidence-growth.py
           python scripts/validate-institution-api-overview.py
 

--- a/docs/multi-source-release-layout.md
+++ b/docs/multi-source-release-layout.md
@@ -72,6 +72,7 @@ reports/
     verification-plan.json
     latest-verification.json
     latest-verification-summary.json
+  source-runtime-evidence-rollup.json
   open-assembly/
     coverage.json
     catalog-audit.json

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -97,6 +97,9 @@ Current strengths:
   `reports/seoul-open-data/runtime-evidence-plan.json` record the first
   non-data.go.kr sources as `0` runtime-evidence sources with explicit blocker
   and warning IDs instead of treating missing evidence as ready.
+- `reports/source-runtime-evidence-rollup.json` rolls those source runtime
+  evidence plans into a release-wide inventory of `4` sources, `0` runtime
+  checks, `20` blocking blockers, and `16` warning instances.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -113,9 +116,10 @@ Current gaps:
   artifacts.
 - Error inventory has draft action routing for data.go.kr and the first
   non-data.go.kr profile batch. Gira #63 adds source-scoped runtime evidence
-  plans for those non-data.go.kr sources, but actual runtime evidence remains
-  `0` for each source until adapters, credentials, sample parameters, and
-  source-scoped candidate artifacts are in place.
+  plans for those non-data.go.kr sources, and Gira #65 rolls them up so release
+  operators can see the remaining blocker and warning IDs centrally. Actual
+  runtime evidence remains `0` for each source until adapters, credentials,
+  sample parameters, and source-scoped candidate artifacts are in place.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -219,6 +223,8 @@ Done when:
   cross-checks its source profile identity;
 - every checked-in source runtime evidence plan validates and records explicit
   blocker and warning IDs while evidence is absent;
+- the release-wide source runtime evidence rollup validates against checked-in
+  source plans;
 - source-scoped reports are generated under `reports/<source>/`;
 - root reports are documented as release-wide rollups;
 - CI validates source-scoped report paths where present;
@@ -325,6 +331,9 @@ Use this order unless a production failure changes priority:
     sources. Tracked by Gira #63; this records why KOSIS, ECOS, Open Assembly,
     and Seoul Open Data have `0` runtime checks and what must be built before
     evidence can be collected.
+17. Add a release-wide source runtime evidence rollup. Tracked by Gira #65;
+    this centralizes non-data.go.kr runtime evidence blockers and warnings
+    without treating missing evidence as ready.
 
 ## Measurement Rules
 

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,0 +1,270 @@
+{
+  "schema_version": "datapan.source-runtime-evidence-rollup.v1",
+  "generated_at": "2026-06-30T08:31:32Z",
+  "provider": "multi-source",
+  "source_plan_inputs": [
+    "reports/ecos/runtime-evidence-plan.json",
+    "reports/kosis/runtime-evidence-plan.json",
+    "reports/open-assembly/runtime-evidence-plan.json",
+    "reports/seoul-open-data/runtime-evidence-plan.json"
+  ],
+  "summary": {
+    "sources": 4,
+    "sources_without_evidence": 4,
+    "evidence_total": 0,
+    "verified": 0,
+    "failed": 0,
+    "skipped": 0,
+    "unknown": 0,
+    "blocking_count": 20,
+    "warning_count": 16
+  },
+  "sources": [
+    {
+      "source_id": "ecos",
+      "provider": "ECOS",
+      "runtime_evidence_plan": "reports/ecos/runtime-evidence-plan.json",
+      "evidence_total": 0,
+      "blocking_count": 5,
+      "warning_count": 4,
+      "blocker_ids": [
+        "adapter_not_registered",
+        "credential_required",
+        "metadata_only_verification",
+        "runtime_catalog_not_materialized",
+        "sample_parameters_not_pinned",
+        "source_specific_error_taxonomy_pending"
+      ],
+      "warning_ids": [
+        "non_data_runtime_evidence_not_collected",
+        "source_runtime_adapter_not_registered",
+        "source_runtime_error_taxonomy_pending",
+        "source_runtime_manual_samples_unpinned"
+      ],
+      "next_action_count": 4
+    },
+    {
+      "source_id": "kosis",
+      "provider": "KOSIS",
+      "runtime_evidence_plan": "reports/kosis/runtime-evidence-plan.json",
+      "evidence_total": 0,
+      "blocking_count": 5,
+      "warning_count": 4,
+      "blocker_ids": [
+        "adapter_not_registered",
+        "credential_required",
+        "metadata_only_verification",
+        "runtime_catalog_not_materialized",
+        "sample_parameters_not_pinned",
+        "source_specific_error_taxonomy_pending"
+      ],
+      "warning_ids": [
+        "non_data_runtime_evidence_not_collected",
+        "source_runtime_adapter_not_registered",
+        "source_runtime_error_taxonomy_pending",
+        "source_runtime_manual_samples_unpinned"
+      ],
+      "next_action_count": 4
+    },
+    {
+      "source_id": "open_assembly",
+      "provider": "open.assembly.go.kr",
+      "runtime_evidence_plan": "reports/open-assembly/runtime-evidence-plan.json",
+      "evidence_total": 0,
+      "blocking_count": 5,
+      "warning_count": 4,
+      "blocker_ids": [
+        "adapter_not_registered",
+        "credential_required",
+        "metadata_only_verification",
+        "runtime_catalog_not_materialized",
+        "sample_parameters_not_pinned",
+        "source_specific_error_taxonomy_pending"
+      ],
+      "warning_ids": [
+        "non_data_runtime_evidence_not_collected",
+        "source_runtime_adapter_not_registered",
+        "source_runtime_error_taxonomy_pending",
+        "source_runtime_manual_samples_unpinned"
+      ],
+      "next_action_count": 4
+    },
+    {
+      "source_id": "seoul_open_data",
+      "provider": "data.seoul.go.kr",
+      "runtime_evidence_plan": "reports/seoul-open-data/runtime-evidence-plan.json",
+      "evidence_total": 0,
+      "blocking_count": 5,
+      "warning_count": 4,
+      "blocker_ids": [
+        "adapter_not_registered",
+        "credential_required",
+        "metadata_only_verification",
+        "runtime_catalog_not_materialized",
+        "sample_parameters_not_pinned",
+        "source_specific_error_taxonomy_pending"
+      ],
+      "warning_ids": [
+        "non_data_runtime_evidence_not_collected",
+        "source_runtime_adapter_not_registered",
+        "source_runtime_error_taxonomy_pending",
+        "source_runtime_manual_samples_unpinned"
+      ],
+      "next_action_count": 4
+    }
+  ],
+  "blockers_by_id": [
+    {
+      "id": "adapter_not_registered",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "credential_required",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "metadata_only_verification",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "runtime_catalog_not_materialized",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "sample_parameters_not_pinned",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "source_specific_error_taxonomy_pending",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    }
+  ],
+  "warnings_by_id": [
+    {
+      "id": "non_data_runtime_evidence_not_collected",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "source_runtime_adapter_not_registered",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "source_runtime_error_taxonomy_pending",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    },
+    {
+      "id": "source_runtime_manual_samples_unpinned",
+      "count": 4,
+      "source_ids": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ]
+    }
+  ],
+  "warnings": [
+    {
+      "warning_id": "non_data_runtime_evidence_not_collected",
+      "affected_sources": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ],
+      "expected": "Every checked-in non-data.go.kr source has source-scoped runtime evidence after adapters and sample parameters are pinned.",
+      "actual": "4 of 4 non-data.go.kr sources have 0 runtime checks.",
+      "remaining": "Materialize source candidate artifacts, register adapters, inject credentials, and run bounded first batches."
+    },
+    {
+      "warning_id": "source_runtime_adapter_not_registered",
+      "affected_sources": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ],
+      "expected": "Every checked-in non-data.go.kr source has verification and call adapter capabilities before runtime evidence collection.",
+      "actual": "4 of 4 non-data.go.kr sources have no registered runtime adapter.",
+      "remaining": "Register source-specific adapters for ECOS, KOSIS, Open Assembly, and Seoul Open Data."
+    },
+    {
+      "warning_id": "source_runtime_error_taxonomy_pending",
+      "affected_sources": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ],
+      "expected": "Every checked-in non-data.go.kr source has verified source-specific error taxonomy before failures are classified as adapter defects.",
+      "actual": "4 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
+      "remaining": "Verify source-specific error codes and message fields for the first non-data.go.kr source batch."
+    },
+    {
+      "warning_id": "source_runtime_manual_samples_unpinned",
+      "affected_sources": [
+        "ecos",
+        "kosis",
+        "open_assembly",
+        "seoul_open_data"
+      ],
+      "expected": "Every checked-in non-data.go.kr source has pinned first-batch sample parameters.",
+      "actual": "4 of 4 non-data.go.kr sources use manual sample parameter policy.",
+      "remaining": "Pin official first-batch sample parameters per source before bounded checks."
+    }
+  ]
+}

--- a/schemas/datapan.source-runtime-evidence-rollup.v1.schema.json
+++ b/schemas/datapan.source-runtime-evidence-rollup.v1.schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.datapan.dev/datapan.source-runtime-evidence-rollup.v1.schema.json",
+  "title": "Datapan Source Runtime Evidence Rollup v1",
+  "description": "Release-wide rollup of source-scoped runtime evidence plans, blockers, and warnings.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "provider",
+    "source_plan_inputs",
+    "summary",
+    "sources",
+    "blockers_by_id",
+    "warnings_by_id",
+    "warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "datapan.source-runtime-evidence-rollup.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_plan_inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "blockers_by_id": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/id_count"
+      }
+    },
+    "warnings_by_id": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/id_count"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/rollup_warning"
+      }
+    }
+  },
+  "$defs": {
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sources",
+        "sources_without_evidence",
+        "evidence_total",
+        "verified",
+        "failed",
+        "skipped",
+        "unknown",
+        "blocking_count",
+        "warning_count"
+      ],
+      "properties": {
+        "sources": {
+          "$ref": "#/$defs/count"
+        },
+        "sources_without_evidence": {
+          "$ref": "#/$defs/count"
+        },
+        "evidence_total": {
+          "$ref": "#/$defs/count"
+        },
+        "verified": {
+          "$ref": "#/$defs/count"
+        },
+        "failed": {
+          "$ref": "#/$defs/count"
+        },
+        "skipped": {
+          "$ref": "#/$defs/count"
+        },
+        "unknown": {
+          "$ref": "#/$defs/count"
+        },
+        "blocking_count": {
+          "$ref": "#/$defs/count"
+        },
+        "warning_count": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "provider",
+        "runtime_evidence_plan",
+        "evidence_total",
+        "blocking_count",
+        "warning_count",
+        "blocker_ids",
+        "warning_ids",
+        "next_action_count"
+      ],
+      "properties": {
+        "source_id": {
+          "$ref": "#/$defs/source_id"
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "runtime_evidence_plan": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_total": {
+          "$ref": "#/$defs/count"
+        },
+        "blocking_count": {
+          "$ref": "#/$defs/count"
+        },
+        "warning_count": {
+          "$ref": "#/$defs/count"
+        },
+        "blocker_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "warning_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "next_action_count": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "id_count": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "count", "source_ids"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "count": {
+          "$ref": "#/$defs/count"
+        },
+        "source_ids": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/source_id"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "rollup_warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["warning_id", "affected_sources", "expected", "actual", "remaining"],
+      "properties": {
+        "warning_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "affected_sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/source_id"
+          },
+          "uniqueItems": true
+        },
+        "expected": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actual": {
+          "type": "string",
+          "minLength": 1
+        },
+        "remaining": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-source-runtime-evidence-rollup.py
+++ b/scripts/validate-source-runtime-evidence-rollup.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate the release-wide source runtime evidence rollup."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import sys
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit(
+        "missing dependency: install jsonschema before running source runtime evidence rollup validation"
+    ) from exc
+
+
+DEFAULT_ROLLUP = pathlib.Path("reports/source-runtime-evidence-rollup.json")
+
+
+def load_json(path: pathlib.Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def as_dict(value: object, path: pathlib.Path) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def key_counts(counter: dict[str, list[str]]) -> list[dict[str, object]]:
+    return [
+        {"id": key, "count": len(counter[key]), "source_ids": sorted(counter[key])}
+        for key in sorted(counter)
+    ]
+
+
+def validate_rollup(path: pathlib.Path, rollup: dict[str, object]) -> None:
+    source_plan_inputs = rollup.get("source_plan_inputs")
+    if not isinstance(source_plan_inputs, list) or not source_plan_inputs:
+        raise ValueError("source_plan_inputs must be a non-empty array")
+
+    plan_paths = [pathlib.Path(str(item)) for item in source_plan_inputs]
+    expected_inputs = [str(item) for item in sorted(pathlib.Path("reports").glob("*/runtime-evidence-plan.json"))]
+    if [str(item) for item in plan_paths] != expected_inputs:
+        raise ValueError("source_plan_inputs must list all checked-in source runtime evidence plans")
+
+    plans = [as_dict(load_json(plan_path), plan_path) for plan_path in plan_paths]
+    plans_by_source = {str(plan.get("source_id")): plan for plan in plans}
+    if len(plans_by_source) != len(plans):
+        raise ValueError("duplicate source_id values in source runtime evidence plans")
+
+    expected_sources: list[dict[str, object]] = []
+    blockers_by_id: dict[str, list[str]] = collections.defaultdict(list)
+    warnings_by_id: dict[str, list[str]] = collections.defaultdict(list)
+    summary = {
+        "sources": len(plans),
+        "sources_without_evidence": 0,
+        "evidence_total": 0,
+        "verified": 0,
+        "failed": 0,
+        "skipped": 0,
+        "unknown": 0,
+        "blocking_count": 0,
+        "warning_count": 0,
+    }
+
+    for plan_path, plan in zip(plan_paths, plans):
+        source_id = str(plan.get("source_id"))
+        runtime_state = as_dict(plan.get("runtime_state"), plan_path)
+        plan_summary = as_dict(plan.get("summary"), plan_path)
+        blockers = plan.get("blockers")
+        warnings = plan.get("warnings")
+        if not isinstance(blockers, list):
+            raise ValueError(f"{plan_path}: blockers must be an array")
+        if not isinstance(warnings, list):
+            raise ValueError(f"{plan_path}: warnings must be an array")
+
+        blocker_ids = sorted(
+            str(blocker.get("blocker_id"))
+            for blocker in blockers
+            if isinstance(blocker, dict)
+        )
+        warning_ids = sorted(
+            str(warning.get("warning_id"))
+            for warning in warnings
+            if isinstance(warning, dict)
+        )
+        for blocker_id in blocker_ids:
+            blockers_by_id[blocker_id].append(source_id)
+        for warning_id in warning_ids:
+            warnings_by_id[warning_id].append(source_id)
+
+        evidence_total = int(plan_summary.get("evidence_total", 0))
+        if evidence_total == 0:
+            summary["sources_without_evidence"] += 1
+        summary["evidence_total"] += evidence_total
+        for key in ["verified", "failed", "skipped", "unknown"]:
+            summary[key] += int(runtime_state.get(key, 0))
+        summary["blocking_count"] += int(plan_summary.get("blocking_count", 0))
+        summary["warning_count"] += int(plan_summary.get("warning_count", 0))
+
+        expected_sources.append(
+            {
+                "source_id": source_id,
+                "provider": plan.get("provider"),
+                "runtime_evidence_plan": str(plan_path),
+                "evidence_total": evidence_total,
+                "blocking_count": plan_summary.get("blocking_count"),
+                "warning_count": plan_summary.get("warning_count"),
+                "blocker_ids": blocker_ids,
+                "warning_ids": warning_ids,
+                "next_action_count": plan_summary.get("next_action_count"),
+            }
+        )
+
+    expected_sources.sort(key=lambda item: str(item["source_id"]))
+    if rollup.get("summary") != summary:
+        raise ValueError(f"summary expected {summary}, got {rollup.get('summary')}")
+    if rollup.get("sources") != expected_sources:
+        raise ValueError("sources do not match source runtime evidence plans")
+    if rollup.get("blockers_by_id") != key_counts(blockers_by_id):
+        raise ValueError("blockers_by_id does not match source runtime evidence plans")
+    if rollup.get("warnings_by_id") != key_counts(warnings_by_id):
+        raise ValueError("warnings_by_id does not match source runtime evidence plans")
+
+    rollup_warnings = rollup.get("warnings")
+    if not isinstance(rollup_warnings, list):
+        raise ValueError("warnings must be an array")
+    warning_sources = {
+        str(warning.get("warning_id")): sorted(warning.get("affected_sources") or [])
+        for warning in rollup_warnings
+        if isinstance(warning, dict)
+    }
+    missing_warning_ids = sorted(set(warnings_by_id).difference(warning_sources))
+    if missing_warning_ids:
+        raise ValueError(f"missing rollup warnings: {', '.join(missing_warning_ids)}")
+    for warning_id, source_ids in warnings_by_id.items():
+        if warning_sources.get(warning_id) != sorted(source_ids):
+            raise ValueError(f"warnings.{warning_id}.affected_sources does not match plans")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--schema",
+        default="schemas/datapan.source-runtime-evidence-rollup.v1.schema.json",
+        type=pathlib.Path,
+        help="source runtime evidence rollup JSON Schema path",
+    )
+    parser.add_argument(
+        "rollup",
+        nargs="?",
+        default=DEFAULT_ROLLUP,
+        type=pathlib.Path,
+        help="rollup file to validate",
+    )
+    args = parser.parse_args()
+
+    schema = load_json(args.schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    failures = 0
+
+    try:
+        instance = as_dict(load_json(args.rollup), args.rollup)
+        errors = sorted(validator.iter_errors(instance), key=lambda error: list(error.path))
+        if not errors:
+            validate_rollup(args.rollup, instance)
+    except Exception as exc:  # noqa: BLE001 - report all validation blockers
+        print(f"FAIL {args.rollup}: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        failures += 1
+        print(f"FAIL {args.rollup}", file=sys.stderr)
+        for error in errors:
+            location = ".".join(str(part) for part in error.path) or "<root>"
+            print(f"  {location}: {error.message}", file=sys.stderr)
+
+    if failures:
+        return 1
+
+    summary = instance.get("summary", {})
+    print(
+        "ok "
+        f"{args.rollup} "
+        f"(sources={summary.get('sources')}, evidence={summary.get('evidence_total')}, "
+        f"warnings={summary.get('warning_count')})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `datapan.source-runtime-evidence-rollup.v1` for release-wide visibility over source runtime evidence plans.
- Add `reports/source-runtime-evidence-rollup.json` derived from KOSIS, ECOS, Open Assembly, and Seoul Open Data runtime evidence plans.
- Add `scripts/validate-source-runtime-evidence-rollup.py` and run it in release verification workflows.

## Gap Statement
- Gap reduced: Gira #63 made source-scoped runtime evidence blockers visible per source, but operators still had to inspect each source plan manually.
- Current state after this PR: the rollup centralizes `4` sources, `0` runtime checks, `20` blocking blockers, and `16` warning instances.
- Remaining gap: actual runtime evidence collection is still pending until adapters, credentials, pinned sample parameters, source-specific error taxonomy verification, and source-scoped candidate artifacts exist.

## Acceptance Evidence
- [x] `python3 scripts/validate-source-runtime-evidence-rollup.py` passes.
- [x] Rollup totals match checked-in source runtime evidence plans.
- [x] Rollup records remaining warning IDs and blocker IDs explicitly.
- [x] Blueprint current gaps distinguish rollup visibility from actual runtime evidence collection.

## Explicit Warnings Tracked
The rollup preserves these warning IDs across all 4 sources:
- `non_data_runtime_evidence_not_collected` count `4`
- `source_runtime_adapter_not_registered` count `4`
- `source_runtime_manual_samples_unpinned` count `4`
- `source_runtime_error_taxonomy_pending` count `4`

## Local Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with the materialized local registry copy
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

Closes #65
