### PR TITLE
feat: Bind continuation queue to goal routing evidence

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -346,8 +346,8 @@
     {
       "path": "schemas/datapan.release-goal-continuation-queue.v1.schema.json",
       "kind": "schema",
-      "bytes": 12250,
-      "sha256": "233ab75f176644281b452a43e0765bdb7b4e9c9fced513b1c77b654729e0ae41"
+      "bytes": 13955,
+      "sha256": "1e605f1d7d8a2ddd227b8efdc1761d6ac07753657f4ff0e01dbfb171c7110c5e"
     },
     {
       "path": "schemas/datapan.credential-runtime-operator-packets.v1.schema.json",
@@ -414,7 +414,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 27405,
-      "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1"
+      "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -477,7 +477,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc"
+      "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55"
     },
     {
       "path": "reports/credential-runtime-evidence-policy.json",
@@ -547,14 +547,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3998,
-      "sha256": "a21dcf80e2966d6cbb64d8467db9aa46b2918f7ba5f5cf72bb957da22c2557db"
+      "sha256": "ac3e2af0dd4f02cfe3748692deed7307360ce0f57e30d749b1ddfbc26227ba47"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04"
+      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -568,7 +568,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea"
+      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636"
     },
     {
       "path": "reports/dependencies.json",
@@ -638,14 +638,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26966,
-      "sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943"
+      "sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7"
+      "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -679,8 +679,8 @@
       "path": "reports/release-goal-continuation-queue.json",
       "kind": "release_goal_continuation_queue",
       "schema": "https://schemas.datapan.dev/datapan.release-goal-continuation-queue.v1.schema.json",
-      "bytes": 15730,
-      "sha256": "74b1bdabb905b9f63b3140b46e2a2a61a7d938ae8b82a8601c062c32eb81bd46"
+      "bytes": 16643,
+      "sha256": "7648c57ccbdf421123aa551c8c0602da1a4a1ebbe807cc21622e0f3e1fcd716a"
     },
     {
       "path": "reports/release-goal-operating-contract.json",
@@ -694,7 +694,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34991,
-      "sha256": "68fa9753e1af0c2e7fc21cd36662bab0659a324c506a8435d2f49a51b2e2d5d9"
+      "sha256": "3bc0c6cc1d02961fecf14cf71899a6bb2b79ed2545c7c2f7be9905f863cb3cc1"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943"
+    "compatibility_sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
-    "compatibility_sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943",
+    "compatibility_sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea"
+      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -108,7 +108,7 @@
         {
           "path": "schemas/index.json",
           "bytes": 27405,
-          "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1",
+          "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 59095,
-          "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea",
+          "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04",
+          "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 14728,
-          "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc",
+          "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3998,
-          "sha256": "a21dcf80e2966d6cbb64d8467db9aa46b2918f7ba5f5cf72bb957da22c2557db",
+          "sha256": "ac3e2af0dd4f02cfe3748692deed7307360ce0f57e30d749b1ddfbc26227ba47",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2119,
-          "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7",
+          "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26966,
-          "sha256": "3e562c34ca98bbb7f8d7d8ce9b7672587caf8e18c49c12f555b69d48dd07b943",
+          "sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"
@@ -741,8 +741,8 @@
         },
         {
           "path": "reports/release-goal-continuation-queue.json",
-          "bytes": 15730,
-          "sha256": "74b1bdabb905b9f63b3140b46e2a2a61a7d938ae8b82a8601c062c32eb81bd46",
+          "bytes": 16643,
+          "sha256": "7648c57ccbdf421123aa551c8c0602da1a4a1ebbe807cc21622e0f3e1fcd716a",
           "manifest_bound": true,
           "kind": "release_goal_continuation_queue",
           "schema": "https://schemas.datapan.dev/datapan.release-goal-continuation-queue.v1.schema.json"

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "721f17b58a59a6b94d571a59401074b91633ecca4c5e13245b24e5dab99900dc",
+      "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04",
+      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "6050a974d3941b636ae7742a1aa3d95d8918de465f41555960d78a7053fc64ea",
+      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "06cf15ccdb0f2e03701a70ad4ae272d5d2e4f2df5a08050c143e1ce7087470b7",
+      "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4",
       "required": true
     },
     {
@@ -489,7 +489,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 165925101,
+    "manifest_bound_bytes_excluding_self": 165927719,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -11,7 +11,7 @@
   "summary": {
     "artifact_count": 112,
     "schema_artifacts": 67,
-    "manifest_bound_bytes_excluding_self": 165925101,
+    "manifest_bound_bytes_excluding_self": 165927719,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/release-goal-continuation-queue.json
+++ b/reports/release-goal-continuation-queue.json
@@ -14,6 +14,20 @@
     "credential_collection_execution_plan": "reports/credential-runtime-collection-execution-plan.json",
     "release_operational_pressure": "reports/release-operational-pressure.json"
   },
+  "goal_routing": {
+    "parent_goal_issue": 344,
+    "goal_status": "not_complete",
+    "finish_allowed": false,
+    "goal_completion_allowed": false,
+    "goal_closure_allowed": false,
+    "active_non_completion_reason": "credential_runtime_pressure",
+    "primary_candidate": "collect_reviewed_credential_runtime_receipts",
+    "primary_candidate_title": "Collect reviewed credential runtime receipts",
+    "primary_candidate_duplicate_check_command": "gh issue list --repo StatPan/datapan-registry --state open --search 'Collect reviewed credential runtime receipts in:title' --json number,title,state,url",
+    "next_safe_action": "use_existing_or_create_primary_child_ticket_after_duplicate_check",
+    "blocked_by_external_evidence": true,
+    "routing_note": "Use the primary candidate packet only after duplicate detection; keep #344 open until finish preflight and completion audit allow closure."
+  },
   "summary": {
     "finish_allowed": false,
     "goal_status": "not_complete",

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -48,7 +48,7 @@
     "path": "schemas/index.json",
     "schemas": 67,
     "bytes": 27405,
-    "sha256": "e60af7b63714f9cd805bf8abdb363f48a4871714df2468142679f0ec9c6dbaa1"
+    "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -44,7 +44,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "e9c8414f2a3056810bf74daade9c13c0a79fdb9f86e230466d087f1b48582c04"
+      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.release-goal-continuation-queue.v1.schema.json
+++ b/schemas/datapan.release-goal-continuation-queue.v1.schema.json
@@ -12,6 +12,7 @@
     "continuation_ticket",
     "provider",
     "inputs",
+    "goal_routing",
     "summary",
     "finish_boundary",
     "release_evidence_refresh",
@@ -37,6 +38,9 @@
     },
     "inputs": {
       "$ref": "#/$defs/inputs"
+    },
+    "goal_routing": {
+      "$ref": "#/$defs/goal_routing"
     },
     "summary": {
       "$ref": "#/$defs/summary"
@@ -106,6 +110,65 @@
         },
         "release_operational_pressure": {
           "const": "reports/release-operational-pressure.json"
+        }
+      }
+    },
+    "goal_routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parent_goal_issue",
+        "goal_status",
+        "finish_allowed",
+        "goal_completion_allowed",
+        "goal_closure_allowed",
+        "active_non_completion_reason",
+        "primary_candidate",
+        "primary_candidate_title",
+        "primary_candidate_duplicate_check_command",
+        "next_safe_action",
+        "blocked_by_external_evidence",
+        "routing_note"
+      ],
+      "properties": {
+        "parent_goal_issue": {
+          "const": 344
+        },
+        "goal_status": {
+          "enum": ["complete", "not_complete"]
+        },
+        "finish_allowed": {
+          "type": "boolean"
+        },
+        "goal_completion_allowed": {
+          "type": "boolean"
+        },
+        "goal_closure_allowed": {
+          "type": "boolean"
+        },
+        "active_non_completion_reason": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "primary_candidate": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "primary_candidate_title": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "primary_candidate_duplicate_check_command": {
+          "type": "string"
+        },
+        "next_safe_action": {
+          "enum": [
+            "use_existing_or_create_primary_child_ticket_after_duplicate_check",
+            "finish_goal"
+          ]
+        },
+        "blocked_by_external_evidence": {
+          "type": "boolean"
+        },
+        "routing_note": {
+          "$ref": "#/$defs/non_empty_string"
         }
       }
     },

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -514,8 +514,8 @@
       "title": "Datapan Release Goal Continuation Queue v1",
       "contract": "release-goal-continuation-queue",
       "version": "v1",
-      "bytes": 12250,
-      "sha256": "233ab75f176644281b452a43e0765bdb7b4e9c9fced513b1c77b654729e0ae41"
+      "bytes": 13955,
+      "sha256": "1e605f1d7d8a2ddd227b8efdc1761d6ac07753657f4ff0e01dbfb171c7110c5e"
     },
     {
       "path": "schemas/datapan.credential-runtime-operator-packets.v1.schema.json",

--- a/scripts/generate-release-goal-continuation-queue.py
+++ b/scripts/generate-release-goal-continuation-queue.py
@@ -378,6 +378,18 @@ def build_report(
         pressure_actions,
     )
     finish_allowed = finish_summary.get("finish_allowed") is True
+    goal_closure_allowed = finish_allowed and audit_summary.get("decision") == "prepare_goal_finish"
+    primary_candidate = candidates[0] if candidates else None
+    active_non_completion_reason = (
+        str(pressure_summary.get("operational_pressure_decision") or "finish_preflight_blocked")
+        if not finish_allowed
+        else "goal_finish_allowed"
+    )
+    next_safe_action = (
+        "finish_goal"
+        if finish_allowed
+        else "use_existing_or_create_primary_child_ticket_after_duplicate_check"
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated_at,
@@ -394,6 +406,33 @@ def build_report(
             "credential_collection_execution_plan": DEFAULT_CREDENTIAL_EXECUTION_PLAN.as_posix(),
             "release_operational_pressure": DEFAULT_OPERATIONAL_PRESSURE.as_posix(),
         },
+        "goal_routing": {
+            "parent_goal_issue": 344,
+            "goal_status": goal_audit.get("goal_status"),
+            "finish_allowed": finish_allowed,
+            "goal_completion_allowed": decision_summary.get("goal_completion_allowed"),
+            "goal_closure_allowed": goal_closure_allowed,
+            "active_non_completion_reason": active_non_completion_reason,
+            "primary_candidate": primary_candidate.get("id") if primary_candidate else "goal_finish_allowed",
+            "primary_candidate_title": primary_candidate.get("title") if primary_candidate else "Goal finish allowed",
+            "primary_candidate_duplicate_check_command": (
+                as_dict(primary_candidate.get("ticket_packet"), "primary_candidate.ticket_packet").get(
+                    "duplicate_check_command"
+                )
+                if primary_candidate
+                else ""
+            ),
+            "next_safe_action": next_safe_action,
+            "blocked_by_external_evidence": not finish_allowed
+            and (
+                credential_preflight_summary.get("reviewed_receipts_missing", 0) > 0
+                or decision_summary.get("manual_review_required") is True
+            ),
+            "routing_note": (
+                "Use the primary candidate packet only after duplicate detection; keep #344 open until "
+                "finish preflight and completion audit allow closure."
+            ),
+        },
         "summary": {
             "finish_allowed": finish_allowed,
             "goal_status": goal_audit.get("goal_status"),
@@ -409,7 +448,7 @@ def build_report(
             "candidate_count": len(candidates),
             "primary_candidate": candidates[0]["id"] if candidates else "goal_finish_allowed",
             "next_action": "goal_finish_allowed" if finish_allowed else "create_child_ticket",
-            "goal_closure_allowed": finish_allowed and audit_summary.get("decision") == "prepare_goal_finish",
+            "goal_closure_allowed": goal_closure_allowed,
         },
         "finish_boundary": {
             "finish_guard_command": "python3 scripts/guard-release-goal-finish.py",
@@ -437,8 +476,23 @@ def build_report(
 
 def validate_invariants(report: dict[str, Any]) -> None:
     summary = as_dict(report.get("summary"), "summary")
+    goal_routing = as_dict(report.get("goal_routing"), "goal_routing")
     candidates = as_list(report.get("candidates"), "candidates")
     blocking = as_list(report.get("blocking_evidence"), "blocking_evidence")
+    if goal_routing.get("parent_goal_issue") != 344:
+        raise ValueError("goal_routing.parent_goal_issue must preserve #344")
+    if goal_routing.get("goal_status") != summary.get("goal_status"):
+        raise ValueError("goal_routing.goal_status must mirror summary.goal_status")
+    if goal_routing.get("finish_allowed") != summary.get("finish_allowed"):
+        raise ValueError("goal_routing.finish_allowed must mirror summary.finish_allowed")
+    if goal_routing.get("goal_completion_allowed") != summary.get("goal_completion_allowed"):
+        raise ValueError("goal_routing.goal_completion_allowed must mirror summary.goal_completion_allowed")
+    if goal_routing.get("goal_closure_allowed") != summary.get("goal_closure_allowed"):
+        raise ValueError("goal_routing.goal_closure_allowed must mirror summary.goal_closure_allowed")
+    if goal_routing.get("primary_candidate") != summary.get("primary_candidate"):
+        raise ValueError("goal_routing.primary_candidate must mirror summary.primary_candidate")
+    if summary.get("goal_closure_allowed") is False and goal_routing.get("next_safe_action") == "finish_goal":
+        raise ValueError("goal routing must not route to finish while closure is disallowed")
     if summary.get("candidate_count") != len(candidates):
         raise ValueError("summary.candidate_count must match candidates length")
     if summary.get("finish_allowed") is True:
@@ -457,6 +511,11 @@ def validate_invariants(report: dict[str, Any]) -> None:
             raise ValueError("blocked goal continuation reports must set next_action=create_child_ticket")
         if summary.get("goal_closure_allowed") is not False:
             raise ValueError("blocked goal continuation reports must not allow goal closure")
+        if goal_routing.get("blocked_by_external_evidence") is not True:
+            raise ValueError("blocked reports must expose goal_routing.blocked_by_external_evidence=true")
+        duplicate_command = goal_routing.get("primary_candidate_duplicate_check_command")
+        if not isinstance(duplicate_command, str) or "gh issue list" not in duplicate_command:
+            raise ValueError("blocked reports must expose the primary candidate duplicate check command")
     orders = [as_dict(item, "candidate").get("order") for item in candidates]
     if orders != list(range(1, len(candidates) + 1)):
         raise ValueError("candidate.order values must be consecutive from 1")


### PR DESCRIPTION
## Summary
- Add schema-backed `goal_routing` evidence to `reports/release-goal-continuation-queue.json`.
- Route the current non-completion state to `credential_runtime_pressure`, the primary candidate `collect_reviewed_credential_runtime_receipts`, and duplicate-safe use of the existing #457 ticket.
- Regenerate manifest-bound release evidence so hashes and downstream reports remain fixed-point consistent.

## Verification
- `python3 scripts/generate-release-goal-continuation-queue.py --check`
- `python3 scripts/run-release-goal-continuation-ticket-packet.py --self-test`
- `python3 scripts/run-release-goal-continuation-ticket-packet.py --json --detect-existing`
- `python3 -m py_compile scripts/generate-release-goal-continuation-queue.py scripts/run-release-goal-continuation-ticket-packet.py`
- `python3 scripts/refresh-release-ledger-evidence.py --check`
- `git diff --check`

## Goal Boundary
Persistent goal #344 remains not complete. This PR preserves `goal_closure_allowed=false` and does not collect credential receipts or assert manual-review acceptance.

Closes #472
