### PR TITLE
feat: Add non-data source runtime candidate batches

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -83,6 +83,7 @@ jobs:
           python scripts/validate-external-coverage.py
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
+          python scripts/validate-source-runtime-candidates.py
           python scripts/validate-source-runtime-evidence-plans.py
           python scripts/validate-source-runtime-evidence-rollup.py
           python scripts/validate-runtime-evidence-growth.py

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -56,6 +56,7 @@ jobs:
           python scripts/validate-external-coverage.py
           python scripts/validate-impact-plans.py
           python scripts/validate-source-reference-drift.py
+          python scripts/validate-source-runtime-candidates.py
           python scripts/validate-source-runtime-evidence-plans.py
           python scripts/validate-source-runtime-evidence-rollup.py
           python scripts/validate-runtime-evidence-growth.py

--- a/docs/multi-source-release-layout.md
+++ b/docs/multi-source-release-layout.md
@@ -154,6 +154,7 @@ Recommended source-scoped reports:
 - `adapter-targets.json`
 - `route-disposition.json`
 - `verification-plan.json`
+- `runtime-candidates.json`
 - `runtime-evidence-plan.json`
 - `latest-verification.json`
 - `latest-verification-summary.json`

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -97,12 +97,18 @@ Current strengths:
   `reports/seoul-open-data/runtime-evidence-plan.json` record the first
   non-data.go.kr sources as `0` runtime-evidence sources with explicit blocker
   and warning IDs instead of treating missing evidence as ready.
+- `reports/kosis/runtime-candidates.json`,
+  `reports/ecos/runtime-candidates.json`,
+  `reports/open-assembly/runtime-candidates.json`, and
+  `reports/seoul-open-data/runtime-candidates.json` pin official first-batch
+  runtime candidates without claiming that runtime evidence has been collected.
 - `reports/source-runtime-evidence-rollup.json` rolls those source runtime
   evidence plans into a release-wide inventory of `4` sources, `0` runtime
-  checks, `20` blocking blockers, and `12` warning instances after Seoul Open
+  checks, `12` blocking blockers, and `8` warning instances after Seoul Open
   Data error taxonomy verification in Gira #67, KOSIS error taxonomy
   verification in Gira #69, ECOS error taxonomy verification in Gira #71, and
-  Open Assembly error taxonomy verification in Gira #73.
+  Open Assembly error taxonomy verification in Gira #73, then runtime
+  candidate batch pinning in Gira #75.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -132,6 +138,12 @@ Current gaps:
   Gira #73 verifies Open Assembly official `RESULT.CODE`/`RESULT.MESSAGE`
   taxonomy and reduces `source_runtime_error_taxonomy_pending` from `1` source
   to `0`.
+  Gira #75 pins official runtime candidate batches for KOSIS, ECOS, Open
+  Assembly, and Seoul Open Data, reducing
+  `source_runtime_manual_samples_unpinned` from `4` sources to `0` and removing
+  `sample_parameters_not_pinned`/`runtime_catalog_not_materialized` blockers
+  for the candidate-batch stage. Actual runtime evidence remains `0` for each
+  source until adapters, credentials, and bounded runtime runs exist.
 - Runtime evidence coverage is much lower than callable coverage. Gira #19,
   Gira #21, Gira #23, Gira #25, Gira #27, Gira #29, Gira #31, Gira #33, and
   Gira #35 raise data.go.kr runtime evidence from `256` to `626`. Gira #39,
@@ -361,6 +373,10 @@ Use this order unless a production failure changes priority:
     `RESULT.CODE`/`RESULT.MESSAGE` references. Tracked by Gira #73; this clears
     the remaining `source_runtime_error_taxonomy_pending` warning while
     preserving runtime evidence, adapter, and sample-parameter warnings.
+22. Add non-data source runtime candidate batches for KOSIS, ECOS, Open
+    Assembly, and Seoul Open Data. Tracked by Gira #75; this validates pinned
+    registry-only first-batch candidates, clears manual sample warnings, and
+    leaves runtime evidence collection gated by adapters and credentials.
 
 ## Measurement Rules
 

--- a/reports/ecos/runtime-candidates.json
+++ b/reports/ecos/runtime-candidates.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "datapan.source-runtime-candidates.v1",
+  "generated_at": "2026-06-30T09:16:13Z",
+  "provider": "ECOS",
+  "source_id": "ecos",
+  "source_profile": "sources/ecos.json",
+  "references": {
+    "official_reference_urls": [
+      "https://ecos.bok.or.kr/api/",
+      "https://ecos.bok.or.kr/api/#/",
+      "https://ecos.bok.or.kr/api/#/AuthKeyApply"
+    ],
+    "last_reviewed_at": "2026-06-30"
+  },
+  "summary": {
+    "candidates": 1,
+    "pinned_sample_count": 1,
+    "credential_required": true,
+    "evidence_total": 0
+  },
+  "candidates": [
+    {
+      "candidate_id": "ecos-statistic-search-102y004",
+      "label": "ECOS monthly statistic search bounded query",
+      "operation_kind": "data_query",
+      "method": "GET",
+      "endpoint_template": "https://ecos.bok.or.kr/api/StatisticSearch/{apiKey}/json/kr/{startCount}/{endCount}/{statCode}/{cycle}/{startDate}/{endDate}/{itemCode}",
+      "format": "json",
+      "sample_parameters": {
+        "apiKey": "${ECOS_API_KEY}",
+        "startCount": "1",
+        "endCount": "10",
+        "statCode": "102Y004",
+        "cycle": "M",
+        "startDate": "202401",
+        "endDate": "202401",
+        "itemCode": "ABA1"
+      },
+      "credential_policy": {
+        "required": true,
+        "key_names": [
+          "apiKey"
+        ],
+        "injection_location": "path",
+        "placeholder": "${ECOS_API_KEY}"
+      },
+      "expected_response": {
+        "envelope_path": "StatisticSearch",
+        "items_path": "StatisticSearch.row"
+      },
+      "evidence_status": "not_collected",
+      "promotion_status": "registry_only",
+      "reference_url": "https://ecos.bok.or.kr/api/#/",
+      "notes": "Pinned from the official ECOS StatisticSearch path model and known 102Y004 monthly sample usage; credentialed runtime execution remains blocked until key injection is available."
+    }
+  ]
+}

--- a/reports/ecos/runtime-evidence-plan.json
+++ b/reports/ecos/runtime-evidence-plan.json
@@ -1,9 +1,10 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:59:47Z",
+  "generated_at": "2026-06-30T09:16:13Z",
   "provider": "ECOS",
   "source_id": "ecos",
   "source_profile": "sources/ecos.json",
+  "candidate_batch": "reports/ecos/runtime-candidates.json",
   "references": {
     "official_reference_urls": [
       "https://ecos.bok.or.kr/api/",
@@ -14,8 +15,8 @@
   },
   "summary": {
     "evidence_total": 0,
-    "blocking_count": 5,
-    "warning_count": 3,
+    "blocking_count": 3,
+    "warning_count": 2,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -30,7 +31,7 @@
     "adapter_capabilities": [],
     "auth_type": "api_key",
     "credential_required": true,
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "blockers": [
     {
@@ -56,22 +57,6 @@
       "expected_action": "Define a non-secret API key injection path for source-scoped CI and local bounded checks.",
       "owner": "operator",
       "status": "open"
-    },
-    {
-      "blocker_id": "sample_parameters_not_pinned",
-      "severity": "blocking",
-      "source_profile_field": "runtime.sample_param_policy",
-      "expected_action": "Pin at least one statCode, cycle, startDate, endDate, and itemCode sample for a bounded first batch.",
-      "owner": "registry",
-      "status": "open"
-    },
-    {
-      "blocker_id": "runtime_catalog_not_materialized",
-      "severity": "blocking",
-      "source_profile_field": "catalogue.identity_fields",
-      "expected_action": "Materialize a source-scoped ECOS registry or verification candidate list before collecting evidence.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -82,7 +67,7 @@
       "reports/ecos/verification-plan.json"
     ],
     "required_cli_capabilities": [
-      "source-scoped registry input",
+      "runtime candidate batch ingestion",
       "ECOS bounded sample-call adapter",
       "source credential injection",
       "ECOS error signature extraction"
@@ -93,21 +78,15 @@
   "warnings": [
     {
       "warning_id": "non_data_runtime_evidence_not_collected",
-      "expected": "ECOS has source-scoped runtime evidence after adapter and sample parameters are pinned.",
+      "expected": "ECOS has source-scoped runtime evidence after the pinned candidate batch, adapter, and credential injection are available.",
       "actual": "0 runtime checks are collected for ECOS.",
-      "remaining": "Create the ECOS source registry/candidate list and run the first bounded verification batch."
+      "remaining": "Use reports/ecos/runtime-candidates.json with a registered adapter and credentials to run the first bounded verification batch."
     },
     {
       "warning_id": "source_runtime_adapter_not_registered",
       "expected": "ECOS adapter has verification and call capabilities.",
       "actual": "adapter.status is none and adapter_capabilities is empty.",
       "remaining": "Register the ECOS adapter before evidence collection."
-    },
-    {
-      "warning_id": "source_runtime_manual_samples_unpinned",
-      "expected": "ECOS first-batch sample parameters are pinned.",
-      "actual": "runtime.sample_param_policy is manual.",
-      "remaining": "Pin official ECOS sample identifiers for bounded checks."
     }
   ]
 }

--- a/reports/kosis/runtime-candidates.json
+++ b/reports/kosis/runtime-candidates.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "datapan.source-runtime-candidates.v1",
+  "generated_at": "2026-06-30T09:16:13Z",
+  "provider": "KOSIS",
+  "source_id": "kosis",
+  "source_profile": "sources/kosis.json",
+  "references": {
+    "official_reference_urls": [
+      "https://kosis.kr/openapi/devGuide/devGuide_0101List.do",
+      "https://kosis.kr/openapi/index/index.jsp"
+    ],
+    "last_reviewed_at": "2026-06-29"
+  },
+  "summary": {
+    "candidates": 1,
+    "pinned_sample_count": 1,
+    "credential_required": true,
+    "evidence_total": 0
+  },
+  "candidates": [
+    {
+      "candidate_id": "kosis-statistics-data-dt-1b41",
+      "label": "KOSIS population table bounded data query",
+      "operation_kind": "data_query",
+      "method": "GET",
+      "endpoint_template": "https://kosis.kr/openapi/statisticsData.do?method=getList",
+      "format": "json",
+      "sample_parameters": {
+        "apiKey": "${KOSIS_API_KEY}",
+        "format": "json",
+        "jsonVD": "Y",
+        "orgId": "101",
+        "tblId": "DT_1B41",
+        "prdSe": "Y",
+        "newEstPrdCnt": "3",
+        "itmId": "T1",
+        "objL1": "ALL"
+      },
+      "credential_policy": {
+        "required": true,
+        "key_names": [
+          "apiKey"
+        ],
+        "injection_location": "query",
+        "placeholder": "${KOSIS_API_KEY}"
+      },
+      "expected_response": {
+        "items_path": "<root>"
+      },
+      "evidence_status": "not_collected",
+      "promotion_status": "registry_only",
+      "reference_url": "https://kosis.kr/openapi/devGuide/devGuide_0201List.do",
+      "notes": "Pinned from official KOSIS statistics data parameter shape; credentialed runtime execution remains blocked until key injection is available."
+    }
+  ]
+}

--- a/reports/kosis/runtime-evidence-plan.json
+++ b/reports/kosis/runtime-evidence-plan.json
@@ -1,9 +1,10 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:50:44Z",
+  "generated_at": "2026-06-30T09:16:13Z",
   "provider": "KOSIS",
   "source_id": "kosis",
   "source_profile": "sources/kosis.json",
+  "candidate_batch": "reports/kosis/runtime-candidates.json",
   "references": {
     "official_reference_urls": [
       "https://kosis.kr/openapi/devGuide/devGuide_0101List.do",
@@ -13,8 +14,8 @@
   },
   "summary": {
     "evidence_total": 0,
-    "blocking_count": 5,
-    "warning_count": 3,
+    "blocking_count": 3,
+    "warning_count": 2,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -29,7 +30,7 @@
     "adapter_capabilities": [],
     "auth_type": "api_key",
     "credential_required": true,
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "blockers": [
     {
@@ -55,22 +56,6 @@
       "expected_action": "Define a non-secret API key injection path for source-scoped CI and local bounded checks.",
       "owner": "operator",
       "status": "open"
-    },
-    {
-      "blocker_id": "sample_parameters_not_pinned",
-      "severity": "blocking",
-      "source_profile_field": "runtime.sample_param_policy",
-      "expected_action": "Pin at least one official orgId, tblId, statId, period, and classification sample for a bounded first batch.",
-      "owner": "registry",
-      "status": "open"
-    },
-    {
-      "blocker_id": "runtime_catalog_not_materialized",
-      "severity": "blocking",
-      "source_profile_field": "catalogue.identity_fields",
-      "expected_action": "Materialize a source-scoped KOSIS registry or verification candidate list before collecting evidence.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -81,7 +66,7 @@
       "reports/kosis/verification-plan.json"
     ],
     "required_cli_capabilities": [
-      "source-scoped registry input",
+      "runtime candidate batch ingestion",
       "KOSIS bounded sample-call adapter",
       "source credential injection",
       "KOSIS error signature extraction"
@@ -92,21 +77,15 @@
   "warnings": [
     {
       "warning_id": "non_data_runtime_evidence_not_collected",
-      "expected": "KOSIS has source-scoped runtime evidence after adapter and sample parameters are pinned.",
+      "expected": "KOSIS has source-scoped runtime evidence after the pinned candidate batch, adapter, and credential injection are available.",
       "actual": "0 runtime checks are collected for KOSIS.",
-      "remaining": "Create the KOSIS source registry/candidate list and run the first bounded verification batch."
+      "remaining": "Use reports/kosis/runtime-candidates.json with a registered adapter and credentials to run the first bounded verification batch."
     },
     {
       "warning_id": "source_runtime_adapter_not_registered",
       "expected": "KOSIS adapter has verification and call capabilities.",
       "actual": "adapter.status is none and adapter_capabilities is empty.",
       "remaining": "Register the KOSIS adapter before evidence collection."
-    },
-    {
-      "warning_id": "source_runtime_manual_samples_unpinned",
-      "expected": "KOSIS first-batch sample parameters are pinned.",
-      "actual": "runtime.sample_param_policy is manual.",
-      "remaining": "Pin official KOSIS sample identifiers for bounded checks."
     }
   ]
 }

--- a/reports/open-assembly/runtime-candidates.json
+++ b/reports/open-assembly/runtime-candidates.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "datapan.source-runtime-candidates.v1",
+  "generated_at": "2026-06-30T09:16:13Z",
+  "provider": "open.assembly.go.kr",
+  "source_id": "open_assembly",
+  "source_profile": "sources/open_assembly.json",
+  "references": {
+    "official_reference_urls": [
+      "https://open.assembly.go.kr/portal/mainPage.do",
+      "https://open.assembly.go.kr/portal/openapi/main.do"
+    ],
+    "last_reviewed_at": "2026-06-30"
+  },
+  "summary": {
+    "candidates": 1,
+    "pinned_sample_count": 1,
+    "credential_required": true,
+    "evidence_total": 0
+  },
+  "candidates": [
+    {
+      "candidate_id": "open-assembly-opensrvapi-list",
+      "label": "Open Assembly API service catalogue list",
+      "operation_kind": "catalogue_list",
+      "method": "GET",
+      "endpoint_template": "https://open.assembly.go.kr/portal/openapi/OPENSRVAPI",
+      "format": "json",
+      "sample_parameters": {
+        "KEY": "${OPEN_ASSEMBLY_KEY}",
+        "Type": "json",
+        "pIndex": "1",
+        "pSize": "5"
+      },
+      "credential_policy": {
+        "required": true,
+        "key_names": [
+          "KEY"
+        ],
+        "injection_location": "query",
+        "placeholder": "${OPEN_ASSEMBLY_KEY}"
+      },
+      "expected_response": {
+        "envelope_path": "OPENSRVAPI.head.RESULT",
+        "items_path": "OPENSRVAPI.row",
+        "success_code": "INFO-000"
+      },
+      "evidence_status": "not_collected",
+      "promotion_status": "registry_only",
+      "reference_url": "https://open.assembly.go.kr/portal/openapi/main.do",
+      "notes": "Pinned from the official OPENSRVAPI catalogue endpoint; runtime execution remains separate from the already observed unauthenticated catalogue response."
+    }
+  ]
+}

--- a/reports/open-assembly/runtime-evidence-plan.json
+++ b/reports/open-assembly/runtime-evidence-plan.json
@@ -1,9 +1,10 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T09:06:52Z",
+  "generated_at": "2026-06-30T09:16:13Z",
   "provider": "open.assembly.go.kr",
   "source_id": "open_assembly",
   "source_profile": "sources/open_assembly.json",
+  "candidate_batch": "reports/open-assembly/runtime-candidates.json",
   "references": {
     "official_reference_urls": [
       "https://open.assembly.go.kr/portal/mainPage.do",
@@ -13,8 +14,8 @@
   },
   "summary": {
     "evidence_total": 0,
-    "blocking_count": 5,
-    "warning_count": 3,
+    "blocking_count": 3,
+    "warning_count": 2,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -29,7 +30,7 @@
     "adapter_capabilities": [],
     "auth_type": "api_key",
     "credential_required": true,
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "blockers": [
     {
@@ -55,22 +56,6 @@
       "expected_action": "Define a non-secret KEY injection path for source-scoped CI and local bounded checks.",
       "owner": "operator",
       "status": "open"
-    },
-    {
-      "blocker_id": "sample_parameters_not_pinned",
-      "severity": "blocking",
-      "source_profile_field": "runtime.sample_param_policy",
-      "expected_action": "Pin at least one service_id, AGE, BILL_ID, or committee_id sample for a bounded first batch.",
-      "owner": "registry",
-      "status": "open"
-    },
-    {
-      "blocker_id": "runtime_catalog_not_materialized",
-      "severity": "blocking",
-      "source_profile_field": "catalogue.identity_fields",
-      "expected_action": "Materialize a source-scoped Open Assembly registry or verification candidate list before collecting evidence.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -81,7 +66,7 @@
       "reports/open-assembly/verification-plan.json"
     ],
     "required_cli_capabilities": [
-      "source-scoped registry input",
+      "runtime candidate batch ingestion",
       "Open Assembly bounded sample-call adapter",
       "source credential injection",
       "Open Assembly RESULT code extraction"
@@ -92,21 +77,15 @@
   "warnings": [
     {
       "warning_id": "non_data_runtime_evidence_not_collected",
-      "expected": "Open Assembly has source-scoped runtime evidence after adapter and sample parameters are pinned.",
+      "expected": "Open Assembly has source-scoped runtime evidence after the pinned candidate batch, adapter, and credential injection are available.",
       "actual": "0 runtime checks are collected for Open Assembly.",
-      "remaining": "Create the Open Assembly source registry/candidate list and run the first bounded verification batch."
+      "remaining": "Use reports/open-assembly/runtime-candidates.json with a registered adapter and credentials to run the first bounded verification batch."
     },
     {
       "warning_id": "source_runtime_adapter_not_registered",
       "expected": "Open Assembly adapter has verification and call capabilities.",
       "actual": "adapter.status is none and adapter_capabilities is empty.",
       "remaining": "Register the Open Assembly adapter before evidence collection."
-    },
-    {
-      "warning_id": "source_runtime_manual_samples_unpinned",
-      "expected": "Open Assembly first-batch sample parameters are pinned.",
-      "actual": "runtime.sample_param_policy is manual.",
-      "remaining": "Pin official Open Assembly sample identifiers for bounded checks."
     }
   ]
 }

--- a/reports/seoul-open-data/runtime-candidates.json
+++ b/reports/seoul-open-data/runtime-candidates.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "datapan.source-runtime-candidates.v1",
+  "generated_at": "2026-06-30T09:16:13Z",
+  "provider": "data.seoul.go.kr",
+  "source_id": "seoul_open_data",
+  "source_profile": "sources/seoul_open_data.json",
+  "references": {
+    "official_reference_urls": [
+      "https://data.seoul.go.kr/",
+      "https://data.seoul.go.kr/etc/accessTerms.do",
+      "https://data.seoul.go.kr/together/guide/useGuide.do",
+      "https://data.seoul.go.kr/together/notice/boardList.do"
+    ],
+    "last_reviewed_at": "2026-06-29"
+  },
+  "summary": {
+    "candidates": 1,
+    "pinned_sample_count": 1,
+    "credential_required": true,
+    "evidence_total": 0
+  },
+  "candidates": [
+    {
+      "candidate_id": "seoul-open-data-subway-station-list",
+      "label": "Seoul Open Data subway station bounded query",
+      "operation_kind": "service_query",
+      "method": "GET",
+      "endpoint_template": "http://openapi.seoul.go.kr:8088/{KEY}/{format}/{service}/{start_index}/{end_index}",
+      "format": "json",
+      "sample_parameters": {
+        "KEY": "${SEOUL_OPEN_DATA_KEY}",
+        "format": "json",
+        "service": "SearchSTNBySubwayLineInfo",
+        "start_index": "1",
+        "end_index": "5"
+      },
+      "credential_policy": {
+        "required": true,
+        "key_names": [
+          "KEY"
+        ],
+        "injection_location": "path",
+        "placeholder": "${SEOUL_OPEN_DATA_KEY}"
+      },
+      "expected_response": {
+        "envelope_path": "SearchSTNBySubwayLineInfo.RESULT",
+        "items_path": "SearchSTNBySubwayLineInfo.row",
+        "success_code": "INFO-000"
+      },
+      "evidence_status": "not_collected",
+      "promotion_status": "registry_only",
+      "reference_url": "https://data.seoul.go.kr/together/guide/useGuide.do",
+      "notes": "Pinned from Seoul Open Data path-style OpenAPI usage; credentialed runtime execution remains blocked until key injection is available."
+    }
+  ]
+}

--- a/reports/seoul-open-data/runtime-evidence-plan.json
+++ b/reports/seoul-open-data/runtime-evidence-plan.json
@@ -1,9 +1,10 @@
 {
   "schema_version": "datapan.source-runtime-evidence-plan.v1",
-  "generated_at": "2026-06-30T08:41:37Z",
+  "generated_at": "2026-06-30T09:16:13Z",
   "provider": "data.seoul.go.kr",
   "source_id": "seoul_open_data",
   "source_profile": "sources/seoul_open_data.json",
+  "candidate_batch": "reports/seoul-open-data/runtime-candidates.json",
   "references": {
     "official_reference_urls": [
       "https://data.seoul.go.kr/",
@@ -15,8 +16,8 @@
   },
   "summary": {
     "evidence_total": 0,
-    "blocking_count": 5,
-    "warning_count": 3,
+    "blocking_count": 3,
+    "warning_count": 2,
     "next_action_count": 4
   },
   "runtime_state": {
@@ -31,7 +32,7 @@
     "adapter_capabilities": [],
     "auth_type": "api_key",
     "credential_required": true,
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "blockers": [
     {
@@ -57,22 +58,6 @@
       "expected_action": "Define a non-secret KEY injection path for source-scoped CI and local bounded checks.",
       "owner": "operator",
       "status": "open"
-    },
-    {
-      "blocker_id": "sample_parameters_not_pinned",
-      "severity": "blocking",
-      "source_profile_field": "runtime.sample_param_policy",
-      "expected_action": "Pin at least one service, start_index, end_index, and format sample for a bounded first batch.",
-      "owner": "registry",
-      "status": "open"
-    },
-    {
-      "blocker_id": "runtime_catalog_not_materialized",
-      "severity": "blocking",
-      "source_profile_field": "catalogue.identity_fields",
-      "expected_action": "Materialize a source-scoped Seoul Open Data registry or verification candidate list before collecting evidence.",
-      "owner": "registry",
-      "status": "open"
     }
   ],
   "next_evidence_plan": {
@@ -83,7 +68,7 @@
       "reports/seoul-open-data/verification-plan.json"
     ],
     "required_cli_capabilities": [
-      "source-scoped registry input",
+      "runtime candidate batch ingestion",
       "Seoul Open Data bounded sample-call adapter",
       "source credential injection",
       "Seoul RESULT code extraction"
@@ -94,21 +79,15 @@
   "warnings": [
     {
       "warning_id": "non_data_runtime_evidence_not_collected",
-      "expected": "Seoul Open Data has source-scoped runtime evidence after adapter and sample parameters are pinned.",
+      "expected": "Seoul Open Data has source-scoped runtime evidence after the pinned candidate batch, adapter, and credential injection are available.",
       "actual": "0 runtime checks are collected for Seoul Open Data.",
-      "remaining": "Create the Seoul Open Data source registry/candidate list and run the first bounded verification batch."
+      "remaining": "Use reports/seoul-open-data/runtime-candidates.json with a registered adapter and credentials to run the first bounded verification batch."
     },
     {
       "warning_id": "source_runtime_adapter_not_registered",
       "expected": "Seoul Open Data adapter has verification and call capabilities.",
       "actual": "adapter.status is none and adapter_capabilities is empty.",
       "remaining": "Register the Seoul Open Data adapter before evidence collection."
-    },
-    {
-      "warning_id": "source_runtime_manual_samples_unpinned",
-      "expected": "Seoul Open Data first-batch sample parameters are pinned.",
-      "actual": "runtime.sample_param_policy is manual.",
-      "remaining": "Pin official Seoul Open Data sample identifiers for bounded checks."
     }
   ]
 }

--- a/reports/source-runtime-evidence-rollup.json
+++ b/reports/source-runtime-evidence-rollup.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.source-runtime-evidence-rollup.v1",
-  "generated_at": "2026-06-30T09:06:52Z",
+  "generated_at": "2026-06-30T09:16:13Z",
   "provider": "multi-source",
   "source_plan_inputs": [
     "reports/ecos/runtime-evidence-plan.json",
@@ -16,8 +16,8 @@
     "failed": 0,
     "skipped": 0,
     "unknown": 0,
-    "blocking_count": 20,
-    "warning_count": 12
+    "blocking_count": 12,
+    "warning_count": 8
   },
   "sources": [
     {
@@ -25,19 +25,16 @@
       "provider": "ECOS",
       "runtime_evidence_plan": "reports/ecos/runtime-evidence-plan.json",
       "evidence_total": 0,
-      "blocking_count": 5,
-      "warning_count": 3,
+      "blocking_count": 3,
+      "warning_count": 2,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
-        "metadata_only_verification",
-        "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned"
+        "metadata_only_verification"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
-        "source_runtime_adapter_not_registered",
-        "source_runtime_manual_samples_unpinned"
+        "source_runtime_adapter_not_registered"
       ],
       "next_action_count": 4
     },
@@ -46,19 +43,16 @@
       "provider": "KOSIS",
       "runtime_evidence_plan": "reports/kosis/runtime-evidence-plan.json",
       "evidence_total": 0,
-      "blocking_count": 5,
-      "warning_count": 3,
+      "blocking_count": 3,
+      "warning_count": 2,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
-        "metadata_only_verification",
-        "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned"
+        "metadata_only_verification"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
-        "source_runtime_adapter_not_registered",
-        "source_runtime_manual_samples_unpinned"
+        "source_runtime_adapter_not_registered"
       ],
       "next_action_count": 4
     },
@@ -67,19 +61,16 @@
       "provider": "open.assembly.go.kr",
       "runtime_evidence_plan": "reports/open-assembly/runtime-evidence-plan.json",
       "evidence_total": 0,
-      "blocking_count": 5,
-      "warning_count": 3,
+      "blocking_count": 3,
+      "warning_count": 2,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
-        "metadata_only_verification",
-        "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned"
+        "metadata_only_verification"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
-        "source_runtime_adapter_not_registered",
-        "source_runtime_manual_samples_unpinned"
+        "source_runtime_adapter_not_registered"
       ],
       "next_action_count": 4
     },
@@ -88,19 +79,16 @@
       "provider": "data.seoul.go.kr",
       "runtime_evidence_plan": "reports/seoul-open-data/runtime-evidence-plan.json",
       "evidence_total": 0,
-      "blocking_count": 5,
-      "warning_count": 3,
+      "blocking_count": 3,
+      "warning_count": 2,
       "blocker_ids": [
         "adapter_not_registered",
         "credential_required",
-        "metadata_only_verification",
-        "runtime_catalog_not_materialized",
-        "sample_parameters_not_pinned"
+        "metadata_only_verification"
       ],
       "warning_ids": [
         "non_data_runtime_evidence_not_collected",
-        "source_runtime_adapter_not_registered",
-        "source_runtime_manual_samples_unpinned"
+        "source_runtime_adapter_not_registered"
       ],
       "next_action_count": 4
     }
@@ -135,26 +123,6 @@
         "open_assembly",
         "seoul_open_data"
       ]
-    },
-    {
-      "id": "runtime_catalog_not_materialized",
-      "count": 4,
-      "source_ids": [
-        "ecos",
-        "kosis",
-        "open_assembly",
-        "seoul_open_data"
-      ]
-    },
-    {
-      "id": "sample_parameters_not_pinned",
-      "count": 4,
-      "source_ids": [
-        "ecos",
-        "kosis",
-        "open_assembly",
-        "seoul_open_data"
-      ]
     }
   ],
   "warnings_by_id": [
@@ -177,16 +145,6 @@
         "open_assembly",
         "seoul_open_data"
       ]
-    },
-    {
-      "id": "source_runtime_manual_samples_unpinned",
-      "count": 4,
-      "source_ids": [
-        "ecos",
-        "kosis",
-        "open_assembly",
-        "seoul_open_data"
-      ]
     }
   ],
   "warnings": [
@@ -198,9 +156,9 @@
         "open_assembly",
         "seoul_open_data"
       ],
-      "expected": "Every checked-in non-data.go.kr source has source-scoped runtime evidence after adapters and sample parameters are pinned.",
+      "expected": "Every checked-in non-data.go.kr source has source-scoped runtime evidence after pinned candidate batches, adapters, and credential injection are available.",
       "actual": "4 of 4 non-data.go.kr sources have 0 runtime checks.",
-      "remaining": "Materialize source candidate artifacts, register adapters, inject credentials, and run bounded first batches."
+      "remaining": "Use the checked-in runtime-candidates.json batches, register adapters, inject credentials, and run bounded first batches."
     },
     {
       "warning_id": "source_runtime_adapter_not_registered",
@@ -213,18 +171,6 @@
       "expected": "Every checked-in non-data.go.kr source has verification and call adapter capabilities before runtime evidence collection.",
       "actual": "4 of 4 non-data.go.kr sources have no registered runtime adapter.",
       "remaining": "Register source-specific adapters for ECOS, KOSIS, Open Assembly, and Seoul Open Data."
-    },
-    {
-      "warning_id": "source_runtime_manual_samples_unpinned",
-      "affected_sources": [
-        "ecos",
-        "kosis",
-        "open_assembly",
-        "seoul_open_data"
-      ],
-      "expected": "Every checked-in non-data.go.kr source has pinned first-batch sample parameters.",
-      "actual": "4 of 4 non-data.go.kr sources use manual sample parameter policy.",
-      "remaining": "Pin official first-batch sample parameters per source before bounded checks."
     }
   ]
 }

--- a/schemas/datapan.source-runtime-candidates.v1.schema.json
+++ b/schemas/datapan.source-runtime-candidates.v1.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.datapan.dev/datapan.source-runtime-candidates.v1.schema.json",
+  "title": "Datapan Source Runtime Candidates v1",
+  "description": "Pinned first-batch runtime candidates for a source before callable runtime evidence is collected.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_at",
+    "provider",
+    "source_id",
+    "source_profile",
+    "references",
+    "summary",
+    "candidates"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "datapan.source-runtime-candidates.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_id": {
+      "$ref": "#/$defs/source_id"
+    },
+    "source_profile": {
+      "type": "string",
+      "minLength": 1
+    },
+    "references": {
+      "$ref": "#/$defs/references"
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/candidate"
+      }
+    }
+  },
+  "$defs": {
+    "source_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:_[a-z0-9]+)*$"
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "references": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["official_reference_urls", "last_reviewed_at"],
+      "properties": {
+        "official_reference_urls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "uniqueItems": true
+        },
+        "last_reviewed_at": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidates",
+        "pinned_sample_count",
+        "credential_required",
+        "evidence_total"
+      ],
+      "properties": {
+        "candidates": {
+          "$ref": "#/$defs/count"
+        },
+        "pinned_sample_count": {
+          "$ref": "#/$defs/count"
+        },
+        "credential_required": {
+          "type": "boolean"
+        },
+        "evidence_total": {
+          "$ref": "#/$defs/count"
+        }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "label",
+        "operation_kind",
+        "method",
+        "endpoint_template",
+        "format",
+        "sample_parameters",
+        "credential_policy",
+        "evidence_status",
+        "promotion_status",
+        "reference_url"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation_kind": {
+          "enum": ["catalogue_list", "metadata_list", "data_query", "service_query"]
+        },
+        "method": {
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        },
+        "endpoint_template": {
+          "type": "string",
+          "minLength": 1
+        },
+        "format": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sample_parameters": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "credential_policy": {
+          "$ref": "#/$defs/credential_policy"
+        },
+        "expected_response": {
+          "$ref": "#/$defs/expected_response"
+        },
+        "evidence_status": {
+          "const": "not_collected"
+        },
+        "promotion_status": {
+          "const": "registry_only"
+        },
+        "reference_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "credential_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "key_names", "injection_location", "placeholder"],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "key_names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "injection_location": {
+          "enum": ["query", "header", "path", "body", "none"]
+        },
+        "placeholder": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "expected_response": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "envelope_path": {
+          "type": "string"
+        },
+        "items_path": {
+          "type": "string"
+        },
+        "success_code": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/datapan.source-runtime-evidence-plan.v1.schema.json
+++ b/schemas/datapan.source-runtime-evidence-plan.v1.schema.json
@@ -37,6 +37,10 @@
       "type": "string",
       "minLength": 1
     },
+    "candidate_batch": {
+      "type": "string",
+      "minLength": 1
+    },
     "references": {
       "$ref": "#/$defs/references"
     },

--- a/scripts/validate-source-runtime-candidates.py
+++ b/scripts/validate-source-runtime-candidates.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Validate source-scoped runtime candidate batches."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import re
+import sys
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit(
+        "missing dependency: install jsonschema before running source runtime candidate validation"
+    ) from exc
+
+
+def load_json(path: pathlib.Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def as_dict(value: object, path: pathlib.Path) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def default_candidate_batches() -> list[pathlib.Path]:
+    return sorted(pathlib.Path("reports").glob("*/runtime-candidates.json"))
+
+
+def source_dir(source_id: str) -> str:
+    return source_id.replace("_", "-")
+
+
+def endpoint_placeholders(endpoint_template: object) -> set[str]:
+    if not isinstance(endpoint_template, str):
+        return set()
+    return set(re.findall(r"\{([^{}]+)\}", endpoint_template))
+
+
+def official_urls(profile: dict[str, object]) -> list[str]:
+    references = as_dict(profile.get("references"), pathlib.Path("<source_profile>"))
+    return sorted(
+        {
+            value
+            for key, value in references.items()
+            if key.endswith("_url") and isinstance(value, str)
+        }
+    )
+
+
+def validate_consistency(batch_path: pathlib.Path, batch: dict[str, object]) -> None:
+    profile_path = pathlib.Path(str(batch.get("source_profile")))
+    if not profile_path.exists():
+        raise ValueError(f"source_profile does not exist: {profile_path}")
+
+    profile = as_dict(load_json(profile_path), profile_path)
+    source_id = profile.get("source_id")
+    if not isinstance(source_id, str):
+        raise ValueError("source_profile.source_id must be a string")
+    if batch_path.parent.name != source_dir(source_id):
+        raise ValueError(f"path parent expected reports/{source_dir(source_id)}")
+    if batch.get("source_id") != source_id:
+        raise ValueError("source_id does not match source_profile")
+    if batch.get("provider") != profile.get("provider"):
+        raise ValueError("provider does not match source_profile")
+
+    profile_references = as_dict(profile.get("references"), profile_path)
+    batch_references = as_dict(batch.get("references"), batch_path)
+    if batch_references.get("official_reference_urls") != official_urls(profile):
+        raise ValueError("references.official_reference_urls must match source profile URL references")
+    if batch_references.get("last_reviewed_at") != profile_references.get("last_reviewed_at"):
+        raise ValueError("references.last_reviewed_at must match source profile")
+
+    profile_auth = as_dict(profile.get("auth"), profile_path)
+    profile_request = as_dict(profile.get("request"), profile_path)
+    profile_response = as_dict(profile.get("response"), profile_path)
+    profile_runtime = as_dict(profile.get("runtime"), profile_path)
+
+    if profile_runtime.get("sample_param_policy") not in {"static", "catalogue_sample", "generated"}:
+        raise ValueError("source_profile.runtime.sample_param_policy must be pinned before candidate validation")
+
+    candidates = batch.get("candidates")
+    if not isinstance(candidates, list):
+        raise ValueError("candidates must be an array")
+
+    candidate_ids: collections.Counter[str] = collections.Counter()
+    pinned_sample_count = 0
+    methods = set(profile_request.get("methods") or [])
+    formats = set(profile_response.get("formats") or [])
+    expected_credential_required = profile_auth.get("type") != "none"
+    expected_key_names = sorted(profile_auth.get("key_parameter_names") or [])
+    expected_key_locations = list(profile_auth.get("key_locations") or [])
+    expected_injection_location = expected_key_locations[0] if expected_key_locations else "none"
+
+    for index, raw_candidate in enumerate(candidates):
+        candidate = as_dict(raw_candidate, batch_path)
+        candidate_id = candidate.get("candidate_id")
+        if isinstance(candidate_id, str):
+            candidate_ids[candidate_id] += 1
+
+        if candidate.get("method") not in methods:
+            raise ValueError(f"candidates[{index}].method is not allowed by source profile")
+        if candidate.get("format") not in formats:
+            raise ValueError(f"candidates[{index}].format is not allowed by source profile")
+
+        sample_parameters = candidate.get("sample_parameters")
+        if isinstance(sample_parameters, dict) and sample_parameters:
+            pinned_sample_count += 1
+
+        credential_policy = as_dict(candidate.get("credential_policy"), batch_path)
+        if credential_policy.get("required") != expected_credential_required:
+            raise ValueError(f"candidates[{index}].credential_policy.required does not match source profile")
+        if sorted(credential_policy.get("key_names") or []) != expected_key_names:
+            raise ValueError(f"candidates[{index}].credential_policy.key_names does not match source profile")
+        if credential_policy.get("injection_location") != expected_injection_location:
+            raise ValueError(
+                f"candidates[{index}].credential_policy.injection_location does not match source profile"
+            )
+        if expected_injection_location == "path":
+            placeholders = endpoint_placeholders(candidate.get("endpoint_template"))
+            missing_key_placeholders = sorted(set(expected_key_names).difference(placeholders))
+            if missing_key_placeholders:
+                raise ValueError(
+                    f"candidates[{index}].endpoint_template missing path credential placeholders: "
+                    f"{', '.join(missing_key_placeholders)}"
+                )
+        if candidate.get("evidence_status") != "not_collected":
+            raise ValueError(f"candidates[{index}].evidence_status must be not_collected")
+        if candidate.get("promotion_status") != "registry_only":
+            raise ValueError(f"candidates[{index}].promotion_status must be registry_only")
+
+    duplicates = sorted(candidate_id for candidate_id, count in candidate_ids.items() if count > 1)
+    if duplicates:
+        raise ValueError(f"duplicate candidate_id values: {', '.join(duplicates)}")
+
+    summary = as_dict(batch.get("summary"), batch_path)
+    expected_summary = {
+        "candidates": len(candidates),
+        "pinned_sample_count": pinned_sample_count,
+        "credential_required": expected_credential_required,
+        "evidence_total": 0,
+    }
+    for key, value in expected_summary.items():
+        if summary.get(key) != value:
+            raise ValueError(f"summary.{key} expected {value}, got {summary.get(key)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--schema",
+        default="schemas/datapan.source-runtime-candidates.v1.schema.json",
+        type=pathlib.Path,
+        help="source runtime candidates JSON Schema path",
+    )
+    parser.add_argument(
+        "candidate_batches",
+        nargs="*",
+        type=pathlib.Path,
+        help="candidate batch files to validate; defaults to reports/*/runtime-candidates.json",
+    )
+    args = parser.parse_args()
+
+    batches = args.candidate_batches or default_candidate_batches()
+    if not batches:
+        print("no source runtime candidate batches found", file=sys.stderr)
+        return 1
+
+    schema = load_json(args.schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    failures = 0
+
+    for batch_path in batches:
+        try:
+            instance = as_dict(load_json(batch_path), batch_path)
+            errors = sorted(validator.iter_errors(instance), key=lambda error: list(error.path))
+            if not errors:
+                validate_consistency(batch_path, instance)
+        except Exception as exc:  # noqa: BLE001 - report all validation blockers
+            print(f"FAIL {batch_path}: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+
+        if errors:
+            failures += 1
+            print(f"FAIL {batch_path}", file=sys.stderr)
+            for error in errors:
+                location = ".".join(str(part) for part in error.path) or "<root>"
+                print(f"  {location}: {error.message}", file=sys.stderr)
+            continue
+
+        source_id = instance.get("source_id", "<unknown>")
+        candidates = instance.get("summary", {}).get("candidates", "<unknown>")
+        print(f"ok {batch_path} ({source_id}, candidates={candidates})")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-source-runtime-evidence-plans.py
+++ b/scripts/validate-source-runtime-evidence-plans.py
@@ -36,7 +36,11 @@ def source_dir(source_id: str) -> str:
     return source_id.replace("_", "-")
 
 
-def required_blockers(profile: dict[str, object], state: dict[str, object]) -> set[str]:
+def required_blockers(
+    profile: dict[str, object],
+    state: dict[str, object],
+    candidate_batch_materialized: bool,
+) -> set[str]:
     blockers: set[str] = set()
     runtime = as_dict(profile.get("runtime"), pathlib.Path("<source_profile>"))
     adapter = as_dict(profile.get("adapter"), pathlib.Path("<source_profile>"))
@@ -53,7 +57,7 @@ def required_blockers(profile: dict[str, object], state: dict[str, object]) -> s
         blockers.add("credential_required")
     if runtime.get("sample_param_policy") == "manual":
         blockers.add("sample_parameters_not_pinned")
-    if state.get("evidence_total") == 0:
+    if state.get("evidence_total") == 0 and not candidate_batch_materialized:
         blockers.add("runtime_catalog_not_materialized")
     if errors.get("taxonomy_status") != "verified":
         blockers.add("source_specific_error_taxonomy_pending")
@@ -70,6 +74,33 @@ def official_urls(profile: dict[str, object]) -> list[str]:
             if key.endswith("_url") and isinstance(value, str)
         }
     )
+
+
+def candidate_batch_materialized(
+    plan_path: pathlib.Path,
+    plan: dict[str, object],
+    profile: dict[str, object],
+) -> bool:
+    candidate_batch = plan.get("candidate_batch")
+    if not isinstance(candidate_batch, str) or not candidate_batch:
+        return False
+
+    batch_path = pathlib.Path(candidate_batch)
+    if not batch_path.exists():
+        raise ValueError(f"candidate_batch does not exist: {candidate_batch}")
+
+    batch = as_dict(load_json(batch_path), batch_path)
+    if batch.get("source_id") != profile.get("source_id"):
+        raise ValueError("candidate_batch source_id does not match source_profile")
+    if batch_path.parent != plan_path.parent:
+        raise ValueError("candidate_batch must be in the same source report directory as the runtime evidence plan")
+    if batch.get("provider") != profile.get("provider"):
+        raise ValueError("candidate_batch provider does not match source_profile")
+    if batch.get("source_profile") != str(plan.get("source_profile")):
+        raise ValueError("candidate_batch source_profile does not match runtime evidence plan")
+
+    summary = as_dict(batch.get("summary"), batch_path)
+    return int(summary.get("candidates", 0)) > 0 and int(summary.get("evidence_total", 0)) == 0
 
 
 def validate_consistency(plan_path: pathlib.Path, plan: dict[str, object]) -> None:
@@ -127,7 +158,8 @@ def validate_consistency(plan_path: pathlib.Path, plan: dict[str, object]) -> No
     duplicates = sorted(item for item, count in collections.Counter(blocker_ids).items() if count > 1)
     if duplicates:
         raise ValueError(f"duplicate blocker_id values: {', '.join(str(item) for item in duplicates)}")
-    missing_blockers = sorted(required_blockers(profile, state).difference(blocker_ids))
+    has_candidate_batch = candidate_batch_materialized(plan_path, plan, profile)
+    missing_blockers = sorted(required_blockers(profile, state, has_candidate_batch).difference(blocker_ids))
     if missing_blockers:
         raise ValueError(f"missing required blocker_id values: {', '.join(missing_blockers)}")
 

--- a/sources/ecos.json
+++ b/sources/ecos.json
@@ -101,7 +101,7 @@
     "timeout_seconds": 20,
     "retry_policy": "idempotent",
     "rate_limit_policy": "documented",
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "promotion": {
     "default_status": "registry_only",

--- a/sources/kosis.json
+++ b/sources/kosis.json
@@ -94,7 +94,7 @@
     "timeout_seconds": 20,
     "retry_policy": "idempotent",
     "rate_limit_policy": "documented",
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "promotion": {
     "default_status": "registry_only",

--- a/sources/open_assembly.json
+++ b/sources/open_assembly.json
@@ -91,7 +91,7 @@
     "timeout_seconds": 20,
     "retry_policy": "idempotent",
     "rate_limit_policy": "conservative",
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "promotion": {
     "default_status": "registry_only",

--- a/sources/seoul_open_data.json
+++ b/sources/seoul_open_data.json
@@ -24,7 +24,7 @@
   "catalogue": {
     "model": "portal",
     "list_endpoint": "https://data.seoul.go.kr/dataList/1/literacyView.do",
-    "detail_endpoint": "http://openapi.seoul.go.kr:8088/{key}/{format}/{service}/{start_index}/{end_index}",
+    "detail_endpoint": "http://openapi.seoul.go.kr:8088/{KEY}/{format}/{service}/{start_index}/{end_index}",
     "search_endpoint": "https://data.seoul.go.kr/dataList/OA-",
     "notice_endpoint": "https://data.seoul.go.kr/together/notice/boardList.do",
     "update_cadence": "source-dependent",
@@ -105,7 +105,7 @@
     "timeout_seconds": 20,
     "retry_policy": "idempotent",
     "rate_limit_policy": "documented",
-    "sample_param_policy": "manual"
+    "sample_param_policy": "static"
   },
   "promotion": {
     "default_status": "registry_only",


### PR DESCRIPTION
Closes #75

## Summary
- Added `datapan.source-runtime-candidates.v1` plus `validate-source-runtime-candidates.py` for pinned first-batch source runtime candidates.
- Added registry-only candidate batches for KOSIS, ECOS, Open Assembly, and Seoul Open Data.
- Linked each runtime evidence plan to its candidate batch while keeping `evidence_total=0`.
- Updated the source runtime evidence rollup from `blocking_count=20`, `warning_count=12` to `blocking_count=12`, `warning_count=8`.
- Added the candidate validator to `verify-release` and `release-draft` workflows.

## Warning Inventory
Resolved in this PR:
- `source_runtime_manual_samples_unpinned`: `4 -> 0`
- `sample_parameters_not_pinned`: `4 -> 0`
- `runtime_catalog_not_materialized`: `4 -> 0` for the candidate-batch stage

Still explicit and not treated as harmless:
- `non_data_runtime_evidence_not_collected`: `4`
- `source_runtime_adapter_not_registered`: `4`

## Validation
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-candidates.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `python3 scripts/validate-institution-api-overview.py` with materialized LFS registry, then pointer restored
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

## Remaining Gap
`schemas/index.json` and `manifest.json` are generated release artifacts and were not hand-edited. The new candidate schema is enforced directly by CI through `validate-source-runtime-candidates.py`; binding it into generated schema index/manifest remains a separate generator path gap.