### PR TITLE
feat: Add operator workflow credential env gate

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -400,8 +400,8 @@
     {
       "path": "schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
       "kind": "schema",
-      "bytes": 17765,
-      "sha256": "35f8219b976ee6f55c59b77133627788368fa3eda69b2c00f2d1978620ed3785"
+      "bytes": 18122,
+      "sha256": "78801a49e587db3bab498ec903507c1369d03b6fd42518b253fe795877ef0847"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",
@@ -414,7 +414,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 27405,
-      "sha256": "cda2bba81e837f2e96819fc52afd4acc708660ff0c9f651995d1d05b413a7798"
+      "sha256": "eca4c4354f688bcad5003f27af5413ea412c3b948673e608c12cc39cbae4c445"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -477,7 +477,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "f103a52f849ca321b75c2c358fbcc0123c270c4e9aba4b77efba163d187c0027"
+      "sha256": "86514f91d7c56a3615fba6b75b79dcccf1ded69dc8f0c5e8260ef359e9c1b840"
     },
     {
       "path": "reports/credential-runtime-evidence-policy.json",
@@ -525,8 +525,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 14326,
-      "sha256": "e210dcccbaa82590319bbb7e19bc153b89dbe43a4a60139775b0227f262fcce0"
+      "bytes": 14546,
+      "sha256": "ea711807bc5fd65cc4d9230be6248c1a8c3d31ff4b9f0ba64fe1622fb91d5b20"
     },
     {
       "path": "reports/credential-runtime-manual-review-decision.json",
@@ -547,14 +547,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3998,
-      "sha256": "d2f8cf7d7196f359aa029cb24481b1581cdaeb17bf65aba3581997c33e2bca82"
+      "sha256": "af8065c614ada63fd056760fce64e938939c871563de5406402e5ae6743c0b2e"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "5fdf7bfea72e6839b45d7a48453e04b66a7e39650ffc9944d764397e3e428614"
+      "sha256": "28d41594cc4b4d139a9c604a4a18b7d7adda4535103f31299a1abd4f430248bb"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -568,7 +568,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "ca2c1c86d9d8a79b61597f0f57965d76dfac9891efd098fa40b81afea9ebba81"
+      "sha256": "b26a7de73b62b9264e1c6af8176a59c1e16dbfa57abcf990a90475c10889f438"
     },
     {
       "path": "reports/dependencies.json",
@@ -638,14 +638,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26966,
-      "sha256": "e190a57548d2b03cee6182b54fe6477840d3c6f0a63086cbe011bef0ea67e587"
+      "sha256": "766c8d37863f991add69b9d850af7379d7c0c69edd5fd4346f3fd08fdc6c95f6"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "c1123b8ffb94459de5ad55e2789ba5d21d7dded49a4450b01f4c4ec85dfe9d4c"
+      "sha256": "a5873ddf94e01aa107408eec1f671893e025a9028fa3dce32b41e36287454aa5"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -694,7 +694,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34991,
-      "sha256": "7d240a34eaa397c3aad34002661521884852d0248b62616569dc9af14593c575"
+      "sha256": "9e9d17129a500eb8422ffa637afaffdb325be86d1363760a56f422499974999d"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/reports/credential-runtime-collection-execution-plan.json
+++ b/reports/credential-runtime-collection-execution-plan.json
@@ -52,6 +52,8 @@
     "script": "scripts/run-credential-runtime-operator-workflow.py",
     "plan_command": "python3 scripts/run-credential-runtime-operator-workflow.py --json",
     "run_command": "python3 scripts/run-credential-runtime-operator-workflow.py --run --json",
+    "require_env_command": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env",
+    "require_env_json_command": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env --json",
     "check_command": "python3 scripts/run-credential-runtime-operator-workflow.py --check",
     "self_test_command": "python3 scripts/run-credential-runtime-operator-workflow.py --self-test",
     "workflow_status": "operator_credentials_required",

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "e190a57548d2b03cee6182b54fe6477840d3c6f0a63086cbe011bef0ea67e587"
+    "compatibility_sha256": "766c8d37863f991add69b9d850af7379d7c0c69edd5fd4346f3fd08fdc6c95f6"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
-    "compatibility_sha256": "e190a57548d2b03cee6182b54fe6477840d3c6f0a63086cbe011bef0ea67e587",
+    "compatibility_sha256": "766c8d37863f991add69b9d850af7379d7c0c69edd5fd4346f3fd08fdc6c95f6",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "ca2c1c86d9d8a79b61597f0f57965d76dfac9891efd098fa40b81afea9ebba81"
+      "sha256": "b26a7de73b62b9264e1c6af8176a59c1e16dbfa57abcf990a90475c10889f438"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -108,7 +108,7 @@
         {
           "path": "schemas/index.json",
           "bytes": 27405,
-          "sha256": "cda2bba81e837f2e96819fc52afd4acc708660ff0c9f651995d1d05b413a7798",
+          "sha256": "eca4c4354f688bcad5003f27af5413ea412c3b948673e608c12cc39cbae4c445",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 59095,
-          "sha256": "ca2c1c86d9d8a79b61597f0f57965d76dfac9891efd098fa40b81afea9ebba81",
+          "sha256": "b26a7de73b62b9264e1c6af8176a59c1e16dbfa57abcf990a90475c10889f438",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "5fdf7bfea72e6839b45d7a48453e04b66a7e39650ffc9944d764397e3e428614",
+          "sha256": "28d41594cc4b4d139a9c604a4a18b7d7adda4535103f31299a1abd4f430248bb",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 14728,
-          "sha256": "f103a52f849ca321b75c2c358fbcc0123c270c4e9aba4b77efba163d187c0027",
+          "sha256": "86514f91d7c56a3615fba6b75b79dcccf1ded69dc8f0c5e8260ef359e9c1b840",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3998,
-          "sha256": "d2f8cf7d7196f359aa029cb24481b1581cdaeb17bf65aba3581997c33e2bca82",
+          "sha256": "af8065c614ada63fd056760fce64e938939c871563de5406402e5ae6743c0b2e",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2119,
-          "sha256": "c1123b8ffb94459de5ad55e2789ba5d21d7dded49a4450b01f4c4ec85dfe9d4c",
+          "sha256": "a5873ddf94e01aa107408eec1f671893e025a9028fa3dce32b41e36287454aa5",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26966,
-          "sha256": "e190a57548d2b03cee6182b54fe6477840d3c6f0a63086cbe011bef0ea67e587",
+          "sha256": "766c8d37863f991add69b9d850af7379d7c0c69edd5fd4346f3fd08fdc6c95f6",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "f103a52f849ca321b75c2c358fbcc0123c270c4e9aba4b77efba163d187c0027",
+      "sha256": "86514f91d7c56a3615fba6b75b79dcccf1ded69dc8f0c5e8260ef359e9c1b840",
       "required": true
     },
     {
@@ -139,8 +139,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 14326,
-      "sha256": "e210dcccbaa82590319bbb7e19bc153b89dbe43a4a60139775b0227f262fcce0",
+      "bytes": 14546,
+      "sha256": "ea711807bc5fd65cc4d9230be6248c1a8c3d31ff4b9f0ba64fe1622fb91d5b20",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "5fdf7bfea72e6839b45d7a48453e04b66a7e39650ffc9944d764397e3e428614",
+      "sha256": "28d41594cc4b4d139a9c604a4a18b7d7adda4535103f31299a1abd4f430248bb",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "ca2c1c86d9d8a79b61597f0f57965d76dfac9891efd098fa40b81afea9ebba81",
+      "sha256": "b26a7de73b62b9264e1c6af8176a59c1e16dbfa57abcf990a90475c10889f438",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "c1123b8ffb94459de5ad55e2789ba5d21d7dded49a4450b01f4c4ec85dfe9d4c",
+      "sha256": "a5873ddf94e01aa107408eec1f671893e025a9028fa3dce32b41e36287454aa5",
       "required": true
     },
     {
@@ -489,7 +489,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 165921708,
+    "manifest_bound_bytes_excluding_self": 165922285,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -11,7 +11,7 @@
   "summary": {
     "artifact_count": 112,
     "schema_artifacts": 67,
-    "manifest_bound_bytes_excluding_self": 165921708,
+    "manifest_bound_bytes_excluding_self": 165922285,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -48,7 +48,7 @@
     "path": "schemas/index.json",
     "schemas": 67,
     "bytes": 27405,
-    "sha256": "cda2bba81e837f2e96819fc52afd4acc708660ff0c9f651995d1d05b413a7798"
+    "sha256": "eca4c4354f688bcad5003f27af5413ea412c3b948673e608c12cc39cbae4c445"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -44,7 +44,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "5fdf7bfea72e6839b45d7a48453e04b66a7e39650ffc9944d764397e3e428614"
+      "sha256": "28d41594cc4b4d139a9c604a4a18b7d7adda4535103f31299a1abd4f430248bb"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
+++ b/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
@@ -276,6 +276,8 @@
         "script",
         "plan_command",
         "run_command",
+        "require_env_command",
+        "require_env_json_command",
         "check_command",
         "self_test_command",
         "workflow_status",
@@ -299,6 +301,12 @@
         },
         "run_command": {
           "const": "python3 scripts/run-credential-runtime-operator-workflow.py --run --json"
+        },
+        "require_env_command": {
+          "const": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env"
+        },
+        "require_env_json_command": {
+          "const": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env --json"
         },
         "check_command": {
           "const": "python3 scripts/run-credential-runtime-operator-workflow.py --check"

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -595,8 +595,8 @@
       "title": "Datapan Credential Runtime Collection Execution Plan v1",
       "contract": "credential-runtime-collection-execution-plan",
       "version": "v1",
-      "bytes": 17765,
-      "sha256": "35f8219b976ee6f55c59b77133627788368fa3eda69b2c00f2d1978620ed3785"
+      "bytes": 18122,
+      "sha256": "78801a49e587db3bab498ec903507c1369d03b6fd42518b253fe795877ef0847"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",

--- a/scripts/generate-credential-runtime-collection-execution-plan.py
+++ b/scripts/generate-credential-runtime-collection-execution-plan.py
@@ -322,6 +322,8 @@ def build_report(
             "script": OPERATOR_WORKFLOW_SCRIPT.as_posix(),
             "plan_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --json",
             "run_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --run --json",
+            "require_env_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --require-env",
+            "require_env_json_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --require-env --json",
             "check_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --check",
             "self_test_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --self-test",
             "workflow_status": summary["session_plan_status"],

--- a/scripts/run-credential-runtime-operator-workflow.py
+++ b/scripts/run-credential-runtime-operator-workflow.py
@@ -420,6 +420,41 @@ def run_steps(report: dict[str, Any], *, json_mode: bool) -> dict[str, Any]:
     return execution
 
 
+def require_operator_env(report: dict[str, Any], *, json_mode: bool, emit: bool = True) -> int:
+    environment = as_dict(report.get("operator_environment"), "operator_environment")
+    missing_envs = environment.get("missing_credential_envs")
+    if not isinstance(missing_envs, list):
+        raise ValueError("operator_environment.missing_credential_envs must be an array")
+    result = {
+        "schema_version": "datapan.credential-runtime-operator-env-gate.v1",
+        "required_credential_envs": environment.get("required_credential_envs", []),
+        "present_credential_envs": environment.get("present_credential_envs", []),
+        "missing_credential_envs": missing_envs,
+        "required_credential_env_count": environment.get("required_credential_env_count"),
+        "present_credential_env_count": environment.get("present_credential_env_count"),
+        "missing_credential_env_count": environment.get("missing_credential_env_count"),
+        "current_operator_env_ready": environment.get("current_operator_env_ready"),
+        "secret_values_included": False,
+    }
+    if not missing_envs:
+        if emit:
+            if json_mode:
+                print(render_json(result), end="")
+            else:
+                print("ok credential runtime operator env gate")
+        return 0
+    if emit:
+        if json_mode:
+            print(render_json(result), end="")
+        else:
+            print(
+                "FAIL credential runtime operator env gate: missing "
+                + ", ".join(str(item) for item in missing_envs),
+                file=sys.stderr,
+            )
+    return 1
+
+
 def self_test(plan_path: pathlib.Path) -> None:
     plan = load_json(plan_path)
     report = build_workflow(
@@ -451,6 +486,23 @@ def self_test(plan_path: pathlib.Path) -> None:
         raise ValueError("self-test expected one present credential env name")
     if "redacted-value" in render_json(partial_report):
         raise ValueError("self-test leaked an env value into the workflow plan")
+    if require_operator_env(report, json_mode=True, emit=False) != 1:
+        raise ValueError("self-test expected empty env gate to fail")
+    complete_env = {name: "redacted-value" for name in report["operator_environment"]["required_credential_envs"]}
+    complete_report = build_workflow(
+        execution_plan=plan,
+        execution_plan_path=plan_path,
+        session_output=DEFAULT_SESSION_OUTPUT,
+        review_plan_output=DEFAULT_REVIEW_PLAN_OUTPUT,
+        queue_path=DEFAULT_QUEUE,
+        run=False,
+        environment=complete_env,
+    )
+    validate_workflow(complete_report)
+    if require_operator_env(complete_report, json_mode=True, emit=False) != 0:
+        raise ValueError("self-test expected complete env gate to pass")
+    if "redacted-value" in render_json(complete_report):
+        raise ValueError("self-test leaked a complete env value into the workflow plan")
     run_report = build_workflow(
         execution_plan=plan,
         execution_plan_path=plan_path,
@@ -491,6 +543,7 @@ def main() -> int:
     parser.add_argument("--run", action="store_true", help="execute the operator workflow")
     parser.add_argument("--json", action="store_true", help="print JSON output")
     parser.add_argument("--check", action="store_true", help="validate the workflow plan without credentials")
+    parser.add_argument("--require-env", action="store_true", help="fail unless all required credential env vars are present")
     parser.add_argument("--self-test", action="store_true", help="run credential-free workflow self-tests")
     args = parser.parse_args()
 
@@ -514,6 +567,8 @@ def main() -> int:
                 f"(status={report['summary']['session_plan_status']})"
             )
             return 0
+        if args.require_env:
+            return require_operator_env(report, json_mode=args.json)
         if args.run:
             report["execution"] = run_steps(report, json_mode=args.json)
     except Exception as exc:  # noqa: BLE001 - operators need the failed invariant


### PR DESCRIPTION
## Summary
- Add `--require-env` to `scripts/run-credential-runtime-operator-workflow.py` as a secret-safe pre-run credential gate for #457.
- Return machine-readable env gate JSON with required/present/missing env names, readiness, and `secret_values_included=false`.
- Expose `require_env_command` and `require_env_json_command` in the checked-in credential runtime collection execution plan and schema.

## Verification
- `python3 -m py_compile scripts/run-credential-runtime-operator-workflow.py scripts/generate-credential-runtime-collection-execution-plan.py`
- `python3 scripts/run-credential-runtime-operator-workflow.py --self-test`
- `python3 scripts/run-credential-runtime-operator-workflow.py --require-env --json` returned missing env names and exit 1 in this shell
- all five credential envs set to `SECRET_VALUE_DO_NOT_LEAK_*` with `--require-env --json` returned ready=true and did not include secret values
- `python3 scripts/generate-credential-runtime-collection-execution-plan.py --check`
- `python3 scripts/refresh-release-ledger-evidence.py --check`

Closes #462
