### PR TITLE
feat: Add credential review handoff routing summary

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -304,8 +304,8 @@
     {
       "path": "schemas/datapan.credential-runtime-review-handoff.v1.schema.json",
       "kind": "schema",
-      "bytes": 10057,
-      "sha256": "cc11fb18a23b0ea4efd4eca6ff109baab0a644b3664dfefa61cd92e78ba32f0a"
+      "bytes": 13071,
+      "sha256": "ba16fbbd0c6aea397cc87d11ba7cc8d719656a1ca32b8204aedb69ac85a9ebf8"
     },
     {
       "path": "schemas/datapan.credential-runtime-manual-review-acceptance.v1.schema.json",
@@ -414,7 +414,7 @@
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
       "bytes": 27405,
-      "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed"
+      "sha256": "b965cf173c6f14c9600968518b314da1b3dbd9ee54a567861598680b70acbbae"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -477,7 +477,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1"
+      "sha256": "57239328712b75f2f2ee4e2457e3a35b053282c8463e2692e0bbcf9ff3a68a75"
     },
     {
       "path": "reports/credential-runtime-evidence-policy.json",
@@ -511,8 +511,8 @@
       "path": "reports/credential-runtime-review-handoff.json",
       "kind": "credential_runtime_review_handoff",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-review-handoff.v1.schema.json",
-      "bytes": 12223,
-      "sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439"
+      "bytes": 13669,
+      "sha256": "3af44ee563b8e19f80db622b02f94357d77c6e0560906dd01389b3c3a1a76bac"
     },
     {
       "path": "reports/credential-runtime-operator-packets.json",
@@ -547,14 +547,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3998,
-      "sha256": "12e124cd5c510b075c417295c04807dc17a8fc589e0dfe891d1b051b9a09d25a"
+      "sha256": "bd0cce652d67e3e82a900b2cdbd664c4aaa3e993ddf6a45c8e4f85028cac00f6"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e"
+      "sha256": "1f6db29b85bbdde2259f6f3681236752f25acd3be40eb975c457c374c01ddc28"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -568,7 +568,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3"
+      "sha256": "dbac22c051659e88e3ea576774bfccdacc8e46a696bcd7128d97cf971c86f6ad"
     },
     {
       "path": "reports/dependencies.json",
@@ -638,14 +638,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26966,
-      "sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678"
+      "sha256": "bc90e7c94716e4e4adc1ed2e87cdf362d6f766a2d4b6d841152959dc47c414ca"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e"
+      "sha256": "d05ae3ab87ac5bbfcee7687524129033c31809cc8c3b4bf5743734aea86784ab"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -694,7 +694,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34991,
-      "sha256": "11bfbf91e39a963ab5bc5ef81809c854ae2041566fceb156d0649ab64fe9f9ad"
+      "sha256": "e298e724b4ea180c266f70e814e7f84e6804cf5ba12c2aec48333b110374f1cb"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -28,9 +28,9 @@
   },
   "current_digests": {
     "handoff_path": "reports/credential-runtime-review-handoff.json",
-    "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
+    "handoff_sha256": "3af44ee563b8e19f80db622b02f94357d77c6e0560906dd01389b3c3a1a76bac",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678"
+    "compatibility_sha256": "bc90e7c94716e4e4adc1ed2e87cdf362d6f766a2d4b6d841152959dc47c414ca"
   },
   "required_human_inputs": [
     {
@@ -60,8 +60,8 @@
     "reviewer": "<reviewer>",
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
-    "handoff_sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
-    "compatibility_sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678",
+    "handoff_sha256": "3af44ee563b8e19f80db622b02f94357d77c6e0560906dd01389b3c3a1a76bac",
+    "compatibility_sha256": "bc90e7c94716e4e4adc1ed2e87cdf362d6f766a2d4b6d841152959dc47c414ca",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/credential-runtime-review-handoff.json
+++ b/reports/credential-runtime-review-handoff.json
@@ -27,6 +27,35 @@
     "reviewed_receipt_glob": "reports/credential-runtime-receipts/*-credentialed-receipt.json",
     "default_ci_mode": "secret_free_review_handoff_validation"
   },
+  "reviewer_routing": {
+    "goal_issue": 344,
+    "handoff_status": "review_required",
+    "first_reviewer_action": "collect_validate_review_and_promote_redacted_receipts",
+    "pending_source_ids": [
+      "data_go_kr",
+      "ecos",
+      "kosis",
+      "open_assembly",
+      "seoul_open_data"
+    ],
+    "pending_review_sources": 5,
+    "reviewed_receipts_checked_in": 0,
+    "relief_eligible_sources": 0,
+    "global_manual_review_relief_allowed": false,
+    "manual_review_required": true,
+    "receipt_validation_command": "python3 scripts/validate-credential-runtime-receipts.py",
+    "receipt_promotion_script": "scripts/promote-credential-runtime-receipt.py",
+    "handoff_check_command": "python3 scripts/generate-credential-runtime-review-handoff.py --check",
+    "queue_check_command": "python3 scripts/generate-credential-runtime-receipt-collection-queue.py --check",
+    "post_review_commands": [
+      "python3 scripts/refresh-release-ledger-evidence.py --write --max-iterations 5",
+      "python3 scripts/refresh-release-ledger-evidence.py --check"
+    ],
+    "default_ci_requires_credentials": false,
+    "checked_in_secrets_allowed": false,
+    "goal_closure_allowed": false,
+    "routing_note": "Review every pending source receipt, promote only redacted reviewed receipts, then refresh release evidence. Keep the persistent goal open until reviewed receipts or explicit manual-review acceptance satisfy release gates."
+  },
   "release_boundary": {
     "canonical_registry_compatible": true,
     "manual_review_required": true,

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3"
+      "sha256": "dbac22c051659e88e3ea576774bfccdacc8e46a696bcd7128d97cf971c86f6ad"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -108,7 +108,7 @@
         {
           "path": "schemas/index.json",
           "bytes": 27405,
-          "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed",
+          "sha256": "b965cf173c6f14c9600968518b314da1b3dbd9ee54a567861598680b70acbbae",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 59095,
-          "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3",
+          "sha256": "dbac22c051659e88e3ea576774bfccdacc8e46a696bcd7128d97cf971c86f6ad",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e",
+          "sha256": "1f6db29b85bbdde2259f6f3681236752f25acd3be40eb975c457c374c01ddc28",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 14728,
-          "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1",
+          "sha256": "57239328712b75f2f2ee4e2457e3a35b053282c8463e2692e0bbcf9ff3a68a75",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -449,8 +449,8 @@
         },
         {
           "path": "reports/credential-runtime-review-handoff.json",
-          "bytes": 12223,
-          "sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
+          "bytes": 13669,
+          "sha256": "3af44ee563b8e19f80db622b02f94357d77c6e0560906dd01389b3c3a1a76bac",
           "manifest_bound": true,
           "kind": "credential_runtime_review_handoff",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-review-handoff.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3998,
-          "sha256": "12e124cd5c510b075c417295c04807dc17a8fc589e0dfe891d1b051b9a09d25a",
+          "sha256": "bd0cce652d67e3e82a900b2cdbd664c4aaa3e993ddf6a45c8e4f85028cac00f6",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2119,
-          "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e",
+          "sha256": "d05ae3ab87ac5bbfcee7687524129033c31809cc8c3b4bf5743734aea86784ab",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26966,
-          "sha256": "32840a25dfef06913660d4e889bbe26f4630fd29085a38176d3faa519c9b0678",
+          "sha256": "bc90e7c94716e4e4adc1ed2e87cdf362d6f766a2d4b6d841152959dc47c414ca",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 14728,
-      "sha256": "f225962f45cb6e091c40c2f5a0b22260b9155b88a037a84fb70964aa10fb10b1",
+      "sha256": "57239328712b75f2f2ee4e2457e3a35b053282c8463e2692e0bbcf9ff3a68a75",
       "required": true
     },
     {
@@ -157,8 +157,8 @@
       "path": "reports/credential-runtime-review-handoff.json",
       "kind": "credential_runtime_review_handoff",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-review-handoff.v1.schema.json",
-      "bytes": 12223,
-      "sha256": "959713fbf79e1a8d72401ae2b48605f7585dcbfd9b05e7822d941e58063a3439",
+      "bytes": 13669,
+      "sha256": "3af44ee563b8e19f80db622b02f94357d77c6e0560906dd01389b3c3a1a76bac",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e",
+      "sha256": "1f6db29b85bbdde2259f6f3681236752f25acd3be40eb975c457c374c01ddc28",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 59095,
-      "sha256": "71b074d2e7c8990d957b2be42d12dddd2c77308238f09cd7527e3dbf536938c3",
+      "sha256": "dbac22c051659e88e3ea576774bfccdacc8e46a696bcd7128d97cf971c86f6ad",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2119,
-      "sha256": "e6e4e0876891e66d4e4f5d51fb51818dc704b8edc9911a270a8ece55f21a2d8e",
+      "sha256": "d05ae3ab87ac5bbfcee7687524129033c31809cc8c3b4bf5743734aea86784ab",
       "required": true
     },
     {
@@ -489,7 +489,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 165934467,
+    "manifest_bound_bytes_excluding_self": 165938927,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -11,7 +11,7 @@
   "summary": {
     "artifact_count": 112,
     "schema_artifacts": 67,
-    "manifest_bound_bytes_excluding_self": 165934467,
+    "manifest_bound_bytes_excluding_self": 165938927,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -48,7 +48,7 @@
     "path": "schemas/index.json",
     "schemas": 67,
     "bytes": 27405,
-    "sha256": "aea0c2dafd8fa2fdc5255f973188a875b651f602c474d5e4bfe945ab1fdb69ed"
+    "sha256": "b965cf173c6f14c9600968518b314da1b3dbd9ee54a567861598680b70acbbae"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -44,7 +44,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "176bde3ad6aac68ec2df6b82f14f43fcb4fc0ce5a8d934b9f4e9d9be7b3d429e"
+      "sha256": "1f6db29b85bbdde2259f6f3681236752f25acd3be40eb975c457c374c01ddc28"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.credential-runtime-review-handoff.v1.schema.json
+++ b/schemas/datapan.credential-runtime-review-handoff.v1.schema.json
@@ -14,6 +14,7 @@
     "provider",
     "summary",
     "operator_contract",
+    "reviewer_routing",
     "release_boundary",
     "global_review_requirements",
     "sources"
@@ -43,6 +44,9 @@
     },
     "operator_contract": {
       "$ref": "#/$defs/operator_contract"
+    },
+    "reviewer_routing": {
+      "$ref": "#/$defs/reviewer_routing"
     },
     "release_boundary": {
       "$ref": "#/$defs/release_boundary"
@@ -168,6 +172,102 @@
         },
         "default_ci_mode": {
           "const": "secret_free_review_handoff_validation"
+        }
+      }
+    },
+    "reviewer_routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "goal_issue",
+        "handoff_status",
+        "first_reviewer_action",
+        "pending_source_ids",
+        "pending_review_sources",
+        "reviewed_receipts_checked_in",
+        "relief_eligible_sources",
+        "global_manual_review_relief_allowed",
+        "manual_review_required",
+        "receipt_validation_command",
+        "receipt_promotion_script",
+        "handoff_check_command",
+        "queue_check_command",
+        "post_review_commands",
+        "default_ci_requires_credentials",
+        "checked_in_secrets_allowed",
+        "goal_closure_allowed",
+        "routing_note"
+      ],
+      "properties": {
+        "goal_issue": {
+          "const": 344
+        },
+        "handoff_status": {
+          "enum": ["review_required", "relief_ready"]
+        },
+        "first_reviewer_action": {
+          "enum": [
+            "collect_validate_review_and_promote_redacted_receipts",
+            "maintain_reviewed_receipt_evidence"
+          ]
+        },
+        "pending_source_ids": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty_string"
+          },
+          "uniqueItems": true
+        },
+        "pending_review_sources": {
+          "$ref": "#/$defs/count"
+        },
+        "reviewed_receipts_checked_in": {
+          "$ref": "#/$defs/count"
+        },
+        "relief_eligible_sources": {
+          "$ref": "#/$defs/count"
+        },
+        "global_manual_review_relief_allowed": {
+          "type": "boolean"
+        },
+        "manual_review_required": {
+          "type": "boolean"
+        },
+        "receipt_validation_command": {
+          "const": "python3 scripts/validate-credential-runtime-receipts.py"
+        },
+        "receipt_promotion_script": {
+          "const": "scripts/promote-credential-runtime-receipt.py"
+        },
+        "handoff_check_command": {
+          "const": "python3 scripts/generate-credential-runtime-review-handoff.py --check"
+        },
+        "queue_check_command": {
+          "const": "python3 scripts/generate-credential-runtime-receipt-collection-queue.py --check"
+        },
+        "post_review_commands": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "const": "python3 scripts/refresh-release-ledger-evidence.py --write --max-iterations 5"
+            },
+            {
+              "const": "python3 scripts/refresh-release-ledger-evidence.py --check"
+            }
+          ],
+          "items": false
+        },
+        "default_ci_requires_credentials": {
+          "const": false
+        },
+        "checked_in_secrets_allowed": {
+          "const": false
+        },
+        "goal_closure_allowed": {
+          "const": false
+        },
+        "routing_note": {
+          "$ref": "#/$defs/non_empty_string"
         }
       }
     },

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -451,8 +451,8 @@
       "title": "Datapan Credential Runtime Review Handoff v1",
       "contract": "credential-runtime-review-handoff",
       "version": "v1",
-      "bytes": 10057,
-      "sha256": "cc11fb18a23b0ea4efd4eca6ff109baab0a644b3664dfefa61cd92e78ba32f0a"
+      "bytes": 13071,
+      "sha256": "ba16fbbd0c6aea397cc87d11ba7cc8d719656a1ca32b8204aedb69ac85a9ebf8"
     },
     {
       "path": "schemas/datapan.credential-runtime-manual-review-acceptance.v1.schema.json",

--- a/scripts/generate-credential-runtime-review-handoff.py
+++ b/scripts/generate-credential-runtime-review-handoff.py
@@ -20,6 +20,8 @@ DEFAULT_SCHEMA = pathlib.Path("schemas/datapan.credential-runtime-review-handoff
 DEFAULT_OUTPUT = pathlib.Path("reports/credential-runtime-review-handoff.json")
 SCHEMA_VERSION = "datapan.credential-runtime-review-handoff.v1"
 HANDOFF_TICKET = 385
+RELEASE_EVIDENCE_REFRESH_COMMAND = "python3 scripts/refresh-release-ledger-evidence.py --write --max-iterations 5"
+RELEASE_EVIDENCE_CHECK_COMMAND = "python3 scripts/refresh-release-ledger-evidence.py --check"
 
 
 def load_json(path: pathlib.Path) -> dict[str, Any]:
@@ -204,6 +206,12 @@ def build_report(queue: dict[str, Any]) -> dict[str, Any]:
         for source in sorted(sources, key=lambda item: str(item.get("source_id")))
     ]
     pending_review = sum(1 for entry in entries if entry["relief_blockers"])
+    pending_source_ids = [entry["source_id"] for entry in entries if entry["relief_blockers"]]
+    first_reviewer_action = (
+        "collect_validate_review_and_promote_redacted_receipts"
+        if pending_source_ids
+        else "maintain_reviewed_receipt_evidence"
+    )
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -249,6 +257,42 @@ def build_report(queue: dict[str, Any]) -> dict[str, Any]:
             ),
             "default_ci_mode": "secret_free_review_handoff_validation",
         },
+        "reviewer_routing": {
+            "goal_issue": 344,
+            "handoff_status": "relief_ready" if global_relief_allowed else "review_required",
+            "first_reviewer_action": first_reviewer_action,
+            "pending_source_ids": pending_source_ids,
+            "pending_review_sources": pending_review,
+            "reviewed_receipts_checked_in": summary.get("reviewed_receipts_checked_in"),
+            "relief_eligible_sources": summary.get("relief_eligible"),
+            "global_manual_review_relief_allowed": global_relief_allowed,
+            "manual_review_required": release_boundary.get("manual_review_required"),
+            "receipt_validation_command": string_value(
+                operator_contract.get("receipt_validation_command"),
+                "operator_contract.receipt_validation_command",
+            ),
+            "receipt_promotion_script": string_value(
+                operator_contract.get("receipt_promotion_script"),
+                "operator_contract.receipt_promotion_script",
+            ),
+            "handoff_check_command": "python3 scripts/generate-credential-runtime-review-handoff.py --check",
+            "queue_check_command": string_value(
+                operator_contract.get("queue_check_command"),
+                "operator_contract.queue_check_command",
+            ),
+            "post_review_commands": [
+                RELEASE_EVIDENCE_REFRESH_COMMAND,
+                RELEASE_EVIDENCE_CHECK_COMMAND,
+            ],
+            "default_ci_requires_credentials": False,
+            "checked_in_secrets_allowed": False,
+            "goal_closure_allowed": False,
+            "routing_note": (
+                "Review every pending source receipt, promote only redacted reviewed receipts, then refresh "
+                "release evidence. Keep the persistent goal open until reviewed receipts or explicit "
+                "manual-review acceptance satisfy release gates."
+            ),
+        },
         "release_boundary": {
             "canonical_registry_compatible": True,
             "manual_review_required": release_boundary.get("manual_review_required"),
@@ -270,6 +314,51 @@ def build_report(queue: dict[str, Any]) -> dict[str, Any]:
         ],
         "sources": entries,
     }
+
+
+def validate_invariants(report: dict[str, Any]) -> None:
+    summary = as_dict(report.get("summary"), "summary")
+    operator_contract = as_dict(report.get("operator_contract"), "operator_contract")
+    routing = as_dict(report.get("reviewer_routing"), "reviewer_routing")
+    release_boundary = as_dict(report.get("release_boundary"), "release_boundary")
+    sources = [as_dict(source, "sources[]") for source in as_list(report.get("sources"), "sources")]
+    pending_sources = [source["source_id"] for source in sources if as_list(source.get("relief_blockers"), "source.relief_blockers")]
+    if routing.get("goal_issue") != 344:
+        raise ValueError("reviewer_routing.goal_issue must preserve #344")
+    if routing.get("handoff_status") != summary.get("handoff_status"):
+        raise ValueError("reviewer_routing.handoff_status must mirror summary.handoff_status")
+    if routing.get("pending_source_ids") != pending_sources:
+        raise ValueError("reviewer_routing.pending_source_ids must match sources with relief blockers")
+    if routing.get("pending_review_sources") != summary.get("pending_review_sources"):
+        raise ValueError("reviewer_routing.pending_review_sources must mirror summary")
+    if routing.get("reviewed_receipts_checked_in") != summary.get("reviewed_receipts_checked_in"):
+        raise ValueError("reviewer_routing.reviewed_receipts_checked_in must mirror summary")
+    if routing.get("relief_eligible_sources") != summary.get("relief_eligible_sources"):
+        raise ValueError("reviewer_routing.relief_eligible_sources must mirror summary")
+    if routing.get("global_manual_review_relief_allowed") != summary.get("global_manual_review_relief_allowed"):
+        raise ValueError("reviewer_routing.global_manual_review_relief_allowed must mirror summary")
+    if routing.get("manual_review_required") != release_boundary.get("manual_review_required"):
+        raise ValueError("reviewer_routing.manual_review_required must mirror release boundary")
+    if routing.get("receipt_validation_command") != operator_contract.get("receipt_validation_command"):
+        raise ValueError("reviewer_routing.receipt_validation_command must mirror operator contract")
+    if routing.get("receipt_promotion_script") != operator_contract.get("receipt_promotion_script"):
+        raise ValueError("reviewer_routing.receipt_promotion_script must mirror operator contract")
+    if routing.get("handoff_check_command") != operator_contract.get("handoff_check_command"):
+        raise ValueError("reviewer_routing.handoff_check_command must mirror operator contract")
+    if routing.get("queue_check_command") != operator_contract.get("queue_check_command"):
+        raise ValueError("reviewer_routing.queue_check_command must mirror operator contract")
+    if routing.get("post_review_commands") != [RELEASE_EVIDENCE_REFRESH_COMMAND, RELEASE_EVIDENCE_CHECK_COMMAND]:
+        raise ValueError("reviewer_routing.post_review_commands must refresh and check release evidence")
+    if routing.get("default_ci_requires_credentials") is not False:
+        raise ValueError("reviewer_routing.default_ci_requires_credentials must remain false")
+    if routing.get("checked_in_secrets_allowed") is not False:
+        raise ValueError("reviewer_routing.checked_in_secrets_allowed must remain false")
+    if routing.get("goal_closure_allowed") is not False:
+        raise ValueError("reviewer_routing.goal_closure_allowed must remain false")
+    if pending_sources and routing.get("first_reviewer_action") != "collect_validate_review_and_promote_redacted_receipts":
+        raise ValueError("pending sources must route to collect/validate/review/promote action")
+    if not pending_sources and routing.get("first_reviewer_action") != "maintain_reviewed_receipt_evidence":
+        raise ValueError("relief-ready handoff must route to maintaining reviewed evidence")
 
 
 def validate_schema(report: dict[str, Any], schema_path: pathlib.Path) -> None:
@@ -294,6 +383,7 @@ def main() -> int:
 
     try:
         report = build_report(load_json(args.queue))
+        validate_invariants(report)
         validate_schema(report, args.schema)
     except Exception as exc:  # noqa: BLE001 - release operators need the failed invariant
         print(f"FAIL generate credential runtime review handoff: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Add schema-backed `reviewer_routing` evidence to `reports/credential-runtime-review-handoff.json`.
- Surface pending source ids, first reviewer action, validation/promotion commands, post-review refresh commands, and secret-free/non-closure boundaries at the top level.
- Regenerate manifest-bound release evidence so consumer compatibility and assembly receipts remain fixed-point consistent.

## Verification
- `python3 scripts/generate-credential-runtime-review-handoff.py --check`
- `python3 scripts/refresh-release-ledger-evidence.py --check`
- `python3 -m py_compile scripts/generate-credential-runtime-review-handoff.py`
- `git diff --check`

## Goal Boundary
Persistent goal #344 remains not complete. This PR preserves `goal_closure_allowed=false`, does not collect credential receipts, and does not assert manual-review acceptance.

Closes #478
