### PR TITLE
feat: Bind runtime candidate schema into release artifacts

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -78,6 +78,7 @@ jobs:
           . .datapan/ci/source-profile-venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install jsonschema
+          python scripts/sync-release-schema-artifacts.py --check
           python scripts/validate-source-profiles.py
           python scripts/validate-error-action-catalogs.py
           python scripts/validate-external-coverage.py

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -51,6 +51,7 @@ jobs:
           . .datapan/ci/source-profile-venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install jsonschema
+          python scripts/sync-release-schema-artifacts.py --check
           python scripts/validate-source-profiles.py
           python scripts/validate-error-action-catalogs.py
           python scripts/validate-external-coverage.py

--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -109,6 +109,10 @@ Current strengths:
   verification in Gira #69, ECOS error taxonomy verification in Gira #71, and
   Open Assembly error taxonomy verification in Gira #73, then runtime
   candidate batch pinning in Gira #75.
+- `scripts/sync-release-schema-artifacts.py` checks that every checked-in
+  `schemas/*.schema.json` file is represented in `schemas/index.json` and
+  `manifest.json`; Gira #77 raises release schema coverage from `20` to `28`
+  artifacts while keeping readiness warnings at `0`.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -160,6 +164,11 @@ Current gaps:
 - Live drift checks for official source documentation are not implemented, but
   checked-in source reference baselines are now validated against source
   profiles.
+- The registry release surface now includes every checked-in registry schema,
+  but the current datapan-cli release readiness gate still reports `expected=20`
+  and `actual=28` for `schema_set_complete`, which means CLI-side schema
+  generator knowledge must be updated before draft-local releases can be the
+  sole source of truth for these newer registry contracts.
 
 ## Gap Matrix
 
@@ -377,6 +386,9 @@ Use this order unless a production failure changes priority:
     Assembly, and Seoul Open Data. Tracked by Gira #75; this validates pinned
     registry-only first-batch candidates, clears manual sample warnings, and
     leaves runtime evidence collection gated by adapters and credentials.
+23. Bind all checked-in registry schemas into release schema artifacts. Tracked
+    by Gira #77; this raises schema artifact coverage from `20` to `28`, adds a
+    CI drift check, and keeps runtime warning IDs unchanged.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-30T08:11:23Z",
+  "generated_at": "2026-06-30T09:32:00Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "data/data-go-kr.registry.json",
   "output_dir": ".",
-  "artifact_count": 39,
+  "artifact_count": 47,
   "artifacts": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -128,11 +128,59 @@
       "sha256": "177616c48df86a13f147282f1c368a9be8293ff5831b2f09067d1adcd8000120"
     },
     {
+      "path": "schemas/datapan.error-action-catalog.v1.schema.json",
+      "kind": "schema",
+      "bytes": 6886,
+      "sha256": "959822bc57b93e8a084d18895c3cf3f81e793f5afea397a409c1909651395da7"
+    },
+    {
+      "path": "schemas/datapan.external-coverage.v1.schema.json",
+      "kind": "schema",
+      "bytes": 5249,
+      "sha256": "874be75ce42d355ce4956315cc1b9548ec1bda300e222d009a8d2e29fd1c9131"
+    },
+    {
+      "path": "schemas/datapan.registry-impact-plan.v1.schema.json",
+      "kind": "schema",
+      "bytes": 8410,
+      "sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+    },
+    {
+      "path": "schemas/datapan.source-profile.v1.schema.json",
+      "kind": "schema",
+      "bytes": 9602,
+      "sha256": "ce01786b97680a16d0e58fdee8377502d5888deb72e03fee50344fcd5b89a2cf"
+    },
+    {
+      "path": "schemas/datapan.source-reference-drift.v1.schema.json",
+      "kind": "schema",
+      "bytes": 4515,
+      "sha256": "e065ae7f7ea80ae512c48039dbd403a3fadc822c9b6f77dab80ada11a3cff204"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-candidates.v1.schema.json",
+      "kind": "schema",
+      "bytes": 5032,
+      "sha256": "2a8a009225b7ae99bf4e78e91dcf5fc6a487f9ca67faa1812f675f8651ab3492"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-plan.v1.schema.json",
+      "kind": "schema",
+      "bytes": 7272,
+      "sha256": "73f325bc706b3596a1d44b5e325523f8f0bf0452ffae3adb047dbbf8ed8bd08d"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-rollup.v1.schema.json",
+      "kind": "schema",
+      "bytes": 5143,
+      "sha256": "73e870fbab654935cce35a4d68427aea58e03368777fe7801a31283e6566d187"
+    },
+    {
       "path": "schemas/index.json",
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
-      "bytes": 7490,
-      "sha256": "0d5b8204e47679390ed8a3cd463cd6334d64baba317c626a45e91b14e7a54bd6"
+      "bytes": 10658,
+      "sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997"
     },
     {
       "path": "data/data-go-kr.registry.json",

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "manifest.json",
   "root": ".",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-30T08:11:38Z",
+  "generated_at": "2026-06-30T09:33:12Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,
@@ -15,7 +15,7 @@
     "missing_required_artifacts": 0,
     "recommended_artifacts": 3,
     "missing_recommended_artifacts": 0,
-    "schema_artifacts": 20,
+    "schema_artifacts": 28,
     "registry_specs": 12060
   },
   "gates": [
@@ -24,8 +24,8 @@
       "status": "pass",
       "severity": "required",
       "message": "release manifest checksums and schema-bound artifacts verified",
-      "expected": 39,
-      "actual": 39
+      "expected": 47,
+      "actual": 47
     },
     {
       "id": "required_artifact_schema_index",
@@ -223,7 +223,7 @@
       "severity": "required",
       "message": "release includes all Datapan schema files known to this CLI",
       "expected": 20,
-      "actual": 20
+      "actual": 28
     },
     {
       "id": "registry_has_specs",

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -3,8 +3,8 @@
   "root": ".",
   "schema_version": "datapan.release-verification.v1",
   "manifest_schema_version": "datapan.release-manifest.v1",
-  "artifact_count": 39,
-  "checked": 39,
+  "artifact_count": 47,
+  "checked": 47,
   "failed": 0,
   "ok": true,
   "results": [
@@ -189,13 +189,85 @@
       "actual_sha256": "177616c48df86a13f147282f1c368a9be8293ff5831b2f09067d1adcd8000120"
     },
     {
+      "path": "schemas/datapan.error-action-catalog.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 6886,
+      "actual_bytes": 6886,
+      "expected_sha256": "959822bc57b93e8a084d18895c3cf3f81e793f5afea397a409c1909651395da7",
+      "actual_sha256": "959822bc57b93e8a084d18895c3cf3f81e793f5afea397a409c1909651395da7"
+    },
+    {
+      "path": "schemas/datapan.external-coverage.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 5249,
+      "actual_bytes": 5249,
+      "expected_sha256": "874be75ce42d355ce4956315cc1b9548ec1bda300e222d009a8d2e29fd1c9131",
+      "actual_sha256": "874be75ce42d355ce4956315cc1b9548ec1bda300e222d009a8d2e29fd1c9131"
+    },
+    {
+      "path": "schemas/datapan.registry-impact-plan.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 8410,
+      "actual_bytes": 8410,
+      "expected_sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c",
+      "actual_sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+    },
+    {
+      "path": "schemas/datapan.source-profile.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 9602,
+      "actual_bytes": 9602,
+      "expected_sha256": "ce01786b97680a16d0e58fdee8377502d5888deb72e03fee50344fcd5b89a2cf",
+      "actual_sha256": "ce01786b97680a16d0e58fdee8377502d5888deb72e03fee50344fcd5b89a2cf"
+    },
+    {
+      "path": "schemas/datapan.source-reference-drift.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 4515,
+      "actual_bytes": 4515,
+      "expected_sha256": "e065ae7f7ea80ae512c48039dbd403a3fadc822c9b6f77dab80ada11a3cff204",
+      "actual_sha256": "e065ae7f7ea80ae512c48039dbd403a3fadc822c9b6f77dab80ada11a3cff204"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-candidates.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 5032,
+      "actual_bytes": 5032,
+      "expected_sha256": "2a8a009225b7ae99bf4e78e91dcf5fc6a487f9ca67faa1812f675f8651ab3492",
+      "actual_sha256": "2a8a009225b7ae99bf4e78e91dcf5fc6a487f9ca67faa1812f675f8651ab3492"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-plan.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 7272,
+      "actual_bytes": 7272,
+      "expected_sha256": "73f325bc706b3596a1d44b5e325523f8f0bf0452ffae3adb047dbbf8ed8bd08d",
+      "actual_sha256": "73f325bc706b3596a1d44b5e325523f8f0bf0452ffae3adb047dbbf8ed8bd08d"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-rollup.v1.schema.json",
+      "kind": "schema",
+      "status": "verified",
+      "expected_bytes": 5143,
+      "actual_bytes": 5143,
+      "expected_sha256": "73e870fbab654935cce35a4d68427aea58e03368777fe7801a31283e6566d187",
+      "actual_sha256": "73e870fbab654935cce35a4d68427aea58e03368777fe7801a31283e6566d187"
+    },
+    {
       "path": "schemas/index.json",
       "kind": "schema_index",
       "status": "verified",
-      "expected_bytes": 7490,
-      "actual_bytes": 7490,
-      "expected_sha256": "0d5b8204e47679390ed8a3cd463cd6334d64baba317c626a45e91b14e7a54bd6",
-      "actual_sha256": "0d5b8204e47679390ed8a3cd463cd6334d64baba317c626a45e91b14e7a54bd6"
+      "expected_bytes": 10658,
+      "actual_bytes": 10658,
+      "expected_sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997",
+      "actual_sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997"
     },
     {
       "path": "data/data-go-kr.registry.json",

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-30T08:11:23Z",
+  "generated_at": "2026-06-30T09:32:00Z",
   "datapan_version": "0.1.0-dev",
-  "count": 20,
+  "count": 28,
   "schemas": [
     {
       "path": "schemas/datapan.specs.v1.schema.json",
@@ -183,6 +183,78 @@
       "version": "v1",
       "bytes": 2367,
       "sha256": "177616c48df86a13f147282f1c368a9be8293ff5831b2f09067d1adcd8000120"
+    },
+    {
+      "path": "schemas/datapan.error-action-catalog.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.error-action-catalog.v1.schema.json",
+      "title": "Datapan Error Action Catalog v1",
+      "contract": "error-action-catalog",
+      "version": "v1",
+      "bytes": 6886,
+      "sha256": "959822bc57b93e8a084d18895c3cf3f81e793f5afea397a409c1909651395da7"
+    },
+    {
+      "path": "schemas/datapan.external-coverage.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.external-coverage.v1.schema.json",
+      "title": "Datapan External Coverage v1",
+      "contract": "external-coverage",
+      "version": "v1",
+      "bytes": 5249,
+      "sha256": "874be75ce42d355ce4956315cc1b9548ec1bda300e222d009a8d2e29fd1c9131"
+    },
+    {
+      "path": "schemas/datapan.registry-impact-plan.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
+      "title": "Datapan Registry Impact Plan v1",
+      "contract": "registry-impact-plan",
+      "version": "v1",
+      "bytes": 8410,
+      "sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+    },
+    {
+      "path": "schemas/datapan.source-profile.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.source-profile.v1.schema.json",
+      "title": "Datapan Source Profile v1",
+      "contract": "source-profile",
+      "version": "v1",
+      "bytes": 9602,
+      "sha256": "ce01786b97680a16d0e58fdee8377502d5888deb72e03fee50344fcd5b89a2cf"
+    },
+    {
+      "path": "schemas/datapan.source-reference-drift.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.source-reference-drift.v1.schema.json",
+      "title": "Datapan Source Reference Drift v1",
+      "contract": "source-reference-drift",
+      "version": "v1",
+      "bytes": 4515,
+      "sha256": "e065ae7f7ea80ae512c48039dbd403a3fadc822c9b6f77dab80ada11a3cff204"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-candidates.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.source-runtime-candidates.v1.schema.json",
+      "title": "Datapan Source Runtime Candidates v1",
+      "contract": "source-runtime-candidates",
+      "version": "v1",
+      "bytes": 5032,
+      "sha256": "2a8a009225b7ae99bf4e78e91dcf5fc6a487f9ca67faa1812f675f8651ab3492"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-plan.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.source-runtime-evidence-plan.v1.schema.json",
+      "title": "Datapan Source Runtime Evidence Plan v1",
+      "contract": "source-runtime-evidence-plan",
+      "version": "v1",
+      "bytes": 7272,
+      "sha256": "73f325bc706b3596a1d44b5e325523f8f0bf0452ffae3adb047dbbf8ed8bd08d"
+    },
+    {
+      "path": "schemas/datapan.source-runtime-evidence-rollup.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.source-runtime-evidence-rollup.v1.schema.json",
+      "title": "Datapan Source Runtime Evidence Rollup v1",
+      "contract": "source-runtime-evidence-rollup",
+      "version": "v1",
+      "bytes": 5143,
+      "sha256": "73e870fbab654935cce35a4d68427aea58e03368777fe7801a31283e6566d187"
     }
   ]
 }

--- a/scripts/sync-release-schema-artifacts.py
+++ b/scripts/sync-release-schema-artifacts.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Synchronize release schema artifacts with checked-in schema files."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import pathlib
+import sys
+
+
+SCHEMA_INDEX_PATH = pathlib.Path("schemas/index.json")
+MANIFEST_PATH = pathlib.Path("manifest.json")
+
+
+def load_json(path: pathlib.Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def stable_json_bytes(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def schema_contract_version(name: str) -> tuple[str, str]:
+    name = name.removeprefix("datapan.").removesuffix(".schema.json")
+    parts = name.split(".")
+    if len(parts) < 2:
+        return name, ""
+    return ".".join(parts[:-1]), parts[-1]
+
+
+def schema_paths() -> list[pathlib.Path]:
+    return sorted(pathlib.Path("schemas").glob("*.schema.json"))
+
+
+def existing_schema_order(index: dict[str, object]) -> list[str]:
+    schemas = index.get("schemas")
+    if not isinstance(schemas, list):
+        return []
+    return [str(item.get("path")) for item in schemas if isinstance(item, dict) and item.get("path")]
+
+
+def ordered_schema_paths(index: dict[str, object]) -> list[pathlib.Path]:
+    paths_by_name = {str(path): path for path in schema_paths()}
+    ordered: list[pathlib.Path] = []
+    for path_name in existing_schema_order(index):
+        path = paths_by_name.pop(path_name, None)
+        if path is not None:
+            ordered.append(path)
+    ordered.extend(paths_by_name[path_name] for path_name in sorted(paths_by_name))
+    return ordered
+
+
+def schema_entry(path: pathlib.Path) -> dict[str, object]:
+    data = path.read_bytes()
+    payload = load_json(path)
+    contract, version = schema_contract_version(path.name)
+    schema_id = payload.get("$id")
+    title = payload.get("title")
+    if not isinstance(schema_id, str) or not schema_id:
+        raise ValueError(f"{path} missing $id")
+    if not isinstance(title, str) or not title:
+        raise ValueError(f"{path} missing title")
+    return {
+        "path": path.as_posix(),
+        "id": schema_id,
+        "title": title,
+        "contract": contract,
+        "version": version,
+        "bytes": len(data),
+        "sha256": sha256_bytes(data),
+    }
+
+
+def expected_schema_index(index: dict[str, object], generated_at: str | None) -> dict[str, object]:
+    entries = [schema_entry(path) for path in ordered_schema_paths(index)]
+    return {
+        "schema_version": "datapan.schema-index.v1",
+        "generated_at": generated_at or str(index.get("generated_at")),
+        "datapan_version": str(index.get("datapan_version")),
+        "count": len(entries),
+        "schemas": entries,
+    }
+
+
+def manifest_schema_artifact(entry: dict[str, object]) -> dict[str, object]:
+    return {
+        "path": entry["path"],
+        "kind": "schema",
+        "bytes": entry["bytes"],
+        "sha256": entry["sha256"],
+    }
+
+
+def expected_manifest(
+    manifest: dict[str, object],
+    index_bytes: bytes,
+    index: dict[str, object],
+    generated_at: str | None,
+) -> dict[str, object]:
+    expected = copy.deepcopy(manifest)
+    if generated_at is not None:
+        expected["generated_at"] = generated_at
+    schema_artifacts = [manifest_schema_artifact(entry) for entry in index["schemas"]]  # type: ignore[index]
+    non_schema_artifacts: list[dict[str, object]] = []
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("manifest.artifacts must be an array")
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ValueError("manifest.artifacts entries must be objects")
+        if artifact.get("kind") == "schema":
+            continue
+        updated = copy.deepcopy(artifact)
+        if updated.get("kind") == "schema_index" and updated.get("path") == SCHEMA_INDEX_PATH.as_posix():
+            updated["bytes"] = len(index_bytes)
+            updated["sha256"] = sha256_bytes(index_bytes)
+        non_schema_artifacts.append(updated)
+    expected["artifact_count"] = len(schema_artifacts) + len(non_schema_artifacts)
+    expected["artifacts"] = schema_artifacts + non_schema_artifacts
+    return expected
+
+
+def explain_drift(current_index: dict[str, object], expected_index: dict[str, object], current_manifest: dict[str, object], expected_manifest_value: dict[str, object]) -> None:
+    current_paths = {str(item.get("path")) for item in current_index.get("schemas", []) if isinstance(item, dict)}
+    expected_paths = {str(item.get("path")) for item in expected_index.get("schemas", []) if isinstance(item, dict)}
+    missing_index = sorted(expected_paths.difference(current_paths))
+    extra_index = sorted(current_paths.difference(expected_paths))
+    if missing_index:
+        print("schema index missing:", ", ".join(missing_index), file=sys.stderr)
+    if extra_index:
+        print("schema index extra:", ", ".join(extra_index), file=sys.stderr)
+    if current_index.get("count") != expected_index.get("count"):
+        print(
+            f"schema index count mismatch: expected {expected_index.get('count')}, got {current_index.get('count')}",
+            file=sys.stderr,
+        )
+    if current_manifest.get("artifact_count") != expected_manifest_value.get("artifact_count"):
+        print(
+            "manifest artifact_count mismatch: "
+            f"expected {expected_manifest_value.get('artifact_count')}, got {current_manifest.get('artifact_count')}",
+            file=sys.stderr,
+        )
+    if current_index != expected_index:
+        print("schemas/index.json drift detected", file=sys.stderr)
+    if current_manifest != expected_manifest_value:
+        print("manifest.json schema artifact drift detected", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="fail when generated schema artifacts are out of date")
+    mode.add_argument("--write", action="store_true", help="rewrite schemas/index.json and manifest.json")
+    parser.add_argument(
+        "--generated-at",
+        help="generated_at value for schemas/index.json; defaults to the current checked-in value",
+    )
+    args = parser.parse_args()
+
+    current_index = load_json(SCHEMA_INDEX_PATH)
+    current_manifest = load_json(MANIFEST_PATH)
+    next_index = expected_schema_index(current_index, args.generated_at)
+    next_index_bytes = stable_json_bytes(next_index)
+    next_manifest = expected_manifest(current_manifest, next_index_bytes, next_index, args.generated_at)
+
+    if args.check:
+        if current_index != next_index or current_manifest != next_manifest:
+            explain_drift(current_index, next_index, current_manifest, next_manifest)
+            return 1
+        print(
+            f"ok release schema artifacts (schemas={next_index['count']}, artifacts={next_manifest['artifact_count']})"
+        )
+        return 0
+
+    SCHEMA_INDEX_PATH.write_bytes(next_index_bytes)
+    MANIFEST_PATH.write_bytes(stable_json_bytes(next_manifest))
+    print(f"wrote {SCHEMA_INDEX_PATH} (schemas={next_index['count']})")
+    print(f"wrote {MANIFEST_PATH} (artifacts={next_manifest['artifact_count']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #77

## Summary
- Added `scripts/sync-release-schema-artifacts.py` with `--check` and `--write` modes.
- Raised release schema coverage from `20` to `28` checked-in schema artifacts.
- Updated `schemas/index.json`, `manifest.json`, `reports/latest-release-verification.json`, and `reports/latest-release-readiness.json`.
- Added schema artifact drift checks to `verify-release` and `release-draft` workflows.

## Drift Resolved
Initial drift detected by the new check:
- schema index missing: `8` schema files
- schema index count: `20 -> 28`
- manifest artifact_count: `39 -> 47`

Current release reports:
- release verification: `checked=47`, `failed=0`, `ok=true`
- release readiness: `schema_artifacts=28`, `warned=0`, `failed=0`
- runtime warnings unchanged: `non_data_runtime_evidence_not_collected=4`, `source_runtime_adapter_not_registered=4`

## Validation
- `python3 scripts/sync-release-schema-artifacts.py --check`
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-candidates.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `datapan catalog release verify` via local datapan-cli with materialized LFS registry
- `datapan catalog release readiness` via local datapan-cli with materialized LFS registry
- `python3 scripts/validate-institution-api-overview.py`
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

## Remaining Gap
The datapan-cli readiness gate still reports `schema_set_complete expected=20 actual=28` with status `pass`. That means the registry release surface is now complete, but datapan-cli's hard-coded release draft schema list still needs its own follow-up before draft-local generation is the sole source of truth for all newer registry schemas.