### PR TITLE
feat: Add credential execution operator routing summary

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -400,8 +400,8 @@
     {
       "path": "schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
       "kind": "schema",
-      "bytes": 19948,
-      "sha256": "db87cbba2f332e1ba723bbdc8df2483d03c3b767abbcb085538b5e60dcc6b98e"
+      "bytes": 23953,
+      "sha256": "223ccc6af441525843cf93805e327191176de9cc7918d3cce2b258273c3df593"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",
@@ -414,7 +414,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 27405,
-      "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec"
+      "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -477,7 +477,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55"
+      "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1"
     },
     {
       "path": "reports/credential-runtime-evidence-policy.json",
@@ -525,8 +525,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 15536,
-      "sha256": "dbc4a1e32c88c06b39a538166f9384e742d55b4d4f096ebddb227e9fa110d617"
+      "bytes": 18279,
+      "sha256": "8c2368d0fe1977e3a2df90c8c65d4d68029697d84d5786edd024b44922d53505"
     },
     {
       "path": "reports/credential-runtime-manual-review-decision.json",
@@ -547,14 +547,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3998,
-      "sha256": "ac3e2af0dd4f02cfe3748692deed7307360ce0f57e30d749b1ddfbc26227ba47"
+      "sha256": "12e124cd5c510b075c417295c04807dc17a8fc589e0dfe891d1b051b9a09d25a"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0"
+      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -568,7 +568,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636"
+      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3"
     },
     {
       "path": "reports/dependencies.json",
@@ -638,14 +638,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26966,
-      "sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b"
+      "sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4"
+      "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -694,7 +694,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34991,
-      "sha256": "3bc0c6cc1d02961fecf14cf71899a6bb2b79ed2545c7c2f7be9905f863cb3cc1"
+      "sha256": "11bfbf91e39a963ab5bc5ef81809c854ae2041566fceb156d0649ab64fe9f9ad"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/reports/credential-runtime-collection-execution-plan.json
+++ b/reports/credential-runtime-collection-execution-plan.json
@@ -29,6 +29,39 @@
     "session_plan_status": "operator_credentials_required",
     "next_action": "run_batch_collection_session_in_operator_env"
   },
+  "operator_routing": {
+    "goal_issue": 344,
+    "plan_status": "operator_credentials_required",
+    "next_action": "run_batch_collection_session_in_operator_env",
+    "operator_blocker": "repository_or_operator_credentials_required",
+    "first_operator_step": "check_github_or_local_secret_readiness_before_collect",
+    "github_secret_readiness_command": "python3 scripts/check-credential-runtime-github-secrets.py --repo StatPan/datapan-registry --json",
+    "github_secret_readiness_check_command": "python3 scripts/check-credential-runtime-github-secrets.py --check",
+    "local_require_env_preflight_command": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env",
+    "github_actions_collect_command": "gh workflow run credential-runtime-collection.yml --repo StatPan/datapan-registry -f mode=collect",
+    "local_batch_collection_run_command": "python3 scripts/run-credential-runtime-collection.py --all --run --skip-not-ready --continue-on-error --session-output .datapan/runtime-evidence/credential-runtime-collection-session.json --json",
+    "session_output_path": ".datapan/runtime-evidence/credential-runtime-collection-session.json",
+    "session_validation_command": "python3 scripts/validate-credential-runtime-collection-session.py .datapan/runtime-evidence/credential-runtime-collection-session.json --require-complete-source-set",
+    "review_plan_generation_command": "python3 scripts/generate-credential-runtime-session-review-plan.py .datapan/runtime-evidence/credential-runtime-collection-session.json --output .datapan/runtime-evidence/credential-runtime-session-review-plan.json",
+    "review_plan_validation_command": "python3 scripts/validate-credential-runtime-session-review-plan.py .datapan/runtime-evidence/credential-runtime-session-review-plan.json --queue reports/credential-runtime-receipt-collection-queue.json",
+    "required_credential_env_count": 5,
+    "required_credential_envs": [
+      "DATAPAN_DATA_GO_KR_SERVICE_KEY",
+      "DATAPAN_ECOS_API_KEY",
+      "DATAPAN_KOSIS_API_KEY",
+      "DATAPAN_OPEN_ASSEMBLY_API_KEY",
+      "DATAPAN_SEOUL_OPEN_DATA_API_KEY"
+    ],
+    "post_promotion_commands": [
+      "python3 scripts/refresh-release-ledger-evidence.py --write --max-iterations 5",
+      "python3 scripts/refresh-release-ledger-evidence.py --check"
+    ],
+    "checked_in_secrets_allowed": false,
+    "checked_in_session_output_allowed": false,
+    "checked_in_review_plan_allowed": false,
+    "goal_closure_allowed": false,
+    "routing_note": "Check repository or local secret readiness before collection, then validate the session, generate a review plan, promote reviewed receipts, and refresh release evidence. Do not check in secrets or raw session output."
+  },
   "batch_execution": {
     "secret_free_batch_preflight_command": "python3 scripts/run-credential-runtime-collection.py --all --json",
     "require_env_batch_preflight_command": "python3 scripts/run-credential-runtime-collection.py --all --require-env",

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b"
+    "compatibility_sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
-    "compatibility_sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b",
+    "compatibility_sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636"
+      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -108,7 +108,7 @@
         {
           "path": "schemas/index.json",
           "bytes": 27405,
-          "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec",
+          "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 59095,
-          "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636",
+          "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0",
+          "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 14728,
-          "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55",
+          "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3998,
-          "sha256": "ac3e2af0dd4f02cfe3748692deed7307360ce0f57e30d749b1ddfbc26227ba47",
+          "sha256": "12e124cd5c510b075c417295c04807dc17a8fc589e0dfe891d1b051b9a09d25a",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2119,
-          "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4",
+          "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26966,
-          "sha256": "9a350287ebe675f30aa8887162a9d018483b040b8c601e9abddf5cfc9318734b",
+          "sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "519112868cb3d826bf9ba72e3080dad6dd6a51a86cb7d5c7fa5d9c02e2d30a55",
+      "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1",
       "required": true
     },
     {
@@ -139,8 +139,8 @@
       "path": "reports/credential-runtime-collection-execution-plan.json",
       "kind": "credential_runtime_collection_execution_plan",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-collection-execution-plan.v1.schema.json",
-      "bytes": 15536,
-      "sha256": "dbc4a1e32c88c06b39a538166f9384e742d55b4d4f096ebddb227e9fa110d617",
+      "bytes": 18279,
+      "sha256": "8c2368d0fe1977e3a2df90c8c65d4d68029697d84d5786edd024b44922d53505",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0",
+      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "7f6b06250c8d8d3e4ca8975948bbe0b283bd7b7466f7f8dbb68edea3d6c55636",
+      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "8b020a734b84c7e4ccd07aea6817a7dce2b9b3381dab62625635440214390ef4",
+      "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e",
       "required": true
     },
     {
@@ -489,7 +489,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 165927719,
+    "manifest_bound_bytes_excluding_self": 165934467,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -11,7 +11,7 @@
   "summary": {
     "artifact_count": 112,
     "schema_artifacts": 67,
-    "manifest_bound_bytes_excluding_self": 165927719,
+    "manifest_bound_bytes_excluding_self": 165934467,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -48,7 +48,7 @@
     "path": "schemas/index.json",
     "schemas": 67,
     "bytes": 27405,
-    "sha256": "9ae77ff23a38826c828bc6c5d7a4cbcd1d8793eee40c9a2aec7b28647277bcec"
+    "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -44,7 +44,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "69e272074ecfc42ac11aeb0f5b399af3e0d88349b089ded8cfdcc6c56e662ec0"
+      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
+++ b/schemas/datapan.credential-runtime-collection-execution-plan.v1.schema.json
@@ -13,6 +13,7 @@
     "provider",
     "inputs",
     "summary",
+    "operator_routing",
     "batch_execution",
     "operator_workflow",
     "session_review_promotion_workflow",
@@ -43,6 +44,9 @@
     },
     "summary": {
       "$ref": "#/$defs/summary"
+    },
+    "operator_routing": {
+      "$ref": "#/$defs/operator_routing"
     },
     "batch_execution": {
       "$ref": "#/$defs/batch_execution"
@@ -190,6 +194,124 @@
             "restore_candidate_batches_before_operator_collection",
             "refresh_release_evidence_after_reviewed_receipts"
           ]
+        }
+      }
+    },
+    "operator_routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "goal_issue",
+        "plan_status",
+        "next_action",
+        "operator_blocker",
+        "first_operator_step",
+        "github_secret_readiness_command",
+        "github_secret_readiness_check_command",
+        "local_require_env_preflight_command",
+        "github_actions_collect_command",
+        "local_batch_collection_run_command",
+        "session_output_path",
+        "session_validation_command",
+        "review_plan_generation_command",
+        "review_plan_validation_command",
+        "required_credential_env_count",
+        "required_credential_envs",
+        "post_promotion_commands",
+        "checked_in_secrets_allowed",
+        "checked_in_session_output_allowed",
+        "checked_in_review_plan_allowed",
+        "goal_closure_allowed",
+        "routing_note"
+      ],
+      "properties": {
+        "goal_issue": {
+          "const": 344
+        },
+        "plan_status": {
+          "enum": [
+            "operator_credentials_required",
+            "candidate_batches_missing",
+            "ready_for_operator_collection",
+            "reviewed_receipts_complete"
+          ]
+        },
+        "next_action": {
+          "enum": [
+            "run_batch_collection_session_in_operator_env",
+            "restore_candidate_batches_before_operator_collection",
+            "refresh_release_evidence_after_reviewed_receipts"
+          ]
+        },
+        "operator_blocker": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "first_operator_step": {
+          "const": "check_github_or_local_secret_readiness_before_collect"
+        },
+        "github_secret_readiness_command": {
+          "const": "python3 scripts/check-credential-runtime-github-secrets.py --repo StatPan/datapan-registry --json"
+        },
+        "github_secret_readiness_check_command": {
+          "const": "python3 scripts/check-credential-runtime-github-secrets.py --check"
+        },
+        "local_require_env_preflight_command": {
+          "const": "python3 scripts/run-credential-runtime-operator-workflow.py --require-env"
+        },
+        "github_actions_collect_command": {
+          "const": "gh workflow run credential-runtime-collection.yml --repo StatPan/datapan-registry -f mode=collect"
+        },
+        "local_batch_collection_run_command": {
+          "$ref": "#/$defs/command"
+        },
+        "session_output_path": {
+          "const": ".datapan/runtime-evidence/credential-runtime-collection-session.json"
+        },
+        "session_validation_command": {
+          "$ref": "#/$defs/command"
+        },
+        "review_plan_generation_command": {
+          "$ref": "#/$defs/command"
+        },
+        "review_plan_validation_command": {
+          "$ref": "#/$defs/command"
+        },
+        "required_credential_env_count": {
+          "$ref": "#/$defs/count"
+        },
+        "required_credential_envs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/env_name"
+          },
+          "uniqueItems": true
+        },
+        "post_promotion_commands": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "python3 scripts/refresh-release-ledger-evidence.py --write --max-iterations 5"
+            },
+            {
+              "const": "python3 scripts/refresh-release-ledger-evidence.py --check"
+            }
+          ],
+          "items": false
+        },
+        "checked_in_secrets_allowed": {
+          "const": false
+        },
+        "checked_in_session_output_allowed": {
+          "const": false
+        },
+        "checked_in_review_plan_allowed": {
+          "const": false
+        },
+        "goal_closure_allowed": {
+          "const": false
+        },
+        "routing_note": {
+          "$ref": "#/$defs/non_empty_string"
         }
       }
     },

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -595,8 +595,8 @@
       "title": "Datapan Credential Runtime Collection Execution Plan v1",
       "contract": "credential-runtime-collection-execution-plan",
       "version": "v1",
-      "bytes": 19948,
-      "sha256": "db87cbba2f332e1ba723bbdc8df2483d03c3b767abbcb085538b5e60dcc6b98e"
+      "bytes": 23953,
+      "sha256": "223ccc6af441525843cf93805e327191176de9cc7918d3cce2b258273c3df593"
     },
     {
       "path": "schemas/datapan.credential-runtime-session-review-decisions.v1.schema.json",

--- a/scripts/generate-credential-runtime-collection-execution-plan.py
+++ b/scripts/generate-credential-runtime-collection-execution-plan.py
@@ -259,6 +259,62 @@ def build_report(
             "operator_packets": DEFAULT_OPERATOR_PACKETS.as_posix(),
         },
         "summary": summary,
+        "operator_routing": {
+            "goal_issue": 344,
+            "plan_status": summary["session_plan_status"],
+            "next_action": summary["next_action"],
+            "operator_blocker": (
+                "repository_or_operator_credentials_required"
+                if summary["session_plan_status"] == "operator_credentials_required"
+                else summary["session_plan_status"]
+            ),
+            "first_operator_step": "check_github_or_local_secret_readiness_before_collect",
+            "github_secret_readiness_command": (
+                f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} "
+                "--repo StatPan/datapan-registry --json"
+            ),
+            "github_secret_readiness_check_command": f"python3 {GITHUB_SECRET_READINESS_SCRIPT.as_posix()} --check",
+            "local_require_env_preflight_command": f"python3 {OPERATOR_WORKFLOW_SCRIPT.as_posix()} --require-env",
+            "github_actions_collect_command": (
+                "gh workflow run credential-runtime-collection.yml "
+                "--repo StatPan/datapan-registry -f mode=collect"
+            ),
+            "local_batch_collection_run_command": string_value(
+                batch_commands.get("batch_collection_run_with_session_output"),
+                "batch.batch_collection_run_with_session_output",
+            ),
+            "session_output_path": string_value(
+                batch_contract.get("session_output_path"),
+                "batch.session_output_path",
+            ),
+            "session_validation_command": string_value(
+                batch_contract.get("session_output_validation_command"),
+                "batch.session_output_validation_command",
+            ),
+            "review_plan_generation_command": string_value(
+                batch_contract.get("session_review_plan_command"),
+                "batch.session_review_plan_command",
+            ),
+            "review_plan_validation_command": string_value(
+                batch_contract.get("session_review_plan_validation_command"),
+                "batch.session_review_plan_validation_command",
+            ),
+            "required_credential_env_count": len(credential_envs),
+            "required_credential_envs": credential_envs,
+            "post_promotion_commands": [
+                string_value(item, "post_promotion.commands[]")
+                for item in as_list(post_promotion.get("commands"), "post_promotion.commands")
+            ],
+            "checked_in_secrets_allowed": False,
+            "checked_in_session_output_allowed": False,
+            "checked_in_review_plan_allowed": False,
+            "goal_closure_allowed": False,
+            "routing_note": (
+                "Check repository or local secret readiness before collection, then validate the session, "
+                "generate a review plan, promote reviewed receipts, and refresh release evidence. "
+                "Do not check in secrets or raw session output."
+            ),
+        },
         "batch_execution": {
             "secret_free_batch_preflight_command": string_value(
                 batch_commands.get("secret_free_batch_preflight"),
@@ -434,6 +490,7 @@ def build_report(
 
 def validate_invariants(report: dict[str, Any]) -> None:
     summary = as_dict(report.get("summary"), "summary")
+    routing = as_dict(report.get("operator_routing"), "operator_routing")
     batch = as_dict(report.get("batch_execution"), "batch_execution")
     workflow = as_dict(report.get("operator_workflow"), "operator_workflow")
     promotion_workflow = as_dict(report.get("session_review_promotion_workflow"), "session_review_promotion_workflow")
@@ -442,6 +499,40 @@ def validate_invariants(report: dict[str, Any]) -> None:
     sources = [as_dict(item, "sources[]") for item in as_list(report.get("sources"), "sources")]
     if summary.get("sources") != len(sources):
         raise ValueError("summary.sources must match sources length")
+    if routing.get("goal_issue") != 344:
+        raise ValueError("operator_routing.goal_issue must preserve #344")
+    if routing.get("plan_status") != summary.get("session_plan_status"):
+        raise ValueError("operator_routing.plan_status must mirror summary.session_plan_status")
+    if routing.get("next_action") != summary.get("next_action"):
+        raise ValueError("operator_routing.next_action must mirror summary.next_action")
+    if routing.get("goal_closure_allowed") is not False:
+        raise ValueError("operator_routing.goal_closure_allowed must remain false")
+    if routing.get("checked_in_secrets_allowed") is not False:
+        raise ValueError("operator_routing.checked_in_secrets_allowed must remain false")
+    if routing.get("checked_in_session_output_allowed") is not False:
+        raise ValueError("operator_routing.checked_in_session_output_allowed must remain false")
+    if routing.get("checked_in_review_plan_allowed") is not False:
+        raise ValueError("operator_routing.checked_in_review_plan_allowed must remain false")
+    if routing.get("required_credential_env_count") != len(routing.get("required_credential_envs", [])):
+        raise ValueError("operator_routing required credential count must match env list")
+    if routing.get("required_credential_envs") != environment.get("required_credential_envs"):
+        raise ValueError("operator_routing required credential envs must mirror operator_environment")
+    if routing.get("github_secret_readiness_command") != workflow.get("github_secret_readiness_command"):
+        raise ValueError("operator_routing GitHub secret readiness command must mirror operator_workflow")
+    if routing.get("github_secret_readiness_check_command") != workflow.get("github_secret_readiness_check_command"):
+        raise ValueError("operator_routing GitHub secret readiness check command must mirror operator_workflow")
+    if routing.get("github_actions_collect_command") != workflow.get("github_actions_collect_command"):
+        raise ValueError("operator_routing GitHub collect command must mirror operator_workflow")
+    if routing.get("session_output_path") != batch.get("session_output_path"):
+        raise ValueError("operator_routing session output path must mirror batch_execution")
+    if routing.get("session_validation_command") != batch.get("session_output_validation_command"):
+        raise ValueError("operator_routing session validation command must mirror batch_execution")
+    if routing.get("review_plan_generation_command") != batch.get("session_review_plan_command"):
+        raise ValueError("operator_routing review plan command must mirror batch_execution")
+    if routing.get("review_plan_validation_command") != batch.get("session_review_plan_validation_command"):
+        raise ValueError("operator_routing review plan validation command must mirror batch_execution")
+    if routing.get("post_promotion_commands") != review.get("post_promotion_commands"):
+        raise ValueError("operator_routing post-promotion commands must mirror post_collection_review")
     if summary.get("credential_gated_sources") != len(sources):
         raise ValueError("execution plan must cover every credential-gated source")
     if summary.get("candidate_batches_missing") == 0 and summary.get("reviewed_receipts_missing", 0) > 0:


### PR DESCRIPTION
## Summary
- Add schema-backed `operator_routing` evidence to `reports/credential-runtime-collection-execution-plan.json`.
- Surface the first operator step, GitHub secret readiness checks, local require-env preflight, collect commands, session validation, review plan generation/validation, and post-promotion refresh commands in one top-level routing object.
- Regenerate manifest-bound release evidence so downstream compatibility and assembly receipts stay fixed-point consistent.

## Verification
- `python3 scripts/generate-credential-runtime-collection-execution-plan.py --check`
- `python3 scripts/refresh-release-ledger-evidence.py --check`
- `python3 -m py_compile scripts/generate-credential-runtime-collection-execution-plan.py`
- `git diff --check`

## Goal Boundary
Persistent goal #344 remains not complete. This PR preserves `goal_closure_allowed=false`, does not collect credential receipts, and does not assert manual-review acceptance.

Closes #474
