### PR TITLE
feat: Verify Seoul Open Data error taxonomy

### DIFF
--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -99,7 +99,8 @@ Current strengths:
   and warning IDs instead of treating missing evidence as ready.
 - `reports/source-runtime-evidence-rollup.json` rolls those source runtime
   evidence plans into a release-wide inventory of `4` sources, `0` runtime
-  checks, `20` blocking blockers, and `16` warning instances.
+  checks, `20` blocking blockers, and `15` warning instances after Seoul Open
+  Data error taxonomy verification in Gira #67.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -120,6 +121,8 @@ Current gaps:
   operators can see the remaining blocker and warning IDs centrally. Actual
   runtime evidence remains `0` for each source until adapters, credentials,
   sample parameters, and source-scoped candidate artifacts are in place.
+  Gira #67 verifies Seoul Open Data's official RESULT-code taxonomy and reduces
+  `source_runtime_error_taxonomy_pending` from `4` sources to `3`.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -334,6 +337,9 @@ Use this order unless a production failure changes priority:
 17. Add a release-wide source runtime evidence rollup. Tracked by Gira #65;
     this centralizes non-data.go.kr runtime evidence blockers and warnings
     without treating missing evidence as ready.
+18. Verify Seoul Open Data error taxonomy from official RESULT-code references.
+    Tracked by Gira #67; this reduces one `source_runtime_error_taxonomy_pending`
+    warning while leaving remaining non-data runtime evidence blockers explicit.
 
 ## Measurement Rules
 

--- a/reports/seoul-open-data/error-action-catalog.json
+++ b/reports/seoul-open-data/error-action-catalog.json
@@ -1,19 +1,19 @@
 {
   "schema_version": "datapan.error-action-catalog.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
+  "generated_at": "2026-06-30T08:41:37Z",
   "provider": "data.seoul.go.kr",
   "source_id": "seoul_open_data",
   "source_profile": "sources/seoul_open_data.json",
   "summary": {
-    "rules": 5,
+    "rules": 7,
     "blocking_rules": 1,
-    "manual_review_rules": 4,
-    "unknown_signature_rules": 1
+    "manual_review_rules": 6,
+    "unknown_signature_rules": 0
   },
   "rules": [
     {
       "rule_id": "seoul-open-data-info-100",
-      "status": "draft",
+      "status": "verified",
       "scope": {
         "hosts": [
           "data.seoul.go.kr",
@@ -52,7 +52,7 @@
     },
     {
       "rule_id": "seoul-open-data-error-300",
-      "status": "draft",
+      "status": "verified",
       "match": {
         "kind": "field_equals",
         "field": "RESULT.CODE",
@@ -75,6 +75,59 @@
       ],
       "evidence": {
         "reference_url": "https://data.seoul.go.kr/dataList/OA-2192/A/1/datasetView.do"
+      }
+    },
+    {
+      "rule_id": "seoul-open-data-error-310",
+      "status": "verified",
+      "match": {
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-310",
+        "case_sensitive": false
+      },
+      "classification": "not_found",
+      "severity": "medium",
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "manual_review",
+          "reason": "Seoul Open Data documents ERROR-310 when the requested service cannot be found. Refresh source service identifiers before creating adapter work."
+        }
+      ],
+      "impact_categories": [
+        "endpoint_changed",
+        "verification_status_changed"
+      ],
+      "evidence": {
+        "reference_url": "https://data.seoul.go.kr/dataList/datasetView.do?currentPageNo=1&infId=OA-13313&searchKey=&searchValue=&serviceKind=1&srvType=A"
+      }
+    },
+    {
+      "rule_id": "seoul-open-data-error-500",
+      "status": "verified",
+      "match": {
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-500",
+        "case_sensitive": false
+      },
+      "classification": "upstream_outage",
+      "severity": "medium",
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "manual_review",
+          "reason": "Seoul Open Data documents ERROR-500 as a provider server error. Preserve the result as provider health evidence before changing parser or adapter code."
+        }
+      ],
+      "impact_categories": [
+        "verification_status_changed"
+      ],
+      "evidence": {
+        "reference_url": "https://data.seoul.go.kr/dataList/OA-13312/A/1/datasetView.do"
       }
     },
     {
@@ -119,19 +172,19 @@
       ]
     },
     {
-      "rule_id": "seoul-open-data-parse-error-unknown",
+      "rule_id": "seoul-open-data-parse-error",
       "status": "draft",
       "match": {
         "kind": "parse_error"
       },
-      "classification": "unknown",
+      "classification": "parser",
       "severity": "high",
       "actions": [
         {
           "target": "registry-release",
           "action": "investigate",
           "automation": "manual_review",
-          "reason": "Seoul Open Data responses are service-specific. Parse failures need evidence before classifying response-shape drift or parser failure."
+          "reason": "Seoul Open Data responses are service-specific. Parse failures are parser evidence unless a provider RESULT.CODE maps the failure to the official taxonomy."
         }
       ],
       "impact_categories": [

--- a/reports/seoul-open-data/runtime-evidence-plan.json
+++ b/reports/seoul-open-data/runtime-evidence-plan.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:22:19Z",
+  "generated_at": "2026-06-30T08:41:37Z",
   "provider": "data.seoul.go.kr",
   "source_id": "seoul_open_data",
   "source_profile": "sources/seoul_open_data.json",
@@ -16,7 +16,7 @@
   "summary": {
     "evidence_total": 0,
     "blocking_count": 5,
-    "warning_count": 4,
+    "warning_count": 3,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -73,14 +73,6 @@
       "expected_action": "Materialize a source-scoped Seoul Open Data registry or verification candidate list before collecting evidence.",
       "owner": "registry",
       "status": "open"
-    },
-    {
-      "blocker_id": "source_specific_error_taxonomy_pending",
-      "severity": "warning",
-      "source_profile_field": "errors.taxonomy_status",
-      "expected_action": "Finish Seoul Open Data error taxonomy verification before treating provider RESULT codes as adapter defects.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -117,12 +109,6 @@
       "expected": "Seoul Open Data first-batch sample parameters are pinned.",
       "actual": "runtime.sample_param_policy is manual.",
       "remaining": "Pin official Seoul Open Data sample identifiers for bounded checks."
-    },
-    {
-      "warning_id": "source_runtime_error_taxonomy_pending",
-      "expected": "Seoul Open Data source-specific error taxonomy is verified.",
-      "actual": "errors.taxonomy_status is draft.",
-      "remaining": "Verify Seoul Open Data RESULT code classifications before treating runtime failures as adapter defects."
     }
   ]
 }

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-rollup.v1",
-  "generated_at": "2026-06-30T08:31:32Z",
+  "generated_at": "2026-06-30T08:41:37Z",
   "provider": "multi-source",
   "source_plan_inputs": [
     "reports/ecos/runtime-evidence-plan.json",
@@ -17,7 +17,7 @@
     "skipped": 0,
     "unknown": 0,
     "blocking_count": 20,
-    "warning_count": 16
+    "warning_count": 15
   },
   "sources": [
     {
@@ -95,19 +95,17 @@
       "runtime_evidence_plan": "reports/seoul-open-data/runtime-evidence-plan.json",
       "evidence_total": 0,
       "blocking_count": 5,
-      "warning_count": 4,
+      "warning_count": 3,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
         "metadata_only_verification",
         "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned",
-        "source_specific_error_taxonomy_pending"
+        "sample_parameters_not_pinned"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
         "source_runtime_adapter_not_registered",
-        "source_runtime_error_taxonomy_pending",
         "source_runtime_manual_samples_unpinned"
       ],
       "next_action_count": 4
@@ -166,12 +164,11 @@
     },
     {
       "id": "source_specific_error_taxonomy_pending",
-      "count": 4,
+      "count": 3,
       "source_ids": [
         "ecos",
         "kosis",
-        "open_assembly",
-        "seoul_open_data"
+        "open_assembly"
       ]
     }
   ],
@@ -198,12 +195,11 @@
     },
     {
       "id": "source_runtime_error_taxonomy_pending",
-      "count": 4,
+      "count": 3,
       "source_ids": [
         "ecos",
         "kosis",
-        "open_assembly",
-        "seoul_open_data"
+        "open_assembly"
       ]
     },
     {
@@ -247,12 +243,11 @@
       "affected_sources": [
         "ecos",
         "kosis",
-        "open_assembly",
-        "seoul_open_data"
+        "open_assembly"
       ],
       "expected": "Every checked-in non-data.go.kr source has verified source-specific error taxonomy before failures are classified as adapter defects.",
-      "actual": "4 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
-      "remaining": "Verify source-specific error codes and message fields for the first non-data.go.kr source batch."
+      "actual": "3 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
+      "remaining": "Verify source-specific error codes and message fields for ECOS, KOSIS, and Open Assembly."
     },
     {
       "warning_id": "source_runtime_manual_samples_unpinned",

--- a/sources/seoul_open_data.json
+++ b/sources/seoul_open_data.json
@@ -70,12 +70,34 @@
     "schema_policy": "documented"
   },
   "errors": {
-    "taxonomy_status": "draft",
+    "taxonomy_status": "verified",
     "status_code_fields": [
       "RESULT.CODE"
     ],
     "message_fields": [
       "RESULT.MESSAGE"
+    ],
+    "known_error_codes": [
+      {
+        "code": "INFO-100",
+        "message": "Invalid or missing Open API key.",
+        "classification": "credential"
+      },
+      {
+        "code": "ERROR-300",
+        "message": "Missing required value.",
+        "classification": "bad_request"
+      },
+      {
+        "code": "ERROR-310",
+        "message": "Requested service not found.",
+        "classification": "not_found"
+      },
+      {
+        "code": "ERROR-500",
+        "message": "Provider server error.",
+        "classification": "upstream_outage"
+      }
     ]
   },
   "runtime": {


### PR DESCRIPTION
## Summary
- Verify Seoul Open Data RESULT-code taxonomy from official Seoul Open Data portal references.
- Add known Seoul Open Data result codes to `sources/seoul_open_data.json`: `INFO-100`, `ERROR-300`, `ERROR-310`, `ERROR-500`.
- Promote official RESULT-code error-action rules to `verified`, remove Seoul's taxonomy-pending runtime warning, and update the release-wide rollup.

## Official References
- Seoul Open Data Open API guide: https://data.seoul.go.kr/together/guide/useGuide.do
- Seoul Open Data Open API input/output dataset page: https://data.seoul.go.kr/dataList/OA-2192/A/1/datasetView.do
- Seoul Open Data dataset pages exposing RESULT codes, including `INFO-100`, `ERROR-300`, `ERROR-310`, and `ERROR-500` result messages.

## Gap Statement
- Gap reduced: `source_runtime_error_taxonomy_pending` for Seoul Open Data is removed.
- Current rollup state after this PR: `warning_count=15`, and `source_runtime_error_taxonomy_pending` affects `ecos`, `kosis`, and `open_assembly` only.
- Remaining gap: Seoul still has no runtime evidence because adapter registration, credential injection, pinned sample parameters, and source-scoped candidate artifacts remain open.

## Acceptance Evidence
- [x] `python3 scripts/validate-source-profiles.py` passes.
- [x] `python3 scripts/validate-error-action-catalogs.py` passes.
- [x] `python3 scripts/validate-source-runtime-evidence-plans.py` passes and Seoul Open Data has no `source_runtime_error_taxonomy_pending` warning.
- [x] `python3 scripts/validate-source-runtime-evidence-rollup.py` passes and rollup warning count is `15`.

## Explicit Warnings Still Tracked
- `source_runtime_error_taxonomy_pending`: count `3`, sources `ecos`, `kosis`, `open_assembly`
- `non_data_runtime_evidence_not_collected`: count `4`
- `source_runtime_adapter_not_registered`: count `4`
- `source_runtime_manual_samples_unpinned`: count `4`

## Local Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with the materialized local registry copy
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

Closes #67
