### PR TITLE
feat: Add registry schema release impact gate

### DIFF
--- a/docs/registry-standardization-blueprint.md
+++ b/docs/registry-standardization-blueprint.md
@@ -113,6 +113,12 @@ Current strengths:
   `schemas/*.schema.json` file is represented in `schemas/index.json` and
   `manifest.json`; Gira #77 raises release schema coverage from `20` to `28`
   artifacts while keeping readiness warnings at `0`.
+- `reports/registry-impact-plan.json` now carries a
+  `registry:schema-release-surface` impact entry, and
+  `scripts/validate-impact-plans.py` fails if release readiness reports schema
+  coverage beyond datapan-cli's known schema set without a downstream impact
+  action. Gira #79 tracks this as a datapan-cli manual investigation while
+  keeping Dataset API, SDK, MCP, and datapan-data actions at `no_action`.
 - `reports/coverage.json` reports high callable-operation coverage.
 - `reports/route-disposition.json` separates dead-route candidates from
   transient failures.
@@ -168,7 +174,8 @@ Current gaps:
   but the current datapan-cli release readiness gate still reports `expected=20`
   and `actual=28` for `schema_set_complete`, which means CLI-side schema
   generator knowledge must be updated before draft-local releases can be the
-  sole source of truth for these newer registry contracts.
+  sole source of truth for these newer registry contracts. Gira #79 makes that
+  mismatch an explicit impact-plan action instead of a remembered PR note.
 
 ## Gap Matrix
 
@@ -389,6 +396,11 @@ Use this order unless a production failure changes priority:
 23. Bind all checked-in registry schemas into release schema artifacts. Tracked
     by Gira #77; this raises schema artifact coverage from `20` to `28`, adds a
     CI drift check, and keeps runtime warning IDs unchanged.
+24. Add a registry schema release impact gate. Tracked by Gira #79; this
+    requires `reports/registry-impact-plan.json` to carry
+    `registry:schema-release-surface` whenever readiness reports
+    `schema_set_complete.actual > expected`, and preserves `no_action`
+    boundaries for Dataset API, SDK, MCP, and datapan-data.
 
 ## Measurement Rules
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.release-manifest.v1",
-  "generated_at": "2026-06-30T09:32:00Z",
+  "generated_at": "2026-06-30T09:40:00Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "source_registry": "data/data-go-kr.registry.json",
@@ -142,8 +142,8 @@
     {
       "path": "schemas/datapan.registry-impact-plan.v1.schema.json",
       "kind": "schema",
-      "bytes": 8410,
-      "sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+      "bytes": 8444,
+      "sha256": "830517bcda01cad7143c02dd13f861aa0b442d3d81e6b0f398c51e30eb14137a"
     },
     {
       "path": "schemas/datapan.source-profile.v1.schema.json",
@@ -180,7 +180,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 10658,
-      "sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997"
+      "sha256": "48b3bb5fd56bf795568c8ab5e670ee8f48f188c1f82f156e286efb25a0c2128b"
     },
     {
       "path": "data/data-go-kr.registry.json",

--- a/reports/latest-release-readiness.json
+++ b/reports/latest-release-readiness.json
@@ -2,7 +2,7 @@
   "manifest": "manifest.json",
   "root": ".",
   "schema_version": "datapan.release-readiness.v1",
-  "generated_at": "2026-06-30T09:33:12Z",
+  "generated_at": "2026-06-30T09:39:15Z",
   "datapan_version": "0.1.0-dev",
   "provider": "data.go.kr",
   "ready": true,

--- a/reports/latest-release-verification.json
+++ b/reports/latest-release-verification.json
@@ -210,10 +210,10 @@
       "path": "schemas/datapan.registry-impact-plan.v1.schema.json",
       "kind": "schema",
       "status": "verified",
-      "expected_bytes": 8410,
-      "actual_bytes": 8410,
-      "expected_sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c",
-      "actual_sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+      "expected_bytes": 8444,
+      "actual_bytes": 8444,
+      "expected_sha256": "830517bcda01cad7143c02dd13f861aa0b442d3d81e6b0f398c51e30eb14137a",
+      "actual_sha256": "830517bcda01cad7143c02dd13f861aa0b442d3d81e6b0f398c51e30eb14137a"
     },
     {
       "path": "schemas/datapan.source-profile.v1.schema.json",
@@ -266,8 +266,8 @@
       "status": "verified",
       "expected_bytes": 10658,
       "actual_bytes": 10658,
-      "expected_sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997",
-      "actual_sha256": "1243953f349693aac46ad354b1ad1a2ab5011031a23af00490328b0ce5bf7997"
+      "expected_sha256": "48b3bb5fd56bf795568c8ab5e670ee8f48f188c1f82f156e286efb25a0c2128b",
+      "actual_sha256": "48b3bb5fd56bf795568c8ab5e670ee8f48f188c1f82f156e286efb25a0c2128b"
     },
     {
       "path": "data/data-go-kr.registry.json",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -10,40 +10,44 @@
   "previous_registry": "reports/*/registry-impact-plan.json",
   "current_registry": "reports/registry-impact-plan.json",
   "summary": {
-    "total": 3,
+    "total": 4,
     "by_category": [
       {
         "category": "added",
         "count": 3
+      },
+      {
+        "category": "release_schema_changed",
+        "count": 1
       }
     ],
     "by_target": [
       {
         "target": "datapan-cli",
-        "count": 2
+        "count": 3
       },
       {
         "target": "datapan-data",
-        "count": 3
+        "count": 4
       },
       {
         "target": "dataset-api",
-        "count": 3
+        "count": 4
       },
       {
         "target": "mcp",
-        "count": 3
+        "count": 4
       },
       {
         "target": "registry-release",
-        "count": 2
+        "count": 3
       },
       {
         "target": "sdk",
-        "count": 3
+        "count": 4
       }
     ],
-    "requires_manual_review": 0,
+    "requires_manual_review": 1,
     "requires_db_migration_review": 0,
     "requires_served_contract_regeneration": 0
   },
@@ -185,6 +189,57 @@
         }
       ],
       "notes": "Adapter work remains blocked unless route disposition produces adapter_candidate evidence."
+    },
+    {
+      "identity": {
+        "provider": "datapan-registry",
+        "source_id": "registry",
+        "endpoint_id": "registry:schema-release-surface"
+      },
+      "category": "release_schema_changed",
+      "severity": "medium",
+      "promoted_dataset": false,
+      "served_dataset": false,
+      "actions": [
+        {
+          "target": "datapan-cli",
+          "action": "investigate",
+          "automation": "manual_review",
+          "reason": "Release readiness reports schema_set_complete expected=20 and actual=28, so datapan-cli release draft schema knowledge must be reconciled with the registry release surface.",
+          "issue_hint": "Update datapan-cli datapanSchemaFiles/release draft schema generation for the 28 checked-in registry schemas."
+        },
+        {
+          "target": "registry-release",
+          "action": "refresh_verification",
+          "automation": "automated",
+          "reason": "Registry release verification must continue checking all 28 schema artifacts and fail on schema index or manifest drift."
+        },
+        {
+          "target": "datapan-data",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Schema release artifact coverage does not create or change a promoted data block."
+        },
+        {
+          "target": "dataset-api",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Schema release artifact coverage does not change served dataset API contracts."
+        },
+        {
+          "target": "sdk",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Schema release artifact coverage does not change SDK contracts."
+        },
+        {
+          "target": "mcp",
+          "action": "no_action",
+          "automation": "automated",
+          "reason": "Schema release artifact coverage does not change MCP tool contracts."
+        }
+      ],
+      "notes": "Registry-only release schema surface expansion from 20 to 28 schema artifacts."
     }
   ]
 }

--- a/schemas/datapan.registry-impact-plan.v1.schema.json
+++ b/schemas/datapan.registry-impact-plan.v1.schema.json
@@ -299,7 +299,8 @@
         "response_shape_changed",
         "cadence_changed",
         "provider_error_taxonomy_changed",
-        "verification_status_changed"
+        "verification_status_changed",
+        "release_schema_changed"
       ]
     },
     "action_target": {

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.schema-index.v1",
-  "generated_at": "2026-06-30T09:32:00Z",
+  "generated_at": "2026-06-30T09:40:00Z",
   "datapan_version": "0.1.0-dev",
   "count": 28,
   "schemas": [
@@ -208,8 +208,8 @@
       "title": "Datapan Registry Impact Plan v1",
       "contract": "registry-impact-plan",
       "version": "v1",
-      "bytes": 8410,
-      "sha256": "7a1363e206d929718a70ee62621c31d8e5f72a2386e929e7c370549cee08806c"
+      "bytes": 8444,
+      "sha256": "830517bcda01cad7143c02dd13f861aa0b442d3d81e6b0f398c51e30eb14137a"
     },
     {
       "path": "schemas/datapan.source-profile.v1.schema.json",

--- a/scripts/validate-impact-plans.py
+++ b/scripts/validate-impact-plans.py
@@ -18,6 +18,8 @@ except ImportError as exc:  # pragma: no cover - environment guard
 
 
 CLIENT_SERVER_TARGETS = {"dataset-api", "sdk", "mcp"}
+REGISTRY_ONLY_NO_ACTION_TARGETS = {"datapan-data", "dataset-api", "sdk", "mcp"}
+SCHEMA_RELEASE_ENDPOINT_ID = "registry:schema-release-surface"
 
 
 def load_json(path: pathlib.Path) -> object:
@@ -51,6 +53,82 @@ def count_summary(entries: object, key: str) -> dict[str, int]:
         if isinstance(value, str) and isinstance(count, int):
             counts[value] = count
     return counts
+
+
+def release_schema_gate_delta() -> tuple[int, int] | None:
+    readiness_path = pathlib.Path("reports/latest-release-readiness.json")
+    if not readiness_path.exists():
+        return None
+    readiness = as_dict(load_json(readiness_path), readiness_path)
+    gates = readiness.get("gates")
+    if not isinstance(gates, list):
+        return None
+    for gate in gates:
+        if not isinstance(gate, dict) or gate.get("id") != "schema_set_complete":
+            continue
+        expected = gate.get("expected")
+        actual = gate.get("actual")
+        if isinstance(expected, int) and isinstance(actual, int):
+            return expected, actual
+    return None
+
+
+def actions_by_target(change: dict[str, object]) -> dict[str, dict[str, object]]:
+    actions = change.get("actions")
+    if not isinstance(actions, list):
+        return {}
+    result: dict[str, dict[str, object]] = {}
+    for action in actions:
+        if isinstance(action, dict) and isinstance(action.get("target"), str):
+            result[str(action["target"])] = action
+    return result
+
+
+def validate_schema_release_impact_gate(path: pathlib.Path, plan: dict[str, object]) -> None:
+    if plan.get("scope", "source") != "release":
+        return
+    delta = release_schema_gate_delta()
+    if delta is None:
+        return
+    expected, actual = delta
+    if actual <= expected:
+        return
+
+    changes = plan.get("changes")
+    if not isinstance(changes, list):
+        raise ValueError("changes must be an array")
+    matching = [
+        change
+        for change in changes
+        if isinstance(change, dict)
+        and isinstance(change.get("identity"), dict)
+        and change["identity"].get("endpoint_id") == SCHEMA_RELEASE_ENDPOINT_ID
+    ]
+    if not matching:
+        raise ValueError(
+            f"missing {SCHEMA_RELEASE_ENDPOINT_ID} change for schema_set_complete expected={expected} actual={actual}"
+        )
+    if len(matching) > 1:
+        raise ValueError(f"duplicate {SCHEMA_RELEASE_ENDPOINT_ID} changes")
+
+    change = matching[0]
+    if change.get("category") != "release_schema_changed":
+        raise ValueError(f"{SCHEMA_RELEASE_ENDPOINT_ID} category must be release_schema_changed")
+    if change.get("promoted_dataset") is not False or change.get("served_dataset") is not False:
+        raise ValueError(f"{SCHEMA_RELEASE_ENDPOINT_ID} must remain registry-only")
+
+    by_target = actions_by_target(change)
+    cli_action = by_target.get("datapan-cli")
+    if not cli_action or cli_action.get("action") != "investigate" or cli_action.get("automation") != "manual_review":
+        raise ValueError(f"{SCHEMA_RELEASE_ENDPOINT_ID} must require datapan-cli manual investigate action")
+    release_action = by_target.get("registry-release")
+    if not release_action or release_action.get("action") != "refresh_verification":
+        raise ValueError(f"{SCHEMA_RELEASE_ENDPOINT_ID} must refresh registry-release verification")
+
+    for target in sorted(REGISTRY_ONLY_NO_ACTION_TARGETS):
+        action = by_target.get(target)
+        if not action or action.get("action") != "no_action":
+            raise ValueError(f"{SCHEMA_RELEASE_ENDPOINT_ID} must keep {target} at no_action")
 
 
 def validate_consistency(path: pathlib.Path, plan: dict[str, object]) -> None:
@@ -120,6 +198,7 @@ def validate_consistency(path: pathlib.Path, plan: dict[str, object]) -> None:
         raise ValueError("summary.requires_db_migration_review does not match actions")
     if summary.get("requires_served_contract_regeneration") != served_contract_regeneration:
         raise ValueError("summary.requires_served_contract_regeneration does not match actions")
+    validate_schema_release_impact_gate(path, plan)
 
 
 def main() -> int:


### PR DESCRIPTION
Closes #79

## Summary
- Added `release_schema_changed` as an impact-plan category.
- Added `registry:schema-release-surface` to `reports/registry-impact-plan.json`.
- Extended `validate-impact-plans.py` so readiness `schema_set_complete.actual > expected` requires the schema release surface impact entry.
- Preserved registry-only no-action boundaries for datapan-data, Dataset API, SDK, and MCP.

## Metrics
- Impact plan changes: `3 -> 4`
- `release_schema_changed`: `1`
- datapan-cli manual review actions: `0 -> 1`
- release verification: `checked=47`, `failed=0`, `ok=true`
- release readiness: `schema_artifacts=28`, `warned=0`, `failed=0`
- Runtime warnings unchanged: `non_data_runtime_evidence_not_collected=4`, `source_runtime_adapter_not_registered=4`

## Validation
- `python3 scripts/sync-release-schema-artifacts.py --check`
- `python3 scripts/validate-source-profiles.py`
- `python3 scripts/validate-error-action-catalogs.py`
- `python3 scripts/validate-external-coverage.py`
- `python3 scripts/validate-impact-plans.py`
- `python3 scripts/validate-source-reference-drift.py`
- `python3 scripts/validate-source-runtime-candidates.py`
- `python3 scripts/validate-source-runtime-evidence-plans.py`
- `python3 scripts/validate-source-runtime-evidence-rollup.py`
- `python3 scripts/validate-runtime-evidence-growth.py`
- `datapan catalog release verify` via local datapan-cli with materialized LFS registry
- `datapan catalog release readiness` via local datapan-cli with materialized LFS registry
- `python3 scripts/validate-institution-api-overview.py`
- `jq empty data/provider-index.json manifest.json reports/*.json reports/*/*.json schemas/*.json`
- `git diff --check`

## Remaining Gap
This does not update datapan-cli itself. It turns the `schema_set_complete expected=20 actual=28` mismatch into a tracked datapan-cli manual investigation while keeping registry release verification automated.