### PR TITLE
feat: Verify Open Assembly error taxonomy

### DIFF
--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -99,9 +99,10 @@ Current strengths:
   and warning IDs instead of treating missing evidence as ready.
 - `reports/source-runtime-evidence-rollup.json` rolls those source runtime
   evidence plans into a release-wide inventory of `4` sources, `0` runtime
-  checks, `20` blocking blockers, and `13` warning instances after Seoul Open
+  checks, `20` blocking blockers, and `12` warning instances after Seoul Open
   Data error taxonomy verification in Gira #67, KOSIS error taxonomy
-  verification in Gira #69, and ECOS error taxonomy verification in Gira #71.
+  verification in Gira #69, ECOS error taxonomy verification in Gira #71, and
+  Open Assembly error taxonomy verification in Gira #73.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -128,6 +129,9 @@ Current gaps:
   `source_runtime_error_taxonomy_pending` from `3` sources to `2`.
   Gira #71 verifies ECOS official `RESULT.CODE`/`RESULT.MESSAGE` taxonomy and
   reduces `source_runtime_error_taxonomy_pending` from `2` sources to `1`.
+  Gira #73 verifies Open Assembly official `RESULT.CODE`/`RESULT.MESSAGE`
+  taxonomy and reduces `source_runtime_error_taxonomy_pending` from `1` source
+  to `0`.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -353,6 +357,10 @@ Use this order unless a production failure changes priority:
     references. Tracked by Gira #71; this reduces one more
     `source_runtime_error_taxonomy_pending` warning while preserving runtime
     evidence, adapter, and sample-parameter warnings.
+21. Verify Open Assembly error taxonomy from official
+    `RESULT.CODE`/`RESULT.MESSAGE` references. Tracked by Gira #73; this clears
+    the remaining `source_runtime_error_taxonomy_pending` warning while
+    preserving runtime evidence, adapter, and sample-parameter warnings.
 
 ## Measurement Rules
 

--- a/reports/open-assembly/error-action-catalog.json
+++ b/reports/open-assembly/error-action-catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.error-action-catalog.v1",
-  "generated_at": "2026-06-29T00:00:00Z",
+  "generated_at": "2026-06-30T09:06:52Z",
   "provider": "open.assembly.go.kr",
   "source_id": "open_assembly",
   "source_profile": "sources/open_assembly.json",
@@ -8,21 +8,21 @@
     "rules": 5,
     "blocking_rules": 1,
     "manual_review_rules": 4,
-    "unknown_signature_rules": 1
+    "unknown_signature_rules": 0
   },
   "rules": [
     {
-      "rule_id": "open-assembly-key-message",
-      "status": "draft",
+      "rule_id": "open-assembly-result-error-290-invalid-api-key",
+      "status": "verified",
       "scope": {
         "hosts": [
           "open.assembly.go.kr"
         ]
       },
       "match": {
-        "kind": "field_contains",
-        "field": "RESULT.MESSAGE",
-        "contains": "KEY",
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-290",
         "case_sensitive": false
       },
       "classification": "credential",
@@ -32,13 +32,13 @@
           "target": "registry-release",
           "action": "refresh_verification",
           "automation": "manual_review",
-          "reason": "Open Assembly uses a KEY query parameter. Verify credential and service approval before routing to parser or adapter work."
+          "reason": "Open Assembly official Open API responses use RESULT.CODE=ERROR-290 when the KEY query parameter is invalid or missing. Verify credential injection before routing the failure to parser or adapter work."
         },
         {
           "target": "documentation",
           "action": "update_error_taxonomy",
           "automation": "manual_review",
-          "reason": "Keep Open Assembly credential handling tied to its source-specific KEY parameter contract."
+          "reason": "Keep Open Assembly RESULT.CODE/RESULT.MESSAGE handling tied to its source-specific KEY parameter contract."
         }
       ],
       "impact_categories": [
@@ -46,32 +46,35 @@
         "verification_status_changed"
       ],
       "evidence": {
-        "reference_url": "https://open.assembly.go.kr/portal/openapi/main.do"
+        "reference_url": "https://open.assembly.go.kr/portal/openapi/OPENSRVAPI?KEY=INVALID&Type=json&pIndex=1&pSize=1"
       }
     },
     {
-      "rule_id": "open-assembly-required-parameter-message",
-      "status": "draft",
+      "rule_id": "open-assembly-result-error-310-service-not-found",
+      "status": "verified",
       "match": {
-        "kind": "field_contains",
-        "field": "RESULT.MESSAGE",
-        "contains": "필수",
+        "kind": "field_equals",
+        "field": "RESULT.CODE",
+        "value": "ERROR-310",
         "case_sensitive": false
       },
-      "classification": "bad_request",
+      "classification": "not_found",
       "severity": "medium",
       "actions": [
         {
           "target": "registry-release",
           "action": "refresh_verification",
           "automation": "manual_review",
-          "reason": "Refresh Open Assembly sample parameters such as service id, AGE, pIndex, and pSize before changing downstream parser or schema behavior."
+          "reason": "Open Assembly official Open API responses use RESULT.CODE=ERROR-310 when the requested service path is not found. Verify service IDs before changing parser or adapter behavior."
         }
       ],
       "impact_categories": [
-        "required_params_changed",
+        "endpoint_changed",
         "verification_status_changed"
-      ]
+      ],
+      "evidence": {
+        "reference_url": "https://open.assembly.go.kr/portal/openapi/NO_SUCH_SERVICE?KEY=INVALID&Type=json&pIndex=1&pSize=1"
+      }
     },
     {
       "rule_id": "open-assembly-http-429",
@@ -115,19 +118,19 @@
       ]
     },
     {
-      "rule_id": "open-assembly-parse-error-unknown",
+      "rule_id": "open-assembly-parse-error",
       "status": "draft",
       "match": {
         "kind": "parse_error"
       },
-      "classification": "unknown",
+      "classification": "parser",
       "severity": "high",
       "actions": [
         {
           "target": "registry-release",
           "action": "investigate",
           "automation": "manual_review",
-          "reason": "Open Assembly supports XML and JSON response modes; parse failures need evidence before classifying response-shape drift or parser failure."
+          "reason": "Open Assembly supports XML and JSON RESULT envelopes; parse failures are parser evidence unless an official RESULT.CODE maps the failure to the Open Assembly taxonomy."
         }
       ],
       "impact_categories": [

--- a/reports/open-assembly/runtime-evidence-plan.json
+++ b/reports/open-assembly/runtime-evidence-plan.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:22:19Z",
+  "generated_at": "2026-06-30T09:06:52Z",
   "provider": "open.assembly.go.kr",
   "source_id": "open_assembly",
   "source_profile": "sources/open_assembly.json",
@@ -9,12 +9,12 @@
       "https://open.assembly.go.kr/portal/mainPage.do",
       "https://open.assembly.go.kr/portal/openapi/main.do"
     ],
-    "last_reviewed_at": "2026-06-29"
+    "last_reviewed_at": "2026-06-30"
   },
   "summary": {
     "evidence_total": 0,
     "blocking_count": 5,
-    "warning_count": 4,
+    "warning_count": 3,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -71,14 +71,6 @@
       "expected_action": "Materialize a source-scoped Open Assembly registry or verification candidate list before collecting evidence.",
       "owner": "registry",
       "status": "open"
-    },
-    {
-      "blocker_id": "source_specific_error_taxonomy_pending",
-      "severity": "warning",
-      "source_profile_field": "errors.taxonomy_status",
-      "expected_action": "Finish Open Assembly error taxonomy verification before treating provider RESULT codes as adapter defects.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -115,12 +107,6 @@
       "expected": "Open Assembly first-batch sample parameters are pinned.",
       "actual": "runtime.sample_param_policy is manual.",
       "remaining": "Pin official Open Assembly sample identifiers for bounded checks."
-    },
-    {
-      "warning_id": "source_runtime_error_taxonomy_pending",
-      "expected": "Open Assembly source-specific error taxonomy is verified.",
-      "actual": "errors.taxonomy_status is draft.",
-      "remaining": "Verify Open Assembly RESULT code classifications before treating runtime failures as adapter defects."
     }
   ]
 }

--- a/reports/source-reference-drift.json
+++ b/reports/source-reference-drift.json
@@ -123,12 +123,12 @@
       "source_id": "open_assembly",
       "provider": "open.assembly.go.kr",
       "source_profile": "sources/open_assembly.json",
-      "last_reviewed_at": "2026-06-29",
+      "last_reviewed_at": "2026-06-30",
       "references": [
         {
           "kind": "homepage_url",
           "url": "https://open.assembly.go.kr/portal/mainPage.do",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["source_identity"]
@@ -136,7 +136,7 @@
         {
           "kind": "api_docs_url",
           "url": "https://open.assembly.go.kr/portal/openapi/main.do",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["catalogue", "auth", "runtime"]
@@ -144,13 +144,13 @@
         {
           "kind": "key_request_url",
           "url": "https://open.assembly.go.kr/portal/mainPage.do",
-          "reviewed_at": "2026-06-29",
+          "reviewed_at": "2026-06-30",
           "check_mode": "manual_review",
           "drift_status": "baseline",
           "contract_impact": ["auth"]
         }
       ],
-      "notes": "Manual baseline only; Open Assembly runtime verification is a separate future task."
+      "notes": "Manual baseline only; Open Assembly error taxonomy was reviewed from official RESULT.CODE/RESULT.MESSAGE responses, and runtime verification is a separate future task."
     },
     {
       "source_id": "seoul_open_data",

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-rollup.v1",
-  "generated_at": "2026-06-30T08:59:47Z",
+  "generated_at": "2026-06-30T09:06:52Z",
   "provider": "multi-source",
   "source_plan_inputs": [
     "reports/ecos/runtime-evidence-plan.json",
@@ -17,7 +17,7 @@
     "skipped": 0,
     "unknown": 0,
     "blocking_count": 20,
-    "warning_count": 13
+    "warning_count": 12
   },
   "sources": [
     {
@@ -68,19 +68,17 @@
       "runtime_evidence_plan": "reports/open-assembly/runtime-evidence-plan.json",
       "evidence_total": 0,
       "blocking_count": 5,
-      "warning_count": 4,
+      "warning_count": 3,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
         "metadata_only_verification",
         "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned",
-        "source_specific_error_taxonomy_pending"
+        "sample_parameters_not_pinned"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
         "source_runtime_adapter_not_registered",
-        "source_runtime_error_taxonomy_pending",
         "source_runtime_manual_samples_unpinned"
       ],
       "next_action_count": 4
@@ -157,13 +155,6 @@
         "open_assembly",
         "seoul_open_data"
       ]
-    },
-    {
-      "id": "source_specific_error_taxonomy_pending",
-      "count": 1,
-      "source_ids": [
-        "open_assembly"
-      ]
     }
   ],
   "warnings_by_id": [
@@ -185,13 +176,6 @@
         "kosis",
         "open_assembly",
         "seoul_open_data"
-      ]
-    },
-    {
-      "id": "source_runtime_error_taxonomy_pending",
-      "count": 1,
-      "source_ids": [
-        "open_assembly"
       ]
     },
     {
@@ -229,15 +213,6 @@
       "expected": "Every checked-in non-data.go.kr source has verification and call adapter capabilities before runtime evidence collection.",
       "actual": "4 of 4 non-data.go.kr sources have no registered runtime adapter.",
       "remaining": "Register source-specific adapters for ECOS, KOSIS, Open Assembly, and Seoul Open Data."
-    },
-    {
-      "warning_id": "source_runtime_error_taxonomy_pending",
-      "affected_sources": [
-        "open_assembly"
-      ],
-      "expected": "Every checked-in non-data.go.kr source has verified source-specific error taxonomy before failures are classified as adapter defects.",
-      "actual": "1 of 4 non-data.go.kr sources has unknown or draft error taxonomy status.",
-      "remaining": "Verify source-specific error codes and message fields for Open Assembly."
     },
     {
       "warning_id": "source_runtime_manual_samples_unpinned",

--- a/sources/open_assembly.json
+++ b/sources/open_assembly.json
@@ -16,7 +16,7 @@
     "homepage_url": "https://open.assembly.go.kr/portal/mainPage.do",
     "api_docs_url": "https://open.assembly.go.kr/portal/openapi/main.do",
     "key_request_url": "https://open.assembly.go.kr/portal/mainPage.do",
-    "last_reviewed_at": "2026-06-29"
+    "last_reviewed_at": "2026-06-30"
   },
   "catalogue": {
     "model": "legislative",
@@ -66,12 +66,24 @@
     "schema_policy": "documented"
   },
   "errors": {
-    "taxonomy_status": "draft",
+    "taxonomy_status": "verified",
     "status_code_fields": [
       "RESULT.CODE"
     ],
     "message_fields": [
       "RESULT.MESSAGE"
+    ],
+    "known_error_codes": [
+      {
+        "code": "ERROR-290",
+        "message": "Invalid or missing Open Assembly API key.",
+        "classification": "credential"
+      },
+      {
+        "code": "ERROR-310",
+        "message": "Requested Open Assembly service not found.",
+        "classification": "not_found"
+      }
     ]
   },
   "runtime": {


### PR DESCRIPTION
## Summary
- Verify Open Assembly `RESULT.CODE` / `RESULT.MESSAGE` error taxonomy from official open.assembly.go.kr Open API responses.
- Add verified Open Assembly error codes to `sources/open_assembly.json`: `ERROR-290` and `ERROR-310`.
- Promote official RESULT-envelope rules to `verified`, remove the final taxonomy-pending runtime warning, and update the release-wide rollup.

## Official References
- Open Assembly Open API docs: https://open.assembly.go.kr/portal/openapi/main.do
- Open Assembly OPENSRVAPI endpoint: https://open.assembly.go.kr/portal/openapi/OPENSRVAPI
- Public Data Portal metadata page for the Open Assembly API catalog: https://www.data.go.kr/data/15125891/openapi.do?recommendDataYn=Y
- Official Open Assembly responses expose JSON/XML `RESULT.CODE` and `RESULT.MESSAGE` envelopes.
- Observed official response signatures used in this PR:
  - `ERROR-290`: invalid or missing KEY, from `https://open.assembly.go.kr/portal/openapi/OPENSRVAPI?KEY=INVALID&Type=json&pIndex=1&pSize=1`
  - `ERROR-310`: service not found, from `https://open.assembly.go.kr/portal/openapi/NO_SUCH_SERVICE?KEY=INVALID&Type=json&pIndex=1&pSize=1`
  - `INFO-000`: normal result observed for `OPENSRVAPI` without KEY; not added as an error-action rule.

## Gap Statement
- Gap reduced: `source_runtime_error_taxonomy_pending` for Open Assembly is removed.
- Current rollup state after this PR: `warning_count=12`, and `source_runtime_error_taxonomy_pending` affects zero sources.
- Remaining gaps are not dismissed: all four non-data sources still lack runtime evidence, registered adapters, and pinned manual samples.

## Acceptance Evidence
- [x] Official Open Assembly reference URLs for RESULT code/message fields are recorded in the profile/catalog evidence.
- [x] `python3 scripts/validate-source-profiles.py` passes.
- [x] `python3 scripts/validate-error-action-catalogs.py` passes.
- [x] `python3 scripts/validate-source-runtime-evidence-plans.py` passes and Open Assembly has no `source_runtime_error_taxonomy_pending` warning.
- [x] `python3 scripts/validate-source-runtime-evidence-rollup.py` passes and rollup warning count is `12`.

## Explicit Warnings Still Tracked
- `non_data_runtime_evidence_not_collected`: count `4`
- `source_runtime_adapter_not_registered`: count `4`
- `source_runtime_manual_samples_unpinned`: count `4`
- `source_runtime_error_taxonomy_pending`: count `0`, removed from rollup warning inventory

## Local Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with the materialized local registry copy
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

Closes #73