### PR TITLE
feat: Verify ECOS error taxonomy

### DIFF
--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -99,9 +99,9 @@ Current strengths:
   and warning IDs instead of treating missing evidence as ready.
 - `reports/source-runtime-evidence-rollup.json` rolls those source runtime
   evidence plans into a release-wide inventory of `4` sources, `0` runtime
-  checks, `20` blocking blockers, and `14` warning instances after Seoul Open
-  Data error taxonomy verification in Gira #67 and KOSIS error taxonomy
-  verification in Gira #69.
+  checks, `20` blocking blockers, and `13` warning instances after Seoul Open
+  Data error taxonomy verification in Gira #67, KOSIS error taxonomy
+  verification in Gira #69, and ECOS error taxonomy verification in Gira #71.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -126,6 +126,8 @@ Current gaps:
   `source_runtime_error_taxonomy_pending` from `4` sources to `3`.
   Gira #69 verifies KOSIS official `err`/`errMsg` taxonomy and reduces
   `source_runtime_error_taxonomy_pending` from `3` sources to `2`.
+  Gira #71 verifies ECOS official `RESULT.CODE`/`RESULT.MESSAGE` taxonomy and
+  reduces `source_runtime_error_taxonomy_pending` from `2` sources to `1`.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -345,6 +347,10 @@ Use this order unless a production failure changes priority:
     warning while leaving remaining non-data runtime evidence blockers explicit.
 19. Verify KOSIS error taxonomy from official `err`/`errMsg` references.
     Tracked by Gira #69; this reduces one more
+    `source_runtime_error_taxonomy_pending` warning while preserving runtime
+    evidence, adapter, and sample-parameter warnings.
+20. Verify ECOS error taxonomy from official `RESULT.CODE`/`RESULT.MESSAGE`
+    references. Tracked by Gira #71; this reduces one more
     `source_runtime_error_taxonomy_pending` warning while preserving runtime
     evidence, adapter, and sample-parameter warnings.
 

--- a/reports/ecos/error-action-catalog.json
+++ b/reports/ecos/error-action-catalog.json
@@ -1,27 +1,28 @@
 {
   "schema_version": "datapan.error-action-catalog.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
+  "generated_at": "2026-06-30T08:59:47Z",
   "provider": "ECOS",
   "source_id": "ecos",
   "source_profile": "sources/ecos.json",
   "summary": {
-    "rules": 5,
+    "rules": 7,
     "blocking_rules": 1,
-    "manual_review_rules": 4,
-    "unknown_signature_rules": 1
+    "manual_review_rules": 6,
+    "unknown_signature_rules": 0
   },
   "rules": [
     {
-      "rule_id": "ecos-auth-key-message",
-      "status": "draft",
+      "rule_id": "ecos-result-info-100-invalid-api-key",
+      "status": "verified",
       "scope": {
         "hosts": [
           "ecos.bok.or.kr"
         ]
       },
       "match": {
-        "kind": "message_contains",
-        "contains": "인증",
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "INFO-100",
         "case_sensitive": false
       },
       "classification": "credential",
@@ -31,13 +32,13 @@
           "target": "registry-release",
           "action": "refresh_verification",
           "automation": "manual_review",
-          "reason": "ECOS uses a path-segment API key. Verify the issued key before routing the failure to parser, schema, or adapter work."
+          "reason": "ECOS official Open API responses use RESULT.CODE=INFO-100 when the path-segment activation key is invalid or missing. Verify credential injection before routing the failure to parser or adapter work."
         },
         {
           "target": "documentation",
           "action": "update_error_taxonomy",
           "automation": "manual_review",
-          "reason": "Keep ECOS credential handling aligned with the official ECOS Open API key flow."
+          "reason": "Keep ECOS RESULT.CODE/RESULT.MESSAGE handling aligned with official ECOS Open API responses."
         }
       ],
       "impact_categories": [
@@ -45,7 +46,71 @@
         "verification_status_changed"
       ],
       "evidence": {
-        "reference_url": "https://ecos.bok.or.kr/api/#/AuthKeyApply"
+        "reference_url": "https://ecos.bok.or.kr/api/StatisticTableList/INVALID/json/kr/1/1"
+      }
+    },
+    {
+      "rule_id": "ecos-result-error-200-invalid-request-type",
+      "status": "verified",
+      "scope": {
+        "hosts": [
+          "ecos.bok.or.kr"
+        ]
+      },
+      "match": {
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-200",
+        "case_sensitive": false
+      },
+      "classification": "bad_request",
+      "severity": "medium",
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "manual_review",
+          "reason": "ECOS official Open API responses use RESULT.CODE=ERROR-200 when the request format/type path segment is missing or invalid. Refresh request construction before changing parser code."
+        }
+      ],
+      "impact_categories": [
+        "required_params_changed",
+        "verification_status_changed"
+      ],
+      "evidence": {
+        "reference_url": "https://ecos.bok.or.kr/api/StatisticTableList/INVALID/badfmt/kr/1/1"
+      }
+    },
+    {
+      "rule_id": "ecos-result-error-301-invalid-count",
+      "status": "verified",
+      "scope": {
+        "hosts": [
+          "ecos.bok.or.kr"
+        ]
+      },
+      "match": {
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-301",
+        "case_sensitive": false
+      },
+      "classification": "bad_request",
+      "severity": "medium",
+      "actions": [
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "manual_review",
+          "reason": "ECOS official Open API responses use RESULT.CODE=ERROR-301 when start/end count path values are invalid. Refresh bounded sample pagination before changing adapter behavior."
+        }
+      ],
+      "impact_categories": [
+        "required_params_changed",
+        "verification_status_changed"
+      ],
+      "evidence": {
+        "reference_url": "https://ecos.bok.or.kr/api/StatisticTableList/INVALID/json/kr/a/b"
       }
     },
     {
@@ -112,19 +177,19 @@
       ]
     },
     {
-      "rule_id": "ecos-parse-error-unknown",
+      "rule_id": "ecos-parse-error",
       "status": "draft",
       "match": {
         "kind": "parse_error"
       },
-      "classification": "unknown",
+      "classification": "parser",
       "severity": "high",
       "actions": [
         {
           "target": "registry-release",
           "action": "investigate",
           "automation": "manual_review",
-          "reason": "ECOS response envelopes are service-specific; parse failures need evidence before classifying response-shape drift or parser failure."
+          "reason": "ECOS supports JSON and XML RESULT envelopes; parse failures are parser evidence unless an official RESULT.CODE maps the failure to the ECOS taxonomy."
         }
       ],
       "impact_categories": [

--- a/reports/ecos/runtime-evidence-plan.json
+++ b/reports/ecos/runtime-evidence-plan.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:22:19Z",
+  "generated_at": "2026-06-30T08:59:47Z",
   "provider": "ECOS",
   "source_id": "ecos",
   "source_profile": "sources/ecos.json",
@@ -10,12 +10,12 @@
       "https://ecos.bok.or.kr/api/#/",
       "https://ecos.bok.or.kr/api/#/AuthKeyApply"
     ],
-    "last_reviewed_at": "2026-06-29"
+    "last_reviewed_at": "2026-06-30"
   },
   "summary": {
     "evidence_total": 0,
     "blocking_count": 5,
-    "warning_count": 4,
+    "warning_count": 3,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -72,14 +72,6 @@
       "expected_action": "Materialize a source-scoped ECOS registry or verification candidate list before collecting evidence.",
       "owner": "registry",
       "status": "open"
-    },
-    {
-      "blocker_id": "source_specific_error_taxonomy_pending",
-      "severity": "warning",
-      "source_profile_field": "errors.taxonomy_status",
-      "expected_action": "Classify ECOS credential, parameter, provider-contract, and upstream signatures before treating failures as adapter defects.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -116,12 +108,6 @@
       "expected": "ECOS first-batch sample parameters are pinned.",
       "actual": "runtime.sample_param_policy is manual.",
       "remaining": "Pin official ECOS sample identifiers for bounded checks."
-    },
-    {
-      "warning_id": "source_runtime_error_taxonomy_pending",
-      "expected": "ECOS source-specific error taxonomy is verified.",
-      "actual": "errors.taxonomy_status is unknown.",
-      "remaining": "Classify ECOS error signatures before treating runtime failures as adapter defects."
     }
   ]
 }

--- a/reports/source-reference-drift.json
+++ b/reports/source-reference-drift.json
@@ -57,12 +57,12 @@
       "source_id": "ecos",
       "provider": "ECOS",
       "source_profile": "sources/ecos.json",
-      "last_reviewed_at": "2026-06-29",
+      "last_reviewed_at": "2026-06-30",
       "references": [
         {
           "kind": "homepage_url",
           "url": "https://ecos.bok.or.kr/api/",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["source_identity"]
@@ -70,7 +70,7 @@
         {
           "kind": "api_docs_url",
           "url": "https://ecos.bok.or.kr/api/#/",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["catalogue", "auth", "runtime"]
@@ -78,13 +78,13 @@
         {
           "kind": "key_request_url",
           "url": "https://ecos.bok.or.kr/api/#/AuthKeyApply",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["auth"]
         }
       ],
-      "notes": "Manual baseline only; ECOS runtime verification is a separate future task."
+      "notes": "Manual baseline only; ECOS error taxonomy was reviewed from official RESULT.CODE/RESULT.MESSAGE responses, and runtime verification is a separate future task."
     },
     {
       "source_id": "kosis",

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-rollup.v1",
-  "generated_at": "2026-06-30T08:50:44Z",
+  "generated_at": "2026-06-30T08:59:47Z",
   "provider": "multi-source",
   "source_plan_inputs": [
     "reports/ecos/runtime-evidence-plan.json",
@@ -17,7 +17,7 @@
     "skipped": 0,
     "unknown": 0,
     "blocking_count": 20,
-    "warning_count": 14
+    "warning_count": 13
   },
   "sources": [
     {
@@ -26,19 +26,17 @@
       "runtime_evidence_plan": "reports/ecos/runtime-evidence-plan.json",
       "evidence_total": 0,
       "blocking_count": 5,
-      "warning_count": 4,
+      "warning_count": 3,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
         "metadata_only_verification",
         "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned",
-        "source_specific_error_taxonomy_pending"
+        "sample_parameters_not_pinned"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
         "source_runtime_adapter_not_registered",
-        "source_runtime_error_taxonomy_pending",
         "source_runtime_manual_samples_unpinned"
       ],
       "next_action_count": 4
@@ -162,9 +160,8 @@
     },
     {
       "id": "source_specific_error_taxonomy_pending",
-      "count": 2,
+      "count": 1,
       "source_ids": [
-        "ecos",
         "open_assembly"
       ]
     }
@@ -192,9 +189,8 @@
     },
     {
       "id": "source_runtime_error_taxonomy_pending",
-      "count": 2,
+      "count": 1,
       "source_ids": [
-        "ecos",
         "open_assembly"
       ]
     },
@@ -237,12 +233,11 @@
     {
       "warning_id": "source_runtime_error_taxonomy_pending",
       "affected_sources": [
-        "ecos",
         "open_assembly"
       ],
       "expected": "Every checked-in non-data.go.kr source has verified source-specific error taxonomy before failures are classified as adapter defects.",
-      "actual": "2 of 4 non-data.go.kr sources have unknown or draft error taxonomy status.",
-      "remaining": "Verify source-specific error codes and message fields for ECOS and Open Assembly."
+      "actual": "1 of 4 non-data.go.kr sources has unknown or draft error taxonomy status.",
+      "remaining": "Verify source-specific error codes and message fields for Open Assembly."
     },
     {
       "warning_id": "source_runtime_manual_samples_unpinned",

--- a/sources/ecos.json
+++ b/sources/ecos.json
@@ -16,7 +16,7 @@
     "homepage_url": "https://ecos.bok.or.kr/api/",
     "api_docs_url": "https://ecos.bok.or.kr/api/#/",
     "key_request_url": "https://ecos.bok.or.kr/api/#/AuthKeyApply",
-    "last_reviewed_at": "2026-06-29"
+    "last_reviewed_at": "2026-06-30"
   },
   "catalogue": {
     "model": "statistics",
@@ -71,7 +71,30 @@
     "schema_policy": "documented"
   },
   "errors": {
-    "taxonomy_status": "unknown"
+    "taxonomy_status": "verified",
+    "status_code_fields": [
+      "RESULT.CODE"
+    ],
+    "message_fields": [
+      "RESULT.MESSAGE"
+    ],
+    "known_error_codes": [
+      {
+        "code": "INFO-100",
+        "message": "Invalid activation key.",
+        "classification": "credential"
+      },
+      {
+        "code": "ERROR-200",
+        "message": "Missing or invalid request type value.",
+        "classification": "bad_request"
+      },
+      {
+        "code": "ERROR-301",
+        "message": "Invalid query count value or invalid start/end count range.",
+        "classification": "bad_request"
+      }
+    ]
   },
   "runtime": {
     "verification_mode": "metadata_only",


### PR DESCRIPTION
## Summary
- Verify ECOS `RESULT.CODE` / `RESULT.MESSAGE` error taxonomy from official Bank of Korea ECOS Open API endpoints.
- Add verified ECOS error codes to `sources/ecos.json`: `INFO-100`, `ERROR-200`, and `ERROR-301`.
- Promote official ECOS RESULT-envelope rules to `verified`, remove ECOS taxonomy-pending runtime warning, and update the release-wide rollup.

## Official References
- ECOS Open API homepage and docs: https://ecos.bok.or.kr/api/
- ECOS key request page: https://ecos.bok.or.kr/api/#/AuthKeyApply
- Official ECOS Open API responses expose JSON/XML `RESULT.CODE` and `RESULT.MESSAGE` envelopes.
- Observed official response signatures used in this PR:
  - `INFO-100`: invalid or missing activation key, from `https://ecos.bok.or.kr/api/StatisticTableList/INVALID/json/kr/1/1`
  - `ERROR-200`: missing or invalid request type/format, from `https://ecos.bok.or.kr/api/StatisticTableList/INVALID/badfmt/kr/1/1`
  - `ERROR-301`: invalid query count/start-end values, from `https://ecos.bok.or.kr/api/StatisticTableList/INVALID/json/kr/a/b`

## Gap Statement
- Gap reduced: `source_runtime_error_taxonomy_pending` for ECOS is removed.
- Current rollup state after this PR: `warning_count=13`, and `source_runtime_error_taxonomy_pending` affects `open_assembly` only.
- Remaining gap: ECOS still has no runtime evidence because adapter registration, credential injection, pinned sample parameters, and source-scoped candidate artifacts remain open.

## Acceptance Evidence
- [x] Official ECOS reference URLs for error/status response fields are recorded in the profile/catalog evidence.
- [x] `python3 scripts/validate-source-profiles.py` passes.
- [x] `python3 scripts/validate-error-action-catalogs.py` passes.
- [x] `python3 scripts/validate-source-runtime-evidence-plans.py` passes and ECOS has no `source_runtime_error_taxonomy_pending` warning.
- [x] `python3 scripts/validate-source-runtime-evidence-rollup.py` passes and rollup warning count is `13`.

## Explicit Warnings Still Tracked
- `source_runtime_error_taxonomy_pending`: count `1`, source `open_assembly`
- `non_data_runtime_evidence_not_collected`: count `4`
- `source_runtime_adapter_not_registered`: count `4`
- `source_runtime_manual_samples_unpinned`: count `4`

## Local Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with the materialized local registry copy
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

Closes #71