### PR TITLE
feat: Verify KOSIS error taxonomy

### DIFF
--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -99,8 +99,9 @@ Current strengths:
   and warning IDs instead of treating missing evidence as ready.
 - `reports/source-runtime-evidence-rollup.json` rolls those source runtime
   evidence plans into a release-wide inventory of `4` sources, `0` runtime
-  checks, `20` blocking blockers, and `15` warning instances after Seoul Open
-  Data error taxonomy verification in Gira #67.
+  checks, `20` blocking blockers, and `14` warning instances after Seoul Open
+  Data error taxonomy verification in Gira #67 and KOSIS error taxonomy
+  verification in Gira #69.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -123,6 +124,8 @@ Current gaps:
   sample parameters, and source-scoped candidate artifacts are in place.
   Gira #67 verifies Seoul Open Data's official RESULT-code taxonomy and reduces
   `source_runtime_error_taxonomy_pending` from `4` sources to `3`.
+  Gira #69 verifies KOSIS official `err`/`errMsg` taxonomy and reduces
+  `source_runtime_error_taxonomy_pending` from `3` sources to `2`.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -340,6 +343,10 @@ Use this order unless a production failure changes priority:
 18. Verify Seoul Open Data error taxonomy from official RESULT-code references.
     Tracked by Gira #67; this reduces one `source_runtime_error_taxonomy_pending`
     warning while leaving remaining non-data runtime evidence blockers explicit.
+19. Verify KOSIS error taxonomy from official `err`/`errMsg` references.
+    Tracked by Gira #69; this reduces one more
+    `source_runtime_error_taxonomy_pending` warning while preserving runtime
+    evidence, adapter, and sample-parameter warnings.
 
 ## Measurement Rules
 

--- a/reports/kosis/error-action-catalog.json
+++ b/reports/kosis/error-action-catalog.json
@@ -1,27 +1,28 @@
 {
   "schema_version": "datapan.error-action-catalog.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
+  "generated_at": "2026-06-30T08:50:44Z",
   "provider": "KOSIS",
   "source_id": "kosis",
   "source_profile": "sources/kosis.json",
   "summary": {
-    "rules": 5,
-    "blocking_rules": 1,
+    "rules": 6,
+    "blocking_rules": 2,
     "manual_review_rules": 4,
-    "unknown_signature_rules": 1
+    "unknown_signature_rules": 0
   },
   "rules": [
     {
-      "rule_id": "kosis-api-key-message",
-      "status": "draft",
+      "rule_id": "kosis-err-10-missing-api-key",
+      "status": "verified",
       "scope": {
         "hosts": [
           "kosis.kr"
         ]
       },
       "match": {
-        "kind": "message_contains",
-        "contains": "apiKey",
+        "kind": "field_equals",
+        "field": "err",
+        "value": "10",
         "case_sensitive": false
       },
       "classification": "credential",
@@ -31,13 +32,13 @@
           "target": "registry-release",
           "action": "refresh_verification",
           "automation": "manual_review",
-          "reason": "KOSIS requests require the issued apiKey parameter. Verify credential and approval state before routing the failure to parser or adapter work."
+          "reason": "KOSIS official OpenAPI responses use err=10 when the authentication key is missing. Verify credential injection before routing the failure to parser or adapter work."
         },
         {
           "target": "documentation",
           "action": "update_error_taxonomy",
           "automation": "manual_review",
-          "reason": "Keep KOSIS credential error handling tied to the official OpenAPI request-variable documentation."
+          "reason": "Keep KOSIS err/errMsg handling tied to official KOSIS OpenAPI responses."
         }
       ],
       "impact_categories": [
@@ -45,15 +46,54 @@
         "verification_status_changed"
       ],
       "evidence": {
-        "reference_url": "https://kosis.kr/openapi/devGuide/devGuide_0101List.do"
+        "reference_url": "https://kosis.kr/openapi/Param/statisticsParameterData.do?apiKey=&format=json&itmId=T6+T16+T26+T5+T15+T25+T2+T12+T22+T3+T13+T23+T4+T14+T24+T1+T11+T21+&jsonVD=Y&method=getList&newEstPrdCnt=3&objL1=ALL&objL2=&objL3=&objL4=&objL5=&objL6=&objL7=&objL8=&orgId=101&prdInterval=1&prdSe=Y&tblId=DT_1B41"
       }
     },
     {
-      "rule_id": "kosis-required-parameter-message",
-      "status": "draft",
+      "rule_id": "kosis-err-11-invalid-api-key",
+      "status": "verified",
+      "scope": {
+        "hosts": [
+          "kosis.kr"
+        ]
+      },
       "match": {
-        "kind": "message_contains",
-        "contains": "필수",
+        "kind": "field_equals",
+        "field": "err",
+        "value": "11",
+        "case_sensitive": false
+      },
+      "classification": "credential",
+      "severity": "blocking",
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "manual_review",
+          "reason": "KOSIS official OpenAPI responses use err=11 when the authentication key is invalid. Verify issued key state before changing parser or adapter code."
+        },
+        {
+          "target": "documentation",
+          "action": "update_error_taxonomy",
+          "automation": "manual_review",
+          "reason": "Keep KOSIS invalid-key handling tied to official KOSIS err/errMsg responses."
+        }
+      ],
+      "impact_categories": [
+        "provider_error_taxonomy_changed",
+        "verification_status_changed"
+      ],
+      "evidence": {
+        "reference_url": "https://kosis.kr/openapi/statisticsBigData.do?apiKey=YTA3Nzg0NTEwM2I2NDdhMmEyYzJjOTY4ZTcwMTI0Njk%3D&endPrdDe=eProd&format=sdmx&method=getList&prdSe=period&startPrdDe=sProd&type=StructureSpecific&userStatsId=istans%2F392%2FDT_AA124%2F3%2F4%2F20180411105926&version=v2_1"
+      }
+    },
+    {
+      "rule_id": "kosis-err-20-missing-required-parameter",
+      "status": "verified",
+      "match": {
+        "kind": "field_equals",
+        "field": "err",
+        "value": "20",
         "case_sensitive": false
       },
       "classification": "bad_request",
@@ -63,7 +103,7 @@
           "target": "registry-release",
           "action": "refresh_verification",
           "automation": "manual_review",
-          "reason": "KOSIS endpoints have operation-specific required parameters such as apiKey, vwCd, parentListId, and format; sample requests should be refreshed before changing parser code."
+          "reason": "KOSIS official OpenAPI responses use err=20 when required request variables are missing. Refresh operation-specific sample parameters before changing parser code."
         }
       ],
       "impact_categories": [
@@ -71,7 +111,7 @@
         "required_params_changed"
       ],
       "evidence": {
-        "reference_url": "https://kosis.kr/openapi/devGuide/devGuide_0101List.do"
+        "reference_url": "https://kosis.kr/openapi/statisticsData.do?apiKey=MzgwMjk2MzU0YWM5NzlmOTJjYzY2Yzk1ODkxOWJmYzA%3D&method=getList"
       }
     },
     {
@@ -116,19 +156,19 @@
       ]
     },
     {
-      "rule_id": "kosis-parse-error-unknown",
+      "rule_id": "kosis-parse-error",
       "status": "draft",
       "match": {
         "kind": "parse_error"
       },
-      "classification": "unknown",
+      "classification": "parser",
       "severity": "high",
       "actions": [
         {
           "target": "registry-release",
           "action": "investigate",
           "automation": "manual_review",
-          "reason": "KOSIS supports JSON, XML, and SDMX; parse failures need evidence before deciding whether the response contract or parser is wrong."
+          "reason": "KOSIS supports JSON, XML, and SDMX; parse failures are parser evidence unless an official err/errMsg response maps the failure to the KOSIS taxonomy."
         }
       ],
       "impact_categories": [

--- a/reports/kosis/runtime-evidence-plan.json
+++ b/reports/kosis/runtime-evidence-plan.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:22:19Z",
+  "generated_at": "2026-06-30T08:50:44Z",
   "provider": "KOSIS",
   "source_id": "kosis",
   "source_profile": "sources/kosis.json",
@@ -14,7 +14,7 @@
   "summary": {
     "evidence_total": 0,
     "blocking_count": 5,
-    "warning_count": 4,
+    "warning_count": 3,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -71,14 +71,6 @@
       "expected_action": "Materialize a source-scoped KOSIS registry or verification candidate list before collecting evidence.",
       "owner": "registry",
       "status": "open"
-    },
-    {
-      "blocker_id": "source_specific_error_taxonomy_pending",
-      "severity": "warning",
-      "source_profile_field": "errors.taxonomy_status",
-      "expected_action": "Classify KOSIS credential, approval, parameter, provider-contract, and upstream signatures before treating failures as adapter defects.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -115,12 +107,6 @@
       "expected": "KOSIS first-batch sample parameters are pinned.",
       "actual": "runtime.sample_param_policy is manual.",
       "remaining": "Pin official KOSIS sample identifiers for bounded checks."
-    },
-    {
-      "warning_id": "source_runtime_error_taxonomy_pending",
-      "expected": "KOSIS source-specific error taxonomy is verified.",
-      "actual": "errors.taxonomy_status is unknown.",
-      "remaining": "Classify KOSIS error signatures before treating runtime failures as adapter defects."
     }
   ]
 }

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-rollup.v1",
-  "generated_at": "2026-06-30T08:41:37Z",
+  "generated_at": "2026-06-30T08:50:44Z",
   "provider": "multi-source",
   "source_plan_inputs": [
     "reports/ecos/runtime-evidence-plan.json",
@@ -17,7 +17,7 @@
     "skipped": 0,
     "unknown": 0,
     "blocking_count": 20,
-    "warning_count": 15
+    "warning_count": 14
   },
   "sources": [
     {
@@ -49,19 +49,17 @@
       "runtime_evidence_plan": "reports/kosis/runtime-evidence-plan.json",
       "evidence_total": 0,
       "blocking_count": 5,
-      "warning_count": 4,
+      "warning_count": 3,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
         "metadata_only_verification",
         "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned",
-        "source_specific_error_taxonomy_pending"
+        "sample_parameters_not_pinned"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
         "source_runtime_adapter_not_registered",
-        "source_runtime_error_taxonomy_pending",
         "source_runtime_manual_samples_unpinned"
       ],
       "next_action_count": 4
@@ -164,10 +162,9 @@
     },
     {
       "id": "source_specific_error_taxonomy_pending",
-      "count": 3,
+      "count": 2,
       "source_ids": [
         "ecos",
-        "kosis",
         "open_assembly"
       ]
     }
@@ -195,10 +192,9 @@
     },
     {
       "id": "source_runtime_error_taxonomy_pending",
-      "count": 3,
+      "count": 2,
       "source_ids": [
         "ecos",
-        "kosis",
         "open_assembly"
       ]
     },
@@ -242,12 +238,11 @@
       "warning_id": "source_runtime_error_taxonomy_pending",
       "affected_sources": [
         "ecos",
-        "kosis",
         "open_assembly"
       ],
       "expected": "Every checked-in non-data.go.kr source has verified source-specific error taxonomy before failures are classified as adapter defects.",
-      "actual": "3 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
-      "remaining": "Verify source-specific error codes and message fields for ECOS, KOSIS, and Open Assembly."
+      "actual": "2 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
+      "remaining": "Verify source-specific error codes and message fields for ECOS and Open Assembly."
     },
     {
       "warning_id": "source_runtime_manual_samples_unpinned",

--- a/sources/kosis.json
+++ b/sources/kosis.json
@@ -64,7 +64,30 @@
     "schema_policy": "documented"
   },
   "errors": {
-    "taxonomy_status": "unknown"
+    "taxonomy_status": "verified",
+    "status_code_fields": [
+      "err"
+    ],
+    "message_fields": [
+      "errMsg"
+    ],
+    "known_error_codes": [
+      {
+        "code": "10",
+        "message": "Missing authentication key.",
+        "classification": "credential"
+      },
+      {
+        "code": "11",
+        "message": "Invalid authentication key.",
+        "classification": "credential"
+      },
+      {
+        "code": "20",
+        "message": "Missing required request variable.",
+        "classification": "bad_request"
+      }
+    ]
   },
   "runtime": {
     "verification_mode": "metadata_only",


### PR DESCRIPTION
## Summary
- Verify KOSIS `err`/`errMsg` error taxonomy from official KOSIS OpenAPI references.
- Add known KOSIS error codes to `sources/kosis.json`: `10`, `11`, and `20`.
- Promote official `err` error-action rules to `verified`, remove KOSIS taxonomy-pending runtime warning, and update the release-wide rollup.

## Official References
- KOSIS statistics list guide documents required `apiKey`, `vwCd`, `parentId`, and `format`: https://kosis.kr/openapi/devGuide/devGuide_0101List.do
- KOSIS statistics data guide documents required `apiKey`, `userStatsId`, `prdSe`, `orgId`, `tblId`, `itmId`, and related parameters: https://kosis.kr/openapi/devGuide/devGuide_0201List.do
- Official kosis.kr OpenAPI responses expose `err=10` for missing auth key, `err=11` for invalid auth key, and `err=20` for missing required request variables.

## Gap Statement
- Gap reduced: `source_runtime_error_taxonomy_pending` for KOSIS is removed.
- Current rollup state after this PR: `warning_count=14`, and `source_runtime_error_taxonomy_pending` affects `ecos` and `open_assembly` only.
- Remaining gap: KOSIS still has no runtime evidence because adapter registration, credential injection, pinned sample parameters, and source-scoped candidate artifacts remain open.

## Acceptance Evidence
- [x] `python3 scripts/validate-source-profiles.py` passes.
- [x] `python3 scripts/validate-error-action-catalogs.py` passes.
- [x] `python3 scripts/validate-source-runtime-evidence-plans.py` passes and KOSIS has no `source_runtime_error_taxonomy_pending` warning.
- [x] `python3 scripts/validate-source-runtime-evidence-rollup.py` passes and rollup warning count is `14`.

## Explicit Warnings Still Tracked
- `source_runtime_error_taxonomy_pending`: count `2`, sources `ecos`, `open_assembly`
- `non_data_runtime_evidence_not_collected`: count `4`
- `source_runtime_adapter_not_registered`: count `4`
- `source_runtime_manual_samples_unpinned`: count `4`

## Local Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with the materialized local registry copy
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

Closes #69
