### PR TITLE
feat: Add GitHub secret readiness checker

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -108,6 +108,7 @@ jobs:
             scripts/generate-credential-runtime-manual-review-acceptance.py \
             scripts/run-credential-runtime-collection.py \
             scripts/run-credential-runtime-operator-workflow.py \
+            scripts/check-credential-runtime-github-secrets.py \
             scripts/promote-credential-runtime-session-review.py \
             scripts/validate-credential-runtime-collection-session.py \
             scripts/generate-credential-runtime-session-review-plan.py \
@@ -186,6 +187,8 @@ jobs:
           python scripts/run-credential-runtime-collection.py --check
           python scripts/run-credential-runtime-operator-workflow.py --self-test
           python scripts/run-credential-runtime-operator-workflow.py --check
+          python scripts/check-credential-runtime-github-secrets.py --self-test
+          python scripts/check-credential-runtime-github-secrets.py --check
           python scripts/promote-credential-runtime-session-review.py --self-test
           python scripts/promote-credential-runtime-session-review.py --check
           python scripts/validate-credential-runtime-collection-session.py --self-test

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -103,6 +103,8 @@ jobs:
           python scripts/run-credential-runtime-collection.py --check
           python scripts/run-credential-runtime-operator-workflow.py --self-test
           python scripts/run-credential-runtime-operator-workflow.py --check
+          python scripts/check-credential-runtime-github-secrets.py --self-test
+          python scripts/check-credential-runtime-github-secrets.py --check
           python scripts/promote-credential-runtime-session-review.py --self-test
           python scripts/promote-credential-runtime-session-review.py --check
           python scripts/validate-credential-runtime-collection-session.py --self-test
@@ -142,6 +144,7 @@ jobs:
           python -m py_compile scripts/generate-credential-runtime-manual-review-acceptance-packet.py
           python -m py_compile scripts/run-credential-runtime-collection.py
           python -m py_compile scripts/run-credential-runtime-operator-workflow.py
+          python -m py_compile scripts/check-credential-runtime-github-secrets.py
           python -m py_compile scripts/promote-credential-runtime-session-review.py
           python -m py_compile scripts/validate-credential-runtime-collection-session.py
           python -m py_compile scripts/generate-credential-runtime-session-review-plan.py

--- a/manifest.json
+++ b/manifest.json
@@ -400,8 +400,8 @@
     {
       "path": "schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
       "kind": "schema",
-      "bytes": 19531,
-      "sha256": "676165185ee91a889027e41e29d1705a5bc16204aee87c4ebb35d1c2362ac170"
+      "bytes": 19948,
+      "sha256": "db87cbba2f332e1ba723bbdc8df2483d03c3b767abbcb085538b5e60dcc6b98e"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",
@@ -414,7 +414,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 27405,
-      "sha256": "101c94edd1f9a5b1d8ce1a48b4dabc420b8b04ae712033ec59f26fd4631e7752"
+      "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -477,7 +477,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "87b873f5d955ae43819f770502ec36705a8d89ce6214d89737ee0047a73d1b10"
+      "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc"
     },
     {
       "path": "reports/credential-runtime-evidence-policy.json",
@@ -525,8 +525,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 15281,
-      "sha256": "e583a7db5d2a0a6a1824e7e85fcddfbfe794fe5604e29b176eb2ef73f77f1c0c"
+      "bytes": 15536,
+      "sha256": "dbc4a1e32c88c06b39a538166f9384e742d55b4d4f096ebddb227e9fa110d617"
     },
     {
       "path": "reports/credential-runtime-manual-review-decision.json",
@@ -547,14 +547,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3998,
-      "sha256": "1ecfde69c64ffd5583035f043045b5d8385e7b811674449e72d78ef585d1abd2"
+      "sha256": "a21dcf80e2966d6cbb64d8467db9aa46b2918f7ba5f5cf72bb957da22c2557db"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "af0f815dc87201dcda61e68fbf4fa8e330d46620471efc66615e5e381167cc41"
+      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -568,7 +568,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "03df04399f6f4e15bc8873a06f43bd5addbc9938db45b186fbd2526450cc57d8"
+      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea"
     },
     {
       "path": "reports/dependencies.json",
@@ -638,14 +638,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26966,
-      "sha256": "3629138b79c9ce656c3b1048950db4ce15aafce8a0ced452cedcda99c7c59894"
+      "sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "81a808e4b84db7b6c2777bd63a9db952261793575259c8c9143f42cdce308d33"
+      "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -694,7 +694,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34991,
-      "sha256": "c7af37837f88bfa3f767e60a79555ec2a593445c30c9052df12ef348c6fe7a24"
+      "sha256": "68fa9753e1af0c2e7fc21cd36662bab0659a324c506a8435d2f49a51b2e2d5d9"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/reports/credential-runtime-collection-execution-plan.json
+++ b/reports/credential-runtime-collection-execution-plan.json
@@ -57,6 +57,8 @@
     "github_actions_dispatch_workflow": ".github/workflows/credential-runtime-collection.yml",
     "github_actions_preflight_command": "gh workflow run credential-runtime-collection.yml --repo StatPan/datapan-registry -f mode=preflight",
     "github_actions_collect_command": "gh workflow run credential-runtime-collection.yml --repo StatPan/datapan-registry -f mode=collect",
+    "github_secret_readiness_command": "python3 scripts/check-credential-runtime-github-secrets.py --repo StatPan/datapan-registry --json",
+    "github_secret_readiness_check_command": "python3 scripts/check-credential-runtime-github-secrets.py --check",
     "github_actions_secret_readiness_schema": "datapan.credential-runtime-github-secret-readiness.v1",
     "github_actions_secret_readiness_artifact": "credential-runtime-secret-readiness",
     "check_command": "python3 scripts/run-credential-runtime-operator-workflow.py --check",

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "3629138b79c9ce656c3b1048950db4ce15aafce8a0ced452cedcda99c7c59894"
+    "compatibility_sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
-    "compatibility_sha256": "3629138b79c9ce656c3b1048950db4ce15aafce8a0ced452cedcda99c7c59894",
+    "compatibility_sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "03df04399f6f4e15bc8873a06f43bd5addbc9938db45b186fbd2526450cc57d8"
+      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -108,7 +108,7 @@
         {
           "path": "schemas/index.json",
           "bytes": 27405,
-          "sha256": "101c94edd1f9a5b1d8ce1a48b4dabc420b8b04ae712033ec59f26fd4631e7752",
+          "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 59095,
-          "sha256": "03df04399f6f4e15bc8873a06f43bd5addbc9938db45b186fbd2526450cc57d8",
+          "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "af0f815dc87201dcda61e68fbf4fa8e330d46620471efc66615e5e381167cc41",
+          "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 14728,
-          "sha256": "87b873f5d955ae43819f770502ec36705a8d89ce6214d89737ee0047a73d1b10",
+          "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3998,
-          "sha256": "1ecfde69c64ffd5583035f043045b5d8385e7b811674449e72d78ef585d1abd2",
+          "sha256": "a21dcf80e2966d6cbb64d8467db9aa46b2918f7ba5f5cf72bb957da22c2557db",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2119,
-          "sha256": "81a808e4b84db7b6c2777bd63a9db952261793575259c8c9143f42cdce308d33",
+          "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26966,
-          "sha256": "3629138b79c9ce656c3b1048950db4ce15aafce8a0ced452cedcda99c7c59894",
+          "sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "87b873f5d955ae43819f770502ec36705a8d89ce6214d89737ee0047a73d1b10",
+      "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc",
       "required": true
     },
     {
@@ -139,8 +139,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 15281,
-      "sha256": "e583a7db5d2a0a6a1824e7e85fcddfbfe794fe5604e29b176eb2ef73f77f1c0c",
+      "bytes": 15536,
+      "sha256": "dbc4a1e32c88c06b39a538166f9384e742d55b4d4f096ebddb227e9fa110d617",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "af0f815dc87201dcda61e68fbf4fa8e330d46620471efc66615e5e381167cc41",
+      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "03df04399f6f4e15bc8873a06f43bd5addbc9938db45b186fbd2526450cc57d8",
+      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "81a808e4b84db7b6c2777bd63a9db952261793575259c8c9143f42cdce308d33",
+      "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7",
       "required": true
     },
     {
@@ -489,7 +489,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 165924429,
+    "manifest_bound_bytes_excluding_self": 165925101,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -11,7 +11,7 @@
   "summary": {
     "artifact_count": 112,
     "schema_artifacts": 67,
-    "manifest_bound_bytes_excluding_self": 165924429,
+    "manifest_bound_bytes_excluding_self": 165925101,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -48,7 +48,7 @@
     "path": "schemas/index.json",
     "schemas": 67,
     "bytes": 27405,
-    "sha256": "101c94edd1f9a5b1d8ce1a48b4dabc420b8b04ae712033ec59f26fd4631e7752"
+    "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -44,7 +44,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "af0f815dc87201dcda61e68fbf4fa8e330d46620471efc66615e5e381167cc41"
+      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
+++ b/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
@@ -281,6 +281,8 @@
         "github_actions_dispatch_workflow",
         "github_actions_preflight_command",
         "github_actions_collect_command",
+        "github_secret_readiness_command",
+        "github_secret_readiness_check_command",
         "github_actions_secret_readiness_schema",
         "github_actions_secret_readiness_artifact",
         "check_command",
@@ -324,6 +326,12 @@
         },
         "github_actions_collect_command": {
           "const": "gh workflow run credential-runtime-collection.yml --repo StatPan/datapan-registry -f mode=collect"
+        },
+        "github_secret_readiness_command": {
+          "const": "python3 scripts/check-credential-runtime-github-secrets.py --repo StatPan/datapan-registry --json"
+        },
+        "github_secret_readiness_check_command": {
+          "const": "python3 scripts/check-credential-runtime-github-secrets.py --check"
         },
         "github_actions_secret_readiness_schema": {
           "const": "datapan.credential-runtime-github-secret-readiness.v1"

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -595,8 +595,8 @@
       "title": "Datapan Credential Runtime Collection Execution Plan v1",
       "contract": "credential-runtime-collection-execution-plan",
       "version": "v1",
-      "bytes": 19531,
-      "sha256": "676165185ee91a889027e41e29d1705a5bc16204aee87c4ebb35d1c2362ac170"
+      "bytes": 19948,
+      "sha256": "db87cbba2f332e1ba723bbdc8df2483d03c3b767abbcb085538b5e60dcc6b98e"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",

--- a/scripts/check-credential-runtime-github-secrets.py
+++ b/scripts/check-credential-runtime-github-secrets.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Check GitHub repository secret readiness for credential runtime collection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_EXECUTION_PLAN = pathlib.Path("reports/credential-runtime-collection-execution-plan.json")
+DEFAULT_REPO = "StatPan/datapan-registry"
+SCHEMA_VERSION = "datapan.credential-runtime-github-secret-readiness.v1"
+
+
+def load_json(path: pathlib.Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def render_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+
+
+def as_dict(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def as_list(value: object, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return value
+
+
+def string_value(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def required_envs(execution_plan: dict[str, Any]) -> list[str]:
+    environment = as_dict(execution_plan.get("operator_environment"), "execution_plan.operator_environment")
+    envs = [
+        string_value(item, "operator_environment.required_credential_envs[]")
+        for item in as_list(environment.get("required_credential_envs"), "operator_environment.required_credential_envs")
+    ]
+    if not envs:
+        raise ValueError("operator_environment.required_credential_envs must not be empty")
+    return envs
+
+
+def load_secret_entries(repo: str) -> list[dict[str, Any]]:
+    result = subprocess.run(
+        ["gh", "secret", "list", "--repo", repo, "--json", "name,updatedAt"],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh secret list failed")
+    value = json.loads(result.stdout)
+    if not isinstance(value, list):
+        raise ValueError("gh secret list output must be an array")
+    return [as_dict(item, "gh_secret_list[]") for item in value]
+
+
+def build_report(*, repo: str, required: list[str], secret_entries: list[dict[str, Any]]) -> dict[str, Any]:
+    by_name = {
+        string_value(entry.get("name"), "secret.name"): entry
+        for entry in secret_entries
+    }
+    present = [name for name in required if name in by_name]
+    missing = [name for name in required if name not in by_name]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo": repo,
+        "source": "gh secret list",
+        "required_credential_envs": required,
+        "present_credential_envs": present,
+        "missing_credential_envs": missing,
+        "required_credential_env_count": len(required),
+        "present_credential_env_count": len(present),
+        "missing_credential_env_count": len(missing),
+        "current_operator_env_ready": not missing,
+        "secret_values_included": False,
+        "present_secret_metadata": [
+            {
+                "name": name,
+                "updatedAt": by_name[name].get("updatedAt", ""),
+            }
+            for name in present
+        ],
+    }
+
+
+def validate_report(report: dict[str, Any]) -> None:
+    if report.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unexpected schema_version")
+    required = as_list(report.get("required_credential_envs"), "required_credential_envs")
+    present = as_list(report.get("present_credential_envs"), "present_credential_envs")
+    missing = as_list(report.get("missing_credential_envs"), "missing_credential_envs")
+    if len(required) != report.get("required_credential_env_count"):
+        raise ValueError("required count mismatch")
+    if len(present) != report.get("present_credential_env_count"):
+        raise ValueError("present count mismatch")
+    if len(missing) != report.get("missing_credential_env_count"):
+        raise ValueError("missing count mismatch")
+    if report.get("current_operator_env_ready") != (len(missing) == 0):
+        raise ValueError("current_operator_env_ready must derive from missing count")
+    if report.get("secret_values_included") is not False:
+        raise ValueError("secret_values_included must remain false")
+    rendered = render_json(report).lower()
+    for marker in ("authorization:", "bearer ", "service_key=", "api_key=", "secret=", "token="):
+        if marker in rendered:
+            raise ValueError(f"report must not contain secret-like marker {marker!r}")
+
+
+def run_self_test() -> None:
+    required = ["DATAPAN_ALPHA_KEY", "DATAPAN_BETA_KEY"]
+    partial = build_report(
+        repo="Owner/repo",
+        required=required,
+        secret_entries=[{"name": "DATAPAN_ALPHA_KEY", "updatedAt": "2026-07-07T00:00:00Z"}],
+    )
+    validate_report(partial)
+    if partial["present_credential_envs"] != ["DATAPAN_ALPHA_KEY"]:
+        raise ValueError("self-test expected alpha key present")
+    if partial["missing_credential_envs"] != ["DATAPAN_BETA_KEY"]:
+        raise ValueError("self-test expected beta key missing")
+    complete = build_report(
+        repo="Owner/repo",
+        required=required,
+        secret_entries=[
+            {"name": "DATAPAN_ALPHA_KEY", "updatedAt": "2026-07-07T00:00:00Z"},
+            {"name": "DATAPAN_BETA_KEY", "updatedAt": "2026-07-07T00:00:00Z"},
+        ],
+    )
+    validate_report(complete)
+    if complete["current_operator_env_ready"] is not True:
+        raise ValueError("self-test expected complete readiness")
+
+
+def print_human(report: dict[str, Any]) -> None:
+    print(
+        "credential runtime GitHub secret readiness "
+        f"(repo={report['repo']}, required={report['required_credential_env_count']}, "
+        f"present={report['present_credential_env_count']}, missing={report['missing_credential_env_count']})"
+    )
+    missing = report["missing_credential_envs"]
+    if missing:
+        print("missing: " + ", ".join(missing))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execution-plan", default=DEFAULT_EXECUTION_PLAN, type=pathlib.Path)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--secret-list-json", type=pathlib.Path, help="read gh secret list JSON from a file")
+    parser.add_argument("--json", action="store_true", help="print JSON output")
+    parser.add_argument("--check", action="store_true", help="validate required env configuration without querying GitHub")
+    parser.add_argument("--self-test", action="store_true", help="run secret-free self-tests")
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            run_self_test()
+            print("ok credential runtime GitHub secret readiness self-test")
+            return 0
+        required = required_envs(as_dict(load_json(args.execution_plan), "execution_plan"))
+        if args.check:
+            if len(set(required)) != len(required):
+                raise ValueError("required credential env names must be unique")
+            print(f"ok credential runtime GitHub secret readiness config (required={len(required)})")
+            return 0
+        if args.secret_list_json:
+            raw_entries = load_json(args.secret_list_json)
+            if not isinstance(raw_entries, list):
+                raise ValueError("--secret-list-json must contain an array")
+            secret_entries = [as_dict(item, "secret_list_json[]") for item in raw_entries]
+        else:
+            secret_entries = load_secret_entries(args.repo)
+        report = build_report(repo=args.repo, required=required, secret_entries=secret_entries)
+        validate_report(report)
+    except Exception as exc:  # noqa: BLE001 - operators need the failed invariant
+        print(f"FAIL credential runtime GitHub secret readiness: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(render_json(report), end="")
+    else:
+        print_human(report)
+    return 0 if report["current_operator_env_ready"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-credential-runtime-collection-execution-plan.py
+++ b/scripts/generate-credential-runtime-collection-execution-plan.py
@@ -24,6 +24,7 @@ DEFAULT_SCHEMA = pathlib.Path("schemas/datapan.credential-runtime-collection-exe
 DEFAULT_OUTPUT = pathlib.Path("reports/credential-runtime-collection-execution-plan.json")
 SCHEMA_VERSION = "datapan.credential-runtime-collection-execution-plan.v1"
 OPERATOR_WORKFLOW_SCRIPT = pathlib.Path("scripts/run-credential-runtime-operator-workflow.py")
+GITHUB_SECRET_READINESS_SCRIPT = pathlib.Path("scripts/check-credential-runtime-github-secrets.py")
 GITHUB_DISPATCH_WORKFLOW = pathlib.Path(".github/workflows/credential-runtime-collection.yml")
 SESSION_REVIEW_PROMOTION_SCRIPT = pathlib.Path("scripts/promote-credential-runtime-session-review.py")
 SESSION_REVIEW_DECISIONS_PATH = pathlib.Path(
@@ -334,6 +335,11 @@ def build_report(
                 "gh workflow run credential-runtime-collection.yml "
                 "--repo StatPan/datapan-registry -f mode=collect"
             ),
+            "github_secret_readiness_command": (
+                f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} "
+                "--repo StatPan/datapan-registry --json"
+            ),
+            "github_secret_readiness_check_command": f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} --check",
             "github_actions_secret_readiness_schema": "datapan.credential-runtime-github-secret-readiness.v1",
             "github_actions_secret_readiness_artifact": "credential-runtime-secret-readiness",
             "check_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --check",
@@ -483,6 +489,12 @@ def validate_invariants(report: dict[str, Any]) -> None:
         command = string_value(workflow.get(key), f"operator_workflow.{key}")
         if "credential-runtime-collection.yml" not in command:
             raise ValueError(f"operator_workflow.{key} must dispatch the credential runtime workflow")
+    if workflow.get("github_secret_readiness_command") != (
+        f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} --repo StatPan/datapan-registry --json"
+    ):
+        raise ValueError("operator_workflow.github_secret_readiness_command must match checked-in checker command")
+    if workflow.get("github_secret_readiness_check_command") != f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} --check":
+        raise ValueError("operator_workflow.github_secret_readiness_check_command must match checked-in checker check command")
     if workflow.get("workflow_status") != summary.get("session_plan_status"):
         raise ValueError("operator_workflow.workflow_status must match summary.session_plan_status")
     if workflow.get("next_action") != summary.get("next_action"):


### PR DESCRIPTION
## Summary
- Add `scripts/check-credential-runtime-github-secrets.py`, a secret-free checker that compares required credential env names from the execution plan against `gh secret list` for `StatPan/datapan-registry`.
- Expose the checker command and check command in `reports/credential-runtime-collection-execution-plan.json` and its schema.
- Add CI coverage for the new checker through self-test/check and py_compile in verify/release-draft workflows.

## Verification
- `python3 -m py_compile scripts/check-credential-runtime-github-secrets.py scripts/generate-credential-runtime-collection-execution-plan.py`
- `python3 scripts/check-credential-runtime-github-secrets.py --self-test`
- `python3 scripts/check-credential-runtime-github-secrets.py --check`
- `python3 scripts/check-credential-runtime-github-secrets.py --repo StatPan/datapan-registry --json; test $? -eq 1`
- `python3 scripts/generate-credential-runtime-collection-execution-plan.py --check`
- `python3 scripts/refresh-release-ledger-evidence.py --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify-release.yml"); YAML.load_file(".github/workflows/release-draft.yml"); puts "ok workflow yaml parse"'`
- `git diff --check`

## Goal Boundary
This reduces #457 secret provisioning readiness friction but does not provision secrets, run credentialed collection, create or promote receipts, or close #344. Current real repo readiness still reports all five required secrets missing and `secret_values_included=false`.

Closes #468
