### PR TITLE
feat: Add Registry-native immutable receipt admission foundation

### DIFF
--- a/docs/release-cadence.md
+++ b/docs/release-cadence.md
@@ -69,6 +69,46 @@ source artifacts that the manifest must checksum. CI writes the current-checkout
 or selected-manifest equivalents under `.datapan/ci/` so workflow evidence can
 verify the same command path without rewriting the checked-in receipt files.
 
+## Immutable Receipt Admission Foundation
+
+`schemas/datapan.release-receipt-admission.v1.schema.json` defines the
+Registry-side, offline admission boundary for immutable producer receipts. A
+receipt is bound to a producer commit and producer-receipt digest plus the
+selected Registry manifest, source-registry, and admission-policy digests. Its
+`receipt_digest` is SHA-256 over canonical JSON with that field omitted, so it
+does not self-reference. The separately supplied producer artifact root is
+required at admission: aggregate and shard files are resolved below that root,
+byte-checked against declared SHA-256 values, and cannot escape via path
+traversal or symlinks. The explicit admission time applies producer-kind
+freshness limits and rejects future receipts.
+
+Validate local contract fixtures without a provider call, Registry publication,
+or Datapan CLI checkout:
+
+```bash
+python3 scripts/validate-release-admission-receipts.py \
+  --manifest tests/fixtures/release-admission/manifest.json \
+  --check-manifest-artifacts \
+  --admission-time 2026-07-22T01:00:00Z \
+  --producer-artifact-root StatPan/datapan-data=tests/fixtures/release-admission/producer-artifacts/datapan-data \
+  --producer-artifact-root StatPan/datapan-health=tests/fixtures/release-admission/producer-artifacts/datapan-health \
+  --producer-artifact-root StatPan/datapan-cli=tests/fixtures/release-admission/producer-artifacts/datapan-cli \
+  tests/fixtures/release-admission/catalog-observation.json \
+  tests/fixtures/release-admission/cli-consumer-smoke.json \
+  tests/fixtures/release-admission/runtime-freshness-shard-0.json
+```
+
+The `runtime_freshness_shard` kind is exclusively for the rotating eight-shard
+freshness run. It requires one immutable producer revision, one Registry
+manifest/source/policy binding, all shard indexes 0 through 7, batch size at
+most 100, parallelism at most 2, and per-operation timeout at most 20 seconds.
+Its Health aggregate and selected shard artifact are byte-bound to the outer
+Registry envelope. A partial aggregate (`receipt_available=false` for any
+shard) cannot synthesize an outer receipt and fails completeness. It does not
+admit or replace Health canary observations. This is a contract foundation
+only; the current external-checkout guard remains in force until later
+producer, workflow-cutover, and rollback evidence is proven.
+
 ## Guarded GitHub Draft
 
 Maintainers may use the `Draft registry release` GitHub Actions workflow when

--- a/docs/release-ledger-goal-completion-audit.json
+++ b/docs/release-ledger-goal-completion-audit.json
@@ -16,11 +16,11 @@
   "current_state_evidence": {
     "manifest": {
       "path": "manifest.json",
-      "artifact_count": 160
+      "artifact_count": 161
     },
     "schema_index": {
       "path": "schemas/index.json",
-      "schema_count": 87
+      "schema_count": 88
     },
     "release_readiness": {
       "path": "reports/latest-release-readiness.json",
@@ -153,9 +153,9 @@
     },
     "release_distribution_footprint": {
       "path": "reports/release-distribution-footprint.json",
-      "artifact_count": 160,
-      "schema_artifacts": 87,
-      "manifest_bound_bytes_excluding_self": 173952337,
+      "artifact_count": 161,
+      "schema_artifacts": 88,
+      "manifest_bound_bytes_excluding_self": 173957232,
       "canonical_registry_path": "data/data-go-kr.registry.json",
       "canonical_registry_bytes": 137735169,
       "large_monolith_threshold_bytes": 100000000,
@@ -218,7 +218,7 @@
       "acceptance_status": "accepted",
       "acceptance_decision": "accepted_manual_review_release_boundary",
       "decision_status": "accepted",
-      "decision_reason": "The accountable release owner re-accepts the current manual-review release boundary for additive, pre-publication diagnostic artifacts. Credential and runtime policy are unchanged; tag, publication, anonymous fetch, and consumer rollout remain separate blocked gates.",
+      "decision_reason": "Accountable revalidation after artifact_count changed 160 to 161 and manifest-bound bytes changed; runtime_risk_evidence and summary are byte-equal, credential, runtime, workflow, and pin semantics are unchanged, and publication and cutover remain blocked.",
       "credential_handoff_status": "relief_ready",
       "pending_review_sources": 0,
       "reviewed_receipts_checked_in": 5,

--- a/fixtures/source-provenance/regional-baseline-v0-pin.json
+++ b/fixtures/source-provenance/regional-baseline-v0-pin.json
@@ -4,7 +4,7 @@
   "registry_tag": "issue-559-unreleased-fixture",
   "registry_manifest": {
     "path": "manifest.json",
-    "sha256": "eec64416c3dd07be90e37c06c450ee5dc96235fec9fa3e46ac36945b00746127"
+    "sha256": "c42f9f8fa56e31459524ac5684e8b0de05c59102822d0f1289ffe7235eca2217"
   },
   "provenance_artifact": {
     "path": "reports/regional-baseline-source-provenance.json",

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "provider": "data.go.kr",
   "source_registry": "data/data-go-kr.registry.json",
   "output_dir": ".",
-  "artifact_count": 160,
+  "artifact_count": 161,
   "artifacts": [
     {
       "path": "schemas/datapan.adapter-targets.v1.schema.json",
@@ -530,11 +530,17 @@
       "sha256": "cf08ea3e578edc2530f0e29e2900e157e2c5dd0615c02efe51b3f552220fe836"
     },
     {
+      "path": "schemas/datapan.release-receipt-admission.v1.schema.json",
+      "kind": "schema",
+      "bytes": 4520,
+      "sha256": "0d9ea5cc7e94136a82579931b391e332df04e35b1ed1eb2de18ed0502c15a666"
+    },
+    {
       "path": "schemas/index.json",
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
-      "bytes": 35518,
-      "sha256": "117e0b0ee681ec861ecd0015faa6ceabeaf47e615179c224266b354571b5a608"
+      "bytes": 35926,
+      "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -611,7 +617,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 8075,
-      "sha256": "7b65d98286bb0ab686d8bf396bb1d107ae939d197973237d0954f304284aafdc"
+      "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3"
     },
     {
       "path": "reports/operation-denominator-rollup.json",
@@ -694,29 +700,29 @@
       "path": "reports/credential-runtime-manual-review-decision.json",
       "kind": "credential_runtime_manual_review_decision",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-decision.v1.schema.json",
-      "bytes": 1782,
-      "sha256": "9157b32d246db0b504d108be55c2291625053e7268b5080f44e250d1429d6435"
+      "bytes": 1771,
+      "sha256": "4d0bee81a67d4b49a1ccb022ab6be7a28a76b9613cbd7c2211d5f22ce9d69151"
     },
     {
       "path": "reports/credential-runtime-manual-review-acceptance.json",
       "kind": "credential_runtime_manual_review_acceptance",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance.v1.schema.json",
-      "bytes": 4596,
-      "sha256": "86e85bf62b4617013b587746f116bd433b4002e9ec8359f27a88a67b73ea452a"
+      "bytes": 4585,
+      "sha256": "268e1aaf383f4a454e3c4d0513692e6d80156ffe5e2dbcf962c5df0f71095631"
     },
     {
       "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3988,
-      "sha256": "b506f757ebdae70b0f1ee15d94ce29e39c8cc2668a3bba3b7bacef755cdc5a14"
+      "sha256": "86718af67e5dc03812854a740b98229557a75460c7aadb8bf60050ae6f76f672"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "a2e0609209a8e1b0b2c15100b05d501b76243d17975e8d8d2a2590954fc1c1f3"
+      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -730,7 +736,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "64e595911dde126b3e7885d805a588ec547b0d924380ca8a12db0e233fd39c38"
+      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7"
     },
     {
       "path": "reports/dependencies.json",
@@ -799,15 +805,15 @@
       "path": "reports/release-consumer-compatibility.json",
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
-      "bytes": 26686,
-      "sha256": "c5812a00ebcb23118c5470ca05b8006b673203f1169a28df1201150ae4894ec1"
+      "bytes": 26675,
+      "sha256": "9ea04b875d96ed773f2b5bc5d0579c789e32d35040c5a79dd2d5e03bb71a6d77"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2141,
-      "sha256": "3447a968def0bd285572778db869b44ac7564906a12cc74518da6e89aa03faa1"
+      "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -856,7 +862,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34969,
-      "sha256": "c13c662174e2e4b8adf9d0f73f1a498a9a9441cec68027fef4f8d5d4818440cc"
+      "sha256": "1a7d02246e9014148862ea6b1f6c7be3062042402802c359988cde7c1e4766ab"
     },
     {
       "path": "reports/unadapted-external-probe.json",

--- a/policy/release-receipt-admission.json
+++ b/policy/release-receipt-admission.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "datapan.release-receipt-admission-policy.v1",
+  "receipt_schema": "schemas/datapan.release-receipt-admission.v1.schema.json",
+  "receipt_validator": "scripts/validate-release-admission-receipts.py",
+  "receipt_validation_command": "python3 scripts/validate-release-admission-receipts.py",
+  "receipt_digest_scope": "sha256 of canonical JSON with sorted keys, compact separators, UTF-8 encoding, and receipt_digest omitted; producer.receipt_sha256 instead identifies immutable producer receipt bytes",
+  "producer_contracts": {
+    "catalog_observation": {"repository": "StatPan/datapan-data", "outcomes": ["no_change", "material_change", "collection_failure"], "subject": "upstream_catalog", "max_age_seconds": 86400},
+    "runtime_freshness_shard": {"repository": "StatPan/datapan-health", "outcomes": ["verified", "failed", "skipped", "unknown"], "provider": "data_go_kr", "subject": "runtime_freshness_rotating_shard", "max_age_seconds": 3600, "shard_count": 8, "batch_size_max": 100, "max_parallelism_max": 2, "per_operation_timeout_seconds_max": 20},
+    "cli_consumer_smoke": {"repository": "StatPan/datapan-cli", "outcomes": ["verified", "failed", "skipped", "unknown"], "subject": "published_registry_consumer_smoke", "max_age_seconds": 86400}
+  },
+  "redaction": {"forbidden_field_names": ["credential_value", "credential_hash", "authorization_header", "service_key", "api_key", "secret", "request_url", "request_urls", "response_body", "response_bodies", "raw_response", "identity", "user_id", "email"], "forbidden_value_patterns": ["authorization:\\s*bearer\\s+", "bearer\\s+[a-z0-9._~+/=-]{16,}", "serviceKey=", "api[_-]?key=", "https?://", "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"]}
+}

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "7d8e645a0f58469fabe3f9289e20ea6835c81e088dd363519d015d1d0f501beb",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "ce272b8f641feb45b3d679f2602f1579dce3ffad3379b7ff3801bd0cd745384c"
+    "compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "7d8e645a0f58469fabe3f9289e20ea6835c81e088dd363519d015d1d0f501beb",
-    "compatibility_sha256": "ce272b8f641feb45b3d679f2602f1579dce3ffad3379b7ff3801bd0cd745384c",
+    "compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/credential-runtime-manual-review-acceptance.json
+++ b/reports/credential-runtime-manual-review-acceptance.json
@@ -17,7 +17,7 @@
     "acceptance_status": "accepted",
     "acceptance_decision": "accepted_manual_review_release_boundary",
     "decision_status": "accepted",
-    "decision_reason": "The accountable release owner re-accepts the current manual-review release boundary for additive, pre-publication diagnostic artifacts. Credential and runtime policy are unchanged; tag, publication, anonymous fetch, and consumer rollout remain separate blocked gates.",
+    "decision_reason": "Accountable revalidation after artifact_count changed 160 to 161 and manifest-bound bytes changed; runtime_risk_evidence and summary are byte-equal, credential, runtime, workflow, and pin semantics are unchanged, and publication and cutover remain blocked.",
     "credential_handoff_status": "relief_ready",
     "pending_review_sources": 0,
     "reviewed_receipts_checked_in": 5,

--- a/reports/credential-runtime-manual-review-decision.json
+++ b/reports/credential-runtime-manual-review-decision.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "datapan.credential-runtime-manual-review-decision.v1",
-  "generated_at": "2026-07-16T10:30:00Z",
+  "generated_at": "2026-07-22T13:19:56Z",
   "goal_issue": 344,
   "decision_ticket": 391,
   "provider": "datapan-registry",
@@ -19,10 +19,10 @@
     "accepted": true,
     "decision_status": "accepted",
     "reviewer": "StatPan",
-    "reviewed_at": "2026-07-16T10:30:00Z",
-    "reason": "The accountable release owner re-accepts the current manual-review release boundary for additive, pre-publication diagnostic artifacts. Credential and runtime policy are unchanged; tag, publication, anonymous fetch, and consumer rollout remain separate blocked gates.",
+    "reviewed_at": "2026-07-22T13:19:56Z",
+    "reason": "Accountable revalidation after artifact_count changed 160 to 161 and manifest-bound bytes changed; runtime_risk_evidence and summary are byte-equal, credential, runtime, workflow, and pin semantics are unchanged, and publication and cutover remain blocked.",
     "handoff_sha256": "7d8e645a0f58469fabe3f9289e20ea6835c81e088dd363519d015d1d0f501beb",
-    "compatibility_sha256": "ce272b8f641feb45b3d679f2602f1579dce3ffad3379b7ff3801bd0cd745384c",
+    "compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a",
     "expires_at": "2026-08-15T10:30:00Z",
     "revalidation_triggers": [
       "credential_receipt_state_changes",

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "64e595911dde126b3e7885d805a588ec547b0d924380ca8a12db0e233fd39c38"
+      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -25,7 +25,7 @@
     "manifest": {
       "path": "manifest.json",
       "generated_at": "2026-07-11T10:28:35Z",
-      "artifact_count": 160,
+      "artifact_count": 161,
       "source_registry": "data/data-go-kr.registry.json"
     },
     "readiness": {
@@ -107,8 +107,8 @@
       "evidence_artifacts": [
         {
           "path": "schemas/index.json",
-          "bytes": 35518,
-          "sha256": "117e0b0ee681ec861ecd0015faa6ceabeaf47e615179c224266b354571b5a608",
+          "bytes": 35926,
+          "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 61997,
-          "sha256": "64e595911dde126b3e7885d805a588ec547b0d924380ca8a12db0e233fd39c38",
+          "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "a2e0609209a8e1b0b2c15100b05d501b76243d17975e8d8d2a2590954fc1c1f3",
+          "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 8075,
-          "sha256": "7b65d98286bb0ab686d8bf396bb1d107ae939d197973237d0954f304284aafdc",
+          "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -465,16 +465,16 @@
         },
         {
           "path": "reports/credential-runtime-manual-review-decision.json",
-          "bytes": 1782,
-          "sha256": "9157b32d246db0b504d108be55c2291625053e7268b5080f44e250d1429d6435",
+          "bytes": 1771,
+          "sha256": "4d0bee81a67d4b49a1ccb022ab6be7a28a76b9613cbd7c2211d5f22ce9d69151",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_decision",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-decision.v1.schema.json"
         },
         {
           "path": "reports/credential-runtime-manual-review-acceptance.json",
-          "bytes": 4596,
-          "sha256": "86e85bf62b4617013b587746f116bd433b4002e9ec8359f27a88a67b73ea452a",
+          "bytes": 4585,
+          "sha256": "268e1aaf383f4a454e3c4d0513692e6d80156ffe5e2dbcf962c5df0f71095631",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3988,
-          "sha256": "b506f757ebdae70b0f1ee15d94ce29e39c8cc2668a3bba3b7bacef755cdc5a14",
+          "sha256": "86718af67e5dc03812854a740b98229557a75460c7aadb8bf60050ae6f76f672",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,15 +525,15 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2141,
-          "sha256": "3447a968def0bd285572778db869b44ac7564906a12cc74518da6e89aa03faa1",
+          "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
         },
         {
           "path": "reports/release-consumer-compatibility.json",
-          "bytes": 26686,
-          "sha256": "c5812a00ebcb23118c5470ca05b8006b673203f1169a28df1201150ae4894ec1",
+          "bytes": 26675,
+          "sha256": "9ea04b875d96ed773f2b5bc5d0579c789e32d35040c5a79dd2d5e03bb71a6d77",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"
@@ -727,8 +727,8 @@
       "evidence_artifacts": [
         {
           "path": "docs/release-ledger-goal-completion-audit.json",
-          "bytes": 25628,
-          "sha256": "4979092a67e52f66997f02dc3f027aa4a749b7643f77f4b7277344c8f6d81491",
+          "bytes": 25617,
+          "sha256": "98aaf2c1d2d5c944a182a8a57190efe8f5d800f7b810a633a13428f92d95b382",
           "manifest_bound": false
         },
         {

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -7,7 +7,7 @@
     "manifest": {
       "path": "manifest.json",
       "generated_at": "2026-07-11T10:28:35Z",
-      "artifact_count": 160,
+      "artifact_count": 161,
       "evidence_contracts": 18
     },
     "readiness": {
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 8075,
-      "sha256": "7b65d98286bb0ab686d8bf396bb1d107ae939d197973237d0954f304284aafdc",
+      "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3",
       "required": true
     },
     {
@@ -166,8 +166,8 @@
       "path": "reports/credential-runtime-manual-review-decision.json",
       "kind": "credential_runtime_manual_review_decision",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-decision.v1.schema.json",
-      "bytes": 1782,
-      "sha256": "9157b32d246db0b504d108be55c2291625053e7268b5080f44e250d1429d6435",
+      "bytes": 1771,
+      "sha256": "4d0bee81a67d4b49a1ccb022ab6be7a28a76b9613cbd7c2211d5f22ce9d69151",
       "required": true
     },
     {
@@ -175,8 +175,8 @@
       "path": "reports/credential-runtime-manual-review-acceptance.json",
       "kind": "credential_runtime_manual_review_acceptance",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance.v1.schema.json",
-      "bytes": 4596,
-      "sha256": "86e85bf62b4617013b587746f116bd433b4002e9ec8359f27a88a67b73ea452a",
+      "bytes": 4585,
+      "sha256": "268e1aaf383f4a454e3c4d0513692e6d80156ffe5e2dbcf962c5df0f71095631",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "a2e0609209a8e1b0b2c15100b05d501b76243d17975e8d8d2a2590954fc1c1f3",
+      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "64e595911dde126b3e7885d805a588ec547b0d924380ca8a12db0e233fd39c38",
+      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2141,
-      "sha256": "3447a968def0bd285572778db869b44ac7564906a12cc74518da6e89aa03faa1",
+      "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d",
       "required": true
     },
     {
@@ -366,7 +366,7 @@
     "credential_handoff_relief_decision": "allowed_by_all_reviewed_validated_receipts",
     "manual_review_decision_status": "accepted",
     "manual_review_decision_accepted": true,
-    "manual_review_decision_reason": "The accountable release owner re-accepts the current manual-review release boundary for additive, pre-publication diagnostic artifacts. Credential and runtime policy are unchanged; tag, publication, anonymous fetch, and consumer rollout remain separate blocked gates.",
+    "manual_review_decision_reason": "Accountable revalidation after artifact_count changed 160 to 161 and manifest-bound bytes changed; runtime_risk_evidence and summary are byte-equal, credential, runtime, workflow, and pin semantics are unchanged, and publication and cutover remain blocked.",
     "manual_review_decision_boundary_accepted": true,
     "manual_review_acceptance_status": "accepted",
     "manual_review_acceptance_accepted": true,
@@ -476,7 +476,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 173952337,
+    "manifest_bound_bytes_excluding_self": 173957232,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -9,9 +9,9 @@
     "self_artifact_excluded": true
   },
   "summary": {
-    "artifact_count": 160,
-    "schema_artifacts": 87,
-    "manifest_bound_bytes_excluding_self": 173952337,
+    "artifact_count": 161,
+    "schema_artifacts": 88,
+    "manifest_bound_bytes_excluding_self": 173957232,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -46,9 +46,9 @@
   ],
   "schema_index_input": {
     "path": "schemas/index.json",
-    "schemas": 87,
-    "bytes": 35518,
-    "sha256": "117e0b0ee681ec861ecd0015faa6ceabeaf47e615179c224266b354571b5a608"
+    "schemas": 88,
+    "bytes": 35926,
+    "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -47,7 +47,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "a2e0609209a8e1b0b2c15100b05d501b76243d17975e8d8d2a2590954fc1c1f3"
+      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.release-receipt-admission.v1.schema.json
+++ b/schemas/datapan.release-receipt-admission.v1.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.datapan.dev/datapan.release-receipt-admission.v1.schema.json",
+  "title": "Datapan Release Receipt Admission v1",
+  "description": "Redacted immutable producer receipt admitted by the Registry release control plane.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "receipt_kind", "producer", "registry", "outcome", "scope", "redaction", "receipt_digest"],
+  "properties": {
+    "schema_version": {"const": "datapan.release-receipt-admission.v1"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "receipt_kind": {"enum": ["catalog_observation", "runtime_freshness_shard", "cli_consumer_smoke"]},
+    "producer": {"$ref": "#/$defs/producer"},
+    "registry": {"$ref": "#/$defs/registry"},
+    "outcome": {"enum": ["no_change", "material_change", "collection_failure", "verified", "failed", "skipped", "unknown"]},
+    "scope": {"$ref": "#/$defs/scope"},
+    "execution": {"$ref": "#/$defs/execution"},
+    "redaction": {"$ref": "#/$defs/redaction"},
+    "receipt_digest": {"$ref": "#/$defs/digest"}
+  },
+  "$defs": {
+    "digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "revision", "receipt_path", "receipt_sha256"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^StatPan/[A-Za-z0-9_.-]+$"},
+        "revision": {"type": "string", "pattern": "^[a-f0-9]{40}$"},
+        "receipt_path": {"type": "string", "pattern": "^[A-Za-z0-9_./-]+\\.json$"},
+        "receipt_sha256": {"$ref": "#/$defs/digest"},
+        "aggregate_path": {"type": "string", "pattern": "^[A-Za-z0-9_./-]+\\.json$"},
+        "aggregate_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "registry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["manifest_path", "manifest_sha256", "source_path", "source_sha256", "policy_path", "policy_sha256"],
+      "properties": {
+        "manifest_path": {"type": "string", "minLength": 1},
+        "manifest_sha256": {"$ref": "#/$defs/digest"},
+        "source_path": {"type": "string", "minLength": 1},
+        "source_sha256": {"$ref": "#/$defs/digest"},
+        "policy_path": {"type": "string", "minLength": 1},
+        "policy_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "subject"],
+      "properties": {
+        "provider": {"type": "string", "minLength": 1},
+        "subject": {"type": "string", "minLength": 1}
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "shard_count", "shard_index", "shard_digest", "batch_size", "max_parallelism", "per_operation_timeout_seconds", "terminal_state"],
+      "properties": {
+        "run_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "shard_count": {"const": 8},
+        "shard_index": {"type": "integer", "minimum": 0, "maximum": 7},
+        "shard_digest": {"$ref": "#/$defs/digest"},
+        "batch_size": {"type": "integer", "minimum": 1, "maximum": 100},
+        "max_parallelism": {"type": "integer", "minimum": 1, "maximum": 2},
+        "per_operation_timeout_seconds": {"type": "integer", "minimum": 1, "maximum": 20},
+        "terminal_state": {"enum": ["verified", "failed", "skipped", "unknown"]}
+      }
+    },
+    "redaction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["secret_values_present", "secret_hashes_present", "request_urls_present", "response_bodies_present", "forbidden_fields_checked"],
+      "properties": {
+        "secret_values_present": {"const": false},
+        "secret_hashes_present": {"const": false},
+        "request_urls_present": {"const": false},
+        "response_bodies_present": {"const": false},
+        "forbidden_fields_checked": {"type": "array", "minItems": 5, "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+      }
+    }
+  },
+  "allOf": [
+    {"if": {"properties": {"receipt_kind": {"const": "runtime_freshness_shard"}}}, "then": {"required": ["execution"], "properties": {"producer": {"required": ["aggregate_path", "aggregate_sha256"]}}}},
+    {"if": {"properties": {"receipt_kind": {"enum": ["catalog_observation", "cli_consumer_smoke"]}}}, "then": {"not": {"required": ["execution"]}}}
+  ]
+}

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "schema_version": "datapan.schema-index.v1",
   "generated_at": "2026-07-04T06:39:24Z",
   "datapan_version": "0.1.0-dev",
-  "count": 87,
+  "count": 88,
   "schemas": [
     {
       "path": "schemas/datapan.adapter-targets.v1.schema.json",
@@ -786,6 +786,15 @@
       "version": "v1",
       "bytes": 3183,
       "sha256": "cf08ea3e578edc2530f0e29e2900e157e2c5dd0615c02efe51b3f552220fe836"
+    },
+    {
+      "path": "schemas/datapan.release-receipt-admission.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.release-receipt-admission.v1.schema.json",
+      "title": "Datapan Release Receipt Admission v1",
+      "contract": "release-receipt-admission",
+      "version": "v1",
+      "bytes": 4520,
+      "sha256": "0d9ea5cc7e94136a82579931b391e332df04e35b1ed1eb2de18ed0502c15a666"
     }
   ]
 }

--- a/scripts/release_admission_receipts.py
+++ b/scripts/release_admission_receipts.py
@@ -1,0 +1,340 @@
+"""Offline validation helpers for immutable Registry release-admission receipts."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import pathlib
+import re
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
+from typing import Any
+
+import jsonschema
+
+SCHEMA_VERSION = "datapan.release-receipt-admission.v1"
+RUNTIME_KIND = "runtime_freshness_shard"
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    return as_dict(value, path.as_posix())
+
+
+def as_dict(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def as_list(value: object, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return value
+
+
+def file_digest(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def rooted_file(root: pathlib.Path, raw_path: object, label: str) -> pathlib.Path:
+    if not isinstance(raw_path, str):
+        raise ValueError(f"{label} must be a string path")
+    relative = PurePosixPath(raw_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"{label} escapes its root")
+    resolved_root = root.resolve()
+    candidate = (resolved_root / pathlib.Path(*relative.parts)).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes its root") from exc
+    if not candidate.is_file():
+        raise ValueError(f"{label} must be a regular file inside its root")
+    return candidate
+
+
+def canonical_digest(receipt: dict[str, Any]) -> str:
+    value = copy.deepcopy(receipt)
+    value.pop("receipt_digest", None)
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def parse_time(value: object, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be an RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} is not an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+@FORMAT_CHECKER.checks("date-time")
+def is_rfc3339_datetime(value: object) -> bool:
+    try:
+        parse_time(value, "date-time")
+    except ValueError:
+        return False
+    return True
+
+
+def validate_schema(receipt: dict[str, Any], schema: dict[str, Any], label: str) -> None:
+    errors = sorted(
+        jsonschema.Draft202012Validator(schema, format_checker=FORMAT_CHECKER).iter_errors(receipt),
+        key=lambda item: list(item.path),
+    )
+    if errors:
+        # Never render an invalid value or unknown property name: receipts are an
+        # untrusted boundary and diagnostics must not echo a secret or identity.
+        rendered = "; ".join(
+            f"{'.'.join(map(str, error.path)) or '<root>'}: schema validation {error.validator}"
+            for error in errors
+        )
+        raise ValueError(f"{label}: {rendered}")
+
+
+def scan_redaction(value: object, policy: dict[str, Any], label: str) -> None:
+    redaction = as_dict(policy.get("redaction"), "policy.redaction")
+    forbidden_keys = set(as_list(redaction.get("forbidden_field_names"), "policy.redaction.forbidden_field_names"))
+    patterns = [re.compile(pattern, re.IGNORECASE) for pattern in as_list(redaction.get("forbidden_value_patterns"), "policy.redaction.forbidden_value_patterns")]
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in forbidden_keys:
+                raise ValueError(f"{label}: forbidden secret-bearing field {key!r}")
+            scan_redaction(child, policy, f"{label}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            scan_redaction(child, policy, f"{label}[{index}]")
+    elif isinstance(value, str):
+        for pattern in patterns:
+            if pattern.search(value):
+                raise ValueError(f"{label}: value matches forbidden secret pattern {pattern.pattern!r}")
+
+
+def validate_manifest(manifest_path: pathlib.Path, *, check_artifacts: bool) -> tuple[dict[str, Any], str, str]:
+    manifest = load_json(manifest_path)
+    if manifest.get("schema_version") != "datapan.release-manifest.v1":
+        raise ValueError("manifest.schema_version must be datapan.release-manifest.v1")
+    source = manifest.get("source_registry")
+    if not isinstance(source, str) or not source:
+        raise ValueError("manifest.source_registry must be a non-empty path")
+    artifacts = as_list(manifest.get("artifacts"), "manifest.artifacts")
+    if manifest.get("artifact_count") != len(artifacts):
+        raise ValueError("manifest.artifact_count must equal manifest.artifacts length")
+    paths: set[str] = set()
+    root = manifest_path.parent
+    for index, raw_artifact in enumerate(artifacts):
+        artifact = as_dict(raw_artifact, f"manifest.artifacts[{index}]")
+        path = artifact.get("path")
+        if not isinstance(path, str) or not path or path in paths:
+            raise ValueError(f"manifest.artifacts[{index}].path must be unique and non-empty")
+        paths.add(path)
+        if check_artifacts:
+            artifact_path = rooted_file(root, path, f"manifest.artifacts[{index}].path")
+            if artifact.get("sha256") != file_digest(artifact_path):
+                raise ValueError(f"manifest artifact digest mismatch: {path}")
+    source_path = rooted_file(root, source, "manifest.source_registry")
+    return manifest, file_digest(manifest_path), file_digest(source_path)
+
+
+def producer_artifact_path(
+    producer: dict[str, Any], artifact_roots: dict[str, pathlib.Path], field: str, label: str
+) -> pathlib.Path:
+    repository = producer.get("repository")
+    root = artifact_roots.get(repository)
+    if root is None:
+        raise ValueError(f"{label}: producer artifact root is required for the authorized producer")
+    raw_path = producer.get(field)
+    if not isinstance(raw_path, str):
+        raise ValueError(f"{label}: producer receipt path must be a string")
+    relative = PurePosixPath(raw_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"{label}: producer artifact path escapes its artifact root")
+    resolved_root = root.resolve()
+    candidate = (resolved_root / pathlib.Path(*relative.parts)).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(f"{label}: producer artifact path escapes its artifact root") from exc
+    if not candidate.is_file():
+        raise ValueError(f"{label}: producer artifact is missing")
+    return candidate
+
+
+def validate_health_aggregate(
+    producer: dict[str, Any],
+    execution: dict[str, Any],
+    scope: dict[str, Any],
+    registry: dict[str, Any],
+    redaction: dict[str, Any],
+    artifact_roots: dict[str, pathlib.Path],
+    label: str,
+) -> None:
+    aggregate_path = producer_artifact_path(producer, artifact_roots, "aggregate_path", label)
+    if producer.get("aggregate_sha256") != file_digest(aggregate_path):
+        raise ValueError(f"{label}: producer aggregate digest does not match artifact bytes")
+    aggregate = load_json(aggregate_path)
+    if aggregate.get("schema_version") != "datapan.health-bounded-observation-run.v1":
+        raise ValueError(f"{label}: producer aggregate schema is not the bounded Health run contract")
+    aggregate_producer = as_dict(aggregate.get("producer"), f"{label}.producer_aggregate.producer")
+    if aggregate_producer.get("repository") != producer.get("repository") or aggregate_producer.get("revision") != producer.get("revision"):
+        raise ValueError(f"{label}: producer aggregate immutable producer binding does not match")
+    aggregate_registry = as_dict(aggregate.get("registry"), f"{label}.producer_aggregate.registry")
+    for field in ("manifest_sha256", "source_sha256", "policy_sha256"):
+        if aggregate_registry.get(field) != registry.get(field):
+            raise ValueError(f"{label}: producer aggregate Registry policy binding does not match")
+    run = as_dict(aggregate.get("run"), f"{label}.producer_aggregate.run")
+    if run.get("run_id") != execution.get("run_id") or run.get("shard_count") != 8:
+        raise ValueError(f"{label}: producer aggregate run binding does not match")
+    if run.get("batch_size") != execution.get("batch_size") or run.get("max_parallel") != execution.get("max_parallelism") or run.get("timeout_ms") != execution.get("per_operation_timeout_seconds") * 1000:
+        raise ValueError(f"{label}: producer aggregate bounded execution values do not match")
+    aggregate_summary = as_dict(aggregate.get("aggregate"), f"{label}.producer_aggregate.aggregate")
+    if (
+        aggregate_summary.get("completeness") != "complete"
+        or aggregate_summary.get("timed_out") is not False
+        or aggregate_summary.get("terminal_state") != execution.get("terminal_state")
+    ):
+        raise ValueError(f"{label}: producer aggregate does not assert complete eight-shard coverage")
+    shards = as_list(aggregate.get("shards"), f"{label}.producer_aggregate.shards")
+    aggregate_indexes = [
+        as_dict(item, f"{label}.producer_aggregate.shards[]").get("index")
+        for item in shards
+        if isinstance(item, dict)
+    ]
+    if sorted(aggregate_indexes) != list(range(8)):
+        raise ValueError(f"{label}: producer aggregate does not enumerate shard indexes 0 through 7")
+    for aggregate_shard in shards:
+        item = as_dict(aggregate_shard, f"{label}.producer_aggregate.shards[]")
+        if item.get("receipt_available") is not True or item.get("completed") is not True:
+            raise ValueError(f"{label}: producer aggregate includes an unavailable or incomplete shard")
+        if (
+            item.get("manifest_sha256") != registry.get("manifest_sha256")
+            or item.get("policy_sha256") != registry.get("policy_sha256")
+        ):
+            raise ValueError(f"{label}: producer aggregate shard Registry policy binding does not match")
+    matches = [
+        as_dict(item, f"{label}.producer_aggregate.shards[]")
+        for item in shards
+        if isinstance(item, dict) and item.get("index") == execution.get("shard_index")
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"{label}: producer aggregate must contain exactly one matching shard")
+    shard = matches[0]
+    expected = {
+        "receipt_path": producer.get("receipt_path"),
+        "receipt_sha256": producer.get("receipt_sha256"),
+        "shard_digest": execution.get("shard_digest"),
+        "scope": scope,
+        "terminal_state": execution.get("terminal_state"),
+    }
+    for key, expected_value in expected.items():
+        if shard.get(key) != expected_value:
+            raise ValueError(f"{label}: producer aggregate shard mapping does not match outer admission envelope")
+    if shard.get("receipt_available") is not True or shard.get("completed") is not True:
+        raise ValueError(f"{label}: producer aggregate shard is not an available completed receipt")
+    aggregate_redaction = as_dict(aggregate.get("redaction"), f"{label}.producer_aggregate.redaction")
+    if shard.get("redaction") != aggregate_redaction or not all(value is True for value in aggregate_redaction.values()):
+        raise ValueError(f"{label}: producer aggregate redaction assertions do not prove a fully redacted shard")
+    if redaction.get("secret_values_present") is not False or redaction.get("secret_hashes_present") is not False or redaction.get("request_urls_present") is not False or redaction.get("response_bodies_present") is not False:
+        raise ValueError(f"{label}: outer redaction mapping is not safe")
+
+
+def validate_receipt(receipt: dict[str, Any], *, schema: dict[str, Any], policy: dict[str, Any], policy_path: pathlib.Path, manifest_path: pathlib.Path, manifest_sha256: str, source_sha256: str, artifact_roots: dict[str, pathlib.Path], admitted_at: datetime, label: str) -> None:
+    validate_schema(receipt, schema, label)
+    scan_redaction(receipt, policy, label)
+    if receipt.get("receipt_digest") != canonical_digest(receipt):
+        raise ValueError(f"{label}: receipt_digest does not match canonical receipt bytes")
+    producer_contracts = as_dict(policy.get("producer_contracts"), "policy.producer_contracts")
+    kind = receipt.get("receipt_kind")
+    contract = as_dict(producer_contracts.get(kind), f"policy.producer_contracts.{kind}")
+    producer = as_dict(receipt.get("producer"), f"{label}.producer")
+    if producer.get("repository") != contract.get("repository"):
+        raise ValueError(f"{label}: producer.repository is not authorized for {kind}")
+    scope = as_dict(receipt.get("scope"), f"{label}.scope")
+    if scope.get("subject") != contract.get("subject"):
+        raise ValueError(f"{label}: scope.subject is not authorized for {kind}")
+    if "provider" in contract and scope.get("provider") != contract.get("provider"):
+        raise ValueError(f"{label}: scope.provider is not authorized for {kind}")
+    if receipt.get("outcome") not in as_list(contract.get("outcomes"), f"policy.producer_contracts.{kind}.outcomes"):
+        raise ValueError(f"{label}: outcome is not valid for {kind}")
+    generated_at = parse_time(receipt.get("generated_at"), f"{label}.generated_at")
+    if generated_at > admitted_at:
+        raise ValueError(f"{label}: generated_at is in the future of admission time")
+    max_age_seconds = contract.get("max_age_seconds")
+    if not isinstance(max_age_seconds, int) or max_age_seconds <= 0:
+        raise ValueError(f"policy.producer_contracts.{kind}.max_age_seconds must be a positive integer")
+    if (admitted_at - generated_at).total_seconds() > max_age_seconds:
+        raise ValueError(f"{label}: receipt is stale at admission time")
+    artifact_path = producer_artifact_path(producer, artifact_roots, "receipt_path", label)
+    if producer.get("receipt_sha256") != file_digest(artifact_path):
+        raise ValueError(f"{label}: producer receipt digest does not match artifact bytes")
+    registry = as_dict(receipt.get("registry"), f"{label}.registry")
+    if registry.get("manifest_path") != manifest_path.as_posix() or registry.get("manifest_sha256") != manifest_sha256:
+        raise ValueError(f"{label}: registry manifest binding does not match the admitted manifest")
+    manifest = load_json(manifest_path)
+    if registry.get("source_path") != manifest.get("source_registry"):
+        raise ValueError(f"{label}: registry source path does not match the admitted manifest")
+    if registry.get("source_sha256") != source_sha256:
+        raise ValueError(f"{label}: registry source digest does not match the admitted manifest source")
+    if registry.get("policy_path") != policy_path.as_posix() or registry.get("policy_sha256") != file_digest(policy_path):
+        raise ValueError(f"{label}: registry admission policy binding does not match")
+    if kind == RUNTIME_KIND:
+        execution = as_dict(receipt.get("execution"), f"{label}.execution")
+        for field, policy_field in (("shard_count", "shard_count"), ("batch_size", "batch_size_max"), ("max_parallelism", "max_parallelism_max"), ("per_operation_timeout_seconds", "per_operation_timeout_seconds_max")):
+            if field == "shard_count":
+                if execution.get(field) != contract.get(policy_field):
+                    raise ValueError(f"{label}: execution.{field} must match policy")
+            elif not isinstance(execution.get(field), int) or execution[field] > contract.get(policy_field):
+                raise ValueError(f"{label}: execution.{field} exceeds policy")
+        if execution.get("terminal_state") != receipt.get("outcome"):
+            raise ValueError(f"{label}: execution.terminal_state must equal outcome")
+        validate_health_aggregate(
+            producer,
+            execution,
+            scope,
+            registry,
+            as_dict(receipt.get("redaction"), f"{label}.redaction"),
+            artifact_roots,
+            label,
+        )
+
+
+def validate_runtime_completeness(receipts: list[dict[str, Any]]) -> str:
+    runtime = [receipt for receipt in receipts if receipt.get("receipt_kind") == RUNTIME_KIND]
+    if len(runtime) != 8:
+        raise ValueError(f"runtime completeness requires exactly 8 shard receipts, got {len(runtime)}")
+    run_ids = {as_dict(receipt["execution"], "runtime.execution").get("run_id") for receipt in runtime}
+    if len(run_ids) != 1:
+        raise ValueError("runtime completeness requires one shared run_id")
+    repositories = {as_dict(receipt["producer"], "runtime.producer").get("repository") for receipt in runtime}
+    revisions = {as_dict(receipt["producer"], "runtime.producer").get("revision") for receipt in runtime}
+    registry_bindings = {
+        json.dumps(as_dict(receipt["registry"], "runtime.registry"), sort_keys=True, separators=(",", ":"))
+        for receipt in runtime
+    }
+    scopes = {
+        json.dumps(as_dict(receipt["scope"], "runtime.scope"), sort_keys=True, separators=(",", ":"))
+        for receipt in runtime
+    }
+    if len(repositories) != 1 or len(revisions) != 1:
+        raise ValueError("runtime completeness requires one producer repository and revision")
+    if len(registry_bindings) != 1:
+        raise ValueError("runtime completeness requires one Registry manifest/source binding")
+    if len(scopes) != 1:
+        raise ValueError("runtime completeness requires one runtime scope")
+    indices = [as_dict(receipt["execution"], "runtime.execution").get("shard_index") for receipt in runtime]
+    if sorted(indices) != list(range(8)):
+        raise ValueError("runtime completeness requires shard indexes 0 through 7 exactly once")
+    digests = [as_dict(receipt["execution"], "runtime.execution").get("shard_digest") for receipt in runtime]
+    if len(set(digests)) != 8:
+        raise ValueError("runtime completeness requires unique shard_digest values")
+    return str(next(iter(run_ids)))

--- a/scripts/validate-release-admission-receipts.py
+++ b/scripts/validate-release-admission-receipts.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Validate Registry-native immutable receipt admission without consumer execution."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+import release_admission_receipts as admission
+
+
+def producer_artifact_roots(values: list[str]) -> dict[str, pathlib.Path]:
+    roots: dict[str, pathlib.Path] = {}
+    for value in values:
+        repository, separator, raw_path = value.partition("=")
+        if not separator or not repository or not raw_path or repository in roots:
+            raise ValueError("--producer-artifact-root must be unique StatPan/repository=path")
+        roots[repository] = pathlib.Path(raw_path)
+    return roots
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("receipts", nargs="+", type=pathlib.Path)
+    parser.add_argument("--schema", default="schemas/datapan.release-receipt-admission.v1.schema.json", type=pathlib.Path)
+    parser.add_argument("--policy", default="policy/release-receipt-admission.json", type=pathlib.Path)
+    parser.add_argument("--manifest", default="manifest.json", type=pathlib.Path)
+    parser.add_argument("--check-manifest-artifacts", action="store_true")
+    parser.add_argument("--require-runtime-completeness", action="store_true")
+    parser.add_argument("--producer-artifact-root", action="append", default=[], metavar="REPOSITORY=PATH")
+    parser.add_argument("--admission-time", default=datetime.now(timezone.utc).isoformat(), help="RFC3339 admission time; defaults to current UTC time")
+    args = parser.parse_args()
+    try:
+        schema = admission.load_json(args.schema)
+        policy = admission.load_json(args.policy)
+        manifest, manifest_sha256, source_sha256 = admission.validate_manifest(args.manifest, check_artifacts=args.check_manifest_artifacts)
+        del manifest
+        admitted_at = admission.parse_time(args.admission_time, "--admission-time")
+        artifact_roots = producer_artifact_roots(args.producer_artifact_root)
+        receipts = [admission.load_json(path) for path in args.receipts]
+        for path, receipt in zip(args.receipts, receipts, strict=True):
+            admission.validate_receipt(receipt, schema=schema, policy=policy, policy_path=args.policy, manifest_path=args.manifest, manifest_sha256=manifest_sha256, source_sha256=source_sha256, artifact_roots=artifact_roots, admitted_at=admitted_at, label=path.as_posix())
+        run_id = admission.validate_runtime_completeness(receipts) if args.require_runtime_completeness else "not_required"
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL release receipt admission: {exc}", file=sys.stderr)
+        return 1
+    print(f"ok release receipt admission (receipts={len(receipts)}, runtime_run_id={run_id})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/release-admission/catalog-observation.json
+++ b/tests/fixtures/release-admission/catalog-observation.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "datapan.release-receipt-admission.v1",
+  "generated_at": "2026-07-22T00:00:00Z",
+  "receipt_kind": "catalog_observation",
+  "producer": {"repository": "StatPan/datapan-data", "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "receipt_path": "receipts/catalog-observation.json", "receipt_sha256": "25d7ed511fe3cf6671851573070e77b9b9bc7e2ab1d5b48ebbc434c4738ba848"},
+  "registry": {"manifest_path": "tests/fixtures/release-admission/manifest.json", "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "source_path": "data/registry.json", "source_sha256": "97c8d6f5771e426b0782c19107d2007637eb7ee452cabb48b1c5d1627a71c8f7", "policy_path": "policy/release-receipt-admission.json", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+  "outcome": "no_change",
+  "scope": {"provider": "data.go.kr", "subject": "upstream_catalog"},
+  "redaction": {"secret_values_present": false, "secret_hashes_present": false, "request_urls_present": false, "response_bodies_present": false, "forbidden_fields_checked": ["credential_value", "credential_hash", "authorization_header", "service_key", "api_key"]},
+  "receipt_digest": "c6444f0beb153601f9d07e40ea07421f88bce101d5f018004a083b280aa6fafd"
+}

--- a/tests/fixtures/release-admission/cli-consumer-smoke.json
+++ b/tests/fixtures/release-admission/cli-consumer-smoke.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "datapan.release-receipt-admission.v1",
+  "generated_at": "2026-07-22T00:00:00Z",
+  "receipt_kind": "cli_consumer_smoke",
+  "producer": {"repository": "StatPan/datapan-cli", "revision": "cccccccccccccccccccccccccccccccccccccccc", "receipt_path": "receipts/cli-consumer-smoke.json", "receipt_sha256": "7480e7bb6a897dab6885afb77d47226acb85e91f1cefef70c22d3f296e577c49"},
+  "registry": {"manifest_path": "tests/fixtures/release-admission/manifest.json", "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "source_path": "data/registry.json", "source_sha256": "97c8d6f5771e426b0782c19107d2007637eb7ee452cabb48b1c5d1627a71c8f7", "policy_path": "policy/release-receipt-admission.json", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+  "outcome": "verified",
+  "scope": {"provider": "data.go.kr", "subject": "published_registry_consumer_smoke"},
+  "redaction": {"secret_values_present": false, "secret_hashes_present": false, "request_urls_present": false, "response_bodies_present": false, "forbidden_fields_checked": ["credential_value", "credential_hash", "authorization_header", "service_key", "api_key"]},
+  "receipt_digest": "8adc6c450cd9b30e4fe4304d6f142d508c31eb1e50d4693e5f33f0becb3499a8"
+}

--- a/tests/fixtures/release-admission/data/registry.json
+++ b/tests/fixtures/release-admission/data/registry.json
@@ -1,0 +1,1 @@
+{"registry":"fixture"}

--- a/tests/fixtures/release-admission/manifest.json
+++ b/tests/fixtures/release-admission/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "datapan.release-manifest.v1",
+  "generated_at": "2026-07-22T00:00:00Z",
+  "datapan_version": "0.1.0-test",
+  "provider": "data.go.kr",
+  "source_registry": "data/registry.json",
+  "artifact_count": 1,
+  "artifacts": [
+    {"path": "data/registry.json", "sha256": "97c8d6f5771e426b0782c19107d2007637eb7ee452cabb48b1c5d1627a71c8f7"}
+  ]
+}

--- a/tests/fixtures/release-admission/producer-artifacts/datapan-cli/receipts/cli-consumer-smoke.json
+++ b/tests/fixtures/release-admission/producer-artifacts/datapan-cli/receipts/cli-consumer-smoke.json
@@ -1,0 +1,1 @@
+{"producer_fixture":"cli_consumer_smoke"}

--- a/tests/fixtures/release-admission/producer-artifacts/datapan-data/receipts/catalog-observation.json
+++ b/tests/fixtures/release-admission/producer-artifacts/datapan-data/receipts/catalog-observation.json
@@ -1,0 +1,1 @@
+{"producer_fixture":"catalog_observation"}

--- a/tests/fixtures/release-admission/producer-artifacts/datapan-health/receipts/runtime-freshness-shard-0.json
+++ b/tests/fixtures/release-admission/producer-artifacts/datapan-health/receipts/runtime-freshness-shard-0.json
@@ -1,0 +1,1 @@
+{"producer_fixture":"runtime_freshness_shard"}

--- a/tests/fixtures/release-admission/producer-artifacts/datapan-health/runs/fixture-run-42.json
+++ b/tests/fixtures/release-admission/producer-artifacts/datapan-health/runs/fixture-run-42.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "datapan.health-bounded-observation-run.v1",
+  "producer": {"repository": "StatPan/datapan-health", "revision": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+  "registry": {"manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "source_sha256": "97c8d6f5771e426b0782c19107d2007637eb7ee452cabb48b1c5d1627a71c8f7", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+  "run": {"run_id": "fixture-run-42", "shard_count": 8, "batch_size": 100, "max_parallel": 2, "timeout_ms": 20000},
+  "shards": [
+    {"index": 0, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c", "receipt_path": "receipts/runtime-freshness-shard-0.json", "receipt_sha256": "cc85419e2072f5866c9c4f25c4d82e96abfeedb1b1f4ea1260a671d477004eab", "shard_digest": "0000000000000000000000000000000000000000000000000000000000000001", "scope": {"provider": "data_go_kr", "subject": "runtime_freshness_rotating_shard"}, "terminal_state": "verified", "redaction": {"secret_values_removed": true, "secret_hashes_removed": true, "authorization_headers_removed": true, "credential_bearing_urls_removed": true, "raw_provider_text_removed": true, "raw_provider_urls_removed": true, "response_bodies_removed": true, "response_rows_removed": true, "user_identity_removed": true}},
+    {"index": 1, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 2, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 3, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 4, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 5, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 6, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+    {"index": 7, "receipt_available": true, "completed": true, "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"}
+  ],
+  "aggregate": {"terminal_state": "verified", "completeness": "complete", "timed_out": false},
+  "redaction": {"secret_values_removed": true, "secret_hashes_removed": true, "authorization_headers_removed": true, "credential_bearing_urls_removed": true, "raw_provider_text_removed": true, "raw_provider_urls_removed": true, "response_bodies_removed": true, "response_rows_removed": true, "user_identity_removed": true}
+}

--- a/tests/fixtures/release-admission/runtime-freshness-shard-0.json
+++ b/tests/fixtures/release-admission/runtime-freshness-shard-0.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "datapan.release-receipt-admission.v1",
+  "generated_at": "2026-07-22T00:00:00Z",
+  "receipt_kind": "runtime_freshness_shard",
+  "producer": {"repository": "StatPan/datapan-health", "revision": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "receipt_path": "receipts/runtime-freshness-shard-0.json", "receipt_sha256": "cc85419e2072f5866c9c4f25c4d82e96abfeedb1b1f4ea1260a671d477004eab", "aggregate_path": "runs/fixture-run-42.json", "aggregate_sha256": "b1d3c006fef0fde0c7ccbf2b47b9bbe6ff9b58c74b19c8b33c35ebfe912fb486"},
+  "registry": {"manifest_path": "tests/fixtures/release-admission/manifest.json", "manifest_sha256": "3fe8191ae44e11fef8aa27f931fa2d86687a74f868f1615b4dae187a1c1a51c9", "source_path": "data/registry.json", "source_sha256": "97c8d6f5771e426b0782c19107d2007637eb7ee452cabb48b1c5d1627a71c8f7", "policy_path": "policy/release-receipt-admission.json", "policy_sha256": "1fa2600c4aa6cf09ca123dfc8a9381d5cffc4c57aa0a0ce50adb3b7bd80bc00c"},
+  "outcome": "verified",
+  "scope": {"provider": "data_go_kr", "subject": "runtime_freshness_rotating_shard"},
+  "execution": {"run_id": "fixture-run-42", "shard_count": 8, "shard_index": 0, "shard_digest": "0000000000000000000000000000000000000000000000000000000000000001", "batch_size": 100, "max_parallelism": 2, "per_operation_timeout_seconds": 20, "terminal_state": "verified"},
+  "redaction": {"secret_values_present": false, "secret_hashes_present": false, "request_urls_present": false, "response_bodies_present": false, "forbidden_fields_checked": ["credential_value", "credential_hash", "authorization_header", "service_key", "api_key"]},
+  "receipt_digest": "97d3b276a7a52b3f73834a719ed6469cd0c6530be312136a5ce63f3a8fb5d666"
+}

--- a/tests/test_release_admission_receipts.py
+++ b/tests/test_release_admission_receipts.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+import release_admission_receipts as admission  # noqa: E402
+
+
+class ReleaseAdmissionReceiptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        (self.root / "data").mkdir()
+        (self.root / "data" / "registry.json").write_text('{"registry":true}\n', encoding="utf-8")
+        artifact = self.root / "data" / "registry.json"
+        manifest = {
+            "schema_version": "datapan.release-manifest.v1",
+            "generated_at": "2026-07-22T00:00:00Z",
+            "datapan_version": "0.1.0-test",
+            "provider": "data.go.kr",
+            "source_registry": "data/registry.json",
+            "artifact_count": 1,
+            "artifacts": [{"path": "data/registry.json", "sha256": admission.file_digest(artifact)}],
+        }
+        self.manifest_path = self.root / "manifest.json"
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        self.schema = admission.load_json(ROOT / "schemas/datapan.release-receipt-admission.v1.schema.json")
+        self.policy = admission.load_json(ROOT / "policy/release-receipt-admission.json")
+        self.policy_path = ROOT / "policy/release-receipt-admission.json"
+        _, self.manifest_digest, self.source_digest = admission.validate_manifest(self.manifest_path, check_artifacts=True)
+        self.artifact_roots: dict[str, pathlib.Path] = {}
+        for kind, contract in self.policy["producer_contracts"].items():
+            root = self.root / "producer-artifacts" / kind
+            receipt_path = root / "receipts" / f"{kind}.json"
+            receipt_path.parent.mkdir(parents=True, exist_ok=True)
+            receipt_path.write_text(json.dumps({"producer_fixture": kind}) + "\n", encoding="utf-8")
+            self.artifact_roots[contract["repository"]] = root
+        self.aggregate_path = self.artifact_roots["StatPan/datapan-health"] / "runs" / "fixture-run-42.json"
+        self.aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def receipt(self, kind: str, *, shard: int | None = None) -> dict:
+        contract = self.policy["producer_contracts"][kind]
+        value = {
+            "schema_version": admission.SCHEMA_VERSION,
+            "generated_at": "2026-07-22T00:00:00Z",
+            "receipt_kind": kind,
+            "producer": {"repository": contract["repository"], "revision": "a" * 40, "receipt_path": f"receipts/{kind}.json", "receipt_sha256": admission.file_digest(self.artifact_roots[contract["repository"]] / "receipts" / f"{kind}.json")},
+            "registry": {"manifest_path": self.manifest_path.as_posix(), "manifest_sha256": self.manifest_digest, "source_path": "data/registry.json", "source_sha256": self.source_digest, "policy_path": self.policy_path.as_posix(), "policy_sha256": admission.file_digest(self.policy_path)},
+            "outcome": contract["outcomes"][0],
+            "scope": {"provider": contract.get("provider", "data.go.kr"), "subject": contract["subject"]},
+            "redaction": {"secret_values_present": False, "secret_hashes_present": False, "request_urls_present": False, "response_bodies_present": False, "forbidden_fields_checked": ["credential_value", "credential_hash", "authorization_header", "service_key", "api_key"]},
+        }
+        if kind == admission.RUNTIME_KIND:
+            value["outcome"] = "verified"
+            value["execution"] = {"run_id": "run-42", "shard_count": 8, "shard_index": shard, "shard_digest": f"{shard:064x}", "batch_size": 100, "max_parallelism": 2, "per_operation_timeout_seconds": 20, "terminal_state": "verified"}
+            value["producer"]["aggregate_path"] = "runs/fixture-run-42.json"
+            value["producer"]["aggregate_sha256"] = "0" * 64
+            source_redaction = {"secret_values_removed": True, "secret_hashes_removed": True, "authorization_headers_removed": True, "credential_bearing_urls_removed": True, "raw_provider_text_removed": True, "raw_provider_urls_removed": True, "response_bodies_removed": True, "response_rows_removed": True, "user_identity_removed": True}
+            aggregate_shards = [
+                {
+                    "index": index,
+                    "receipt_available": True,
+                    "completed": True,
+                    "manifest_sha256": value["registry"]["manifest_sha256"],
+                    "policy_sha256": value["registry"]["policy_sha256"],
+                }
+                for index in range(8)
+            ]
+            aggregate_shards[shard].update({"receipt_path": value["producer"]["receipt_path"], "receipt_sha256": value["producer"]["receipt_sha256"], "shard_digest": value["execution"]["shard_digest"], "scope": value["scope"], "terminal_state": "verified", "redaction": source_redaction})
+            aggregate = {"schema_version": "datapan.health-bounded-observation-run.v1", "producer": {"repository": "StatPan/datapan-health", "revision": "a" * 40}, "registry": {"manifest_sha256": value["registry"]["manifest_sha256"], "source_sha256": value["registry"]["source_sha256"], "policy_sha256": value["registry"]["policy_sha256"]}, "run": {"run_id": "run-42", "shard_count": 8, "batch_size": 100, "max_parallel": 2, "timeout_ms": 20000}, "shards": aggregate_shards, "aggregate": {"terminal_state": "verified", "completeness": "complete", "timed_out": False}, "redaction": source_redaction}
+            self.aggregate_path.write_text(json.dumps(aggregate), encoding="utf-8")
+            value["producer"]["aggregate_sha256"] = admission.file_digest(self.aggregate_path)
+        value["receipt_digest"] = admission.canonical_digest(value)
+        return value
+
+    def validate(self, receipt: dict) -> None:
+        admission.validate_receipt(receipt, schema=self.schema, policy=self.policy, policy_path=self.policy_path, manifest_path=self.manifest_path, manifest_sha256=self.manifest_digest, source_sha256=self.source_digest, artifact_roots=self.artifact_roots, admitted_at=admission.parse_time("2026-07-22T01:00:00Z", "test admission time"), label="fixture")
+
+    def test_all_producer_kinds_are_admitted_with_immutable_bindings(self) -> None:
+        for kind in self.policy["producer_contracts"]:
+            self.validate(self.receipt(kind, shard=0 if kind == admission.RUNTIME_KIND else None))
+
+    def test_secret_bearing_receipt_is_rejected(self) -> None:
+        receipt = self.receipt("catalog_observation")
+        receipt["scope"]["provider"] = "data.go.kr Bearer abcdefghijklmnopqrstuvwxyz"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "secret"):
+            self.validate(receipt)
+
+    def test_unsafe_url_raw_body_and_identity_are_rejected_without_echo(self) -> None:
+        cases = [
+            ("scope.provider", "https://provider.example/?serviceKey=super-secret-token"),
+            ("scope.subject", "operator@example.com"),
+            ("response_body", "super-secret-response-body"),
+        ]
+        for field, value in cases:
+            with self.subTest(field=field):
+                receipt = self.receipt("catalog_observation")
+                if field.startswith("scope."):
+                    receipt["scope"][field.split(".")[1]] = value
+                else:
+                    receipt[field] = value
+                receipt["receipt_digest"] = admission.canonical_digest(receipt)
+                with self.assertRaises(ValueError) as caught:
+                    self.validate(receipt)
+                self.assertNotIn(value, str(caught.exception))
+
+    def test_canonical_digest_excludes_its_own_field_but_detects_payload_tampering(self) -> None:
+        receipt = self.receipt("catalog_observation")
+        digest = receipt["receipt_digest"]
+        self.assertEqual(digest, admission.canonical_digest(receipt))
+        receipt["outcome"] = "material_change"
+        with self.assertRaisesRegex(ValueError, "receipt_digest"):
+            self.validate(receipt)
+
+    def test_stale_and_future_receipts_fail_at_the_explicit_admission_time(self) -> None:
+        for generated_at, reason in (("2026-07-20T00:00:00Z", "stale"), ("2026-07-23T00:00:00Z", "future")):
+            with self.subTest(generated_at=generated_at):
+                receipt = self.receipt("catalog_observation")
+                receipt["generated_at"] = generated_at
+                receipt["receipt_digest"] = admission.canonical_digest(receipt)
+                with self.assertRaisesRegex(ValueError, reason):
+                    self.validate(receipt)
+
+    def test_malformed_timestamp_fails_schema_format_validation(self) -> None:
+        receipt = self.receipt("catalog_observation")
+        receipt["generated_at"] = "not-a-time"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "schema validation format"):
+            self.validate(receipt)
+
+    def test_manifest_paths_reject_traversal_and_symlink_escape(self) -> None:
+        outside = self.root.parent / "outside-registry.json"
+        outside.write_text('{"outside":true}\n', encoding="utf-8")
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest["source_registry"] = "../outside-registry.json"
+        manifest["artifacts"] = [{"path": "../outside-registry.json", "sha256": admission.file_digest(outside)}]
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "escapes"):
+            admission.validate_manifest(self.manifest_path, check_artifacts=True)
+        manifest["source_registry"] = "data/registry.json"
+        manifest["artifacts"] = [{"path": "data/registry.json", "sha256": admission.file_digest(self.root / "data" / "registry.json")}]
+        link = self.root / "data" / "escaped-link.json"
+        link.symlink_to(outside)
+        manifest["source_registry"] = "data/escaped-link.json"
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "escapes"):
+            admission.validate_manifest(self.manifest_path, check_artifacts=False)
+
+    def test_producer_receipt_digest_and_path_are_verified_against_artifact_root(self) -> None:
+        receipt = self.receipt("catalog_observation")
+        receipt["producer"]["receipt_sha256"] = "0" * 64
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "producer receipt digest"):
+            self.validate(receipt)
+        receipt = self.receipt("catalog_observation")
+        receipt["producer"]["receipt_path"] = "../outside.json"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "escapes"):
+            self.validate(receipt)
+
+    def test_manifest_digest_mismatch_is_rejected(self) -> None:
+        receipt = self.receipt("cli_consumer_smoke")
+        receipt["registry"]["manifest_sha256"] = "0" * 64
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "manifest binding"):
+            self.validate(receipt)
+
+    def test_source_path_mismatch_is_rejected(self) -> None:
+        receipt = self.receipt("catalog_observation")
+        receipt["registry"]["source_path"] = "data/other-registry.json"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "source path"):
+            self.validate(receipt)
+
+    def test_runtime_receipts_require_all_eight_unique_shards(self) -> None:
+        receipts = [self.receipt(admission.RUNTIME_KIND, shard=index) for index in range(8)]
+        self.assertEqual(admission.validate_runtime_completeness(receipts), "run-42")
+        with self.assertRaisesRegex(ValueError, "indexes"):
+            admission.validate_runtime_completeness(receipts[:-1] + [self.receipt(admission.RUNTIME_KIND, shard=6)])
+        receipts = [self.receipt(admission.RUNTIME_KIND, shard=index) for index in range(8)]
+        receipts[-1]["producer"]["revision"] = "c" * 40
+        with self.assertRaisesRegex(ValueError, "producer repository and revision"):
+            admission.validate_runtime_completeness(receipts)
+        receipts = [self.receipt(admission.RUNTIME_KIND, shard=index) for index in range(8)]
+        receipts[-1]["registry"]["source_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "Registry manifest/source binding"):
+            admission.validate_runtime_completeness(receipts)
+        receipts = [self.receipt(admission.RUNTIME_KIND, shard=index) for index in range(8)]
+        receipts[-1]["scope"]["provider"] = "other-provider"
+        with self.assertRaisesRegex(ValueError, "runtime scope"):
+            admission.validate_runtime_completeness(receipts)
+
+    def test_partial_or_byte_drifted_health_aggregate_cannot_admit_an_outer_shard(self) -> None:
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        aggregate = json.loads(self.aggregate_path.read_text(encoding="utf-8"))
+        aggregate["shards"][3]["receipt_available"] = False
+        self.aggregate_path.write_text(json.dumps(aggregate), encoding="utf-8")
+        receipt["producer"]["aggregate_sha256"] = admission.file_digest(self.aggregate_path)
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "unavailable or incomplete"):
+            self.validate(receipt)
+
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        receipt["producer"]["aggregate_sha256"] = "0" * 64
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "aggregate digest"):
+            self.validate(receipt)
+
+    def test_health_canary_is_not_a_runtime_freshness_scope(self) -> None:
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        receipt["scope"]["subject"] = "health_probe_canary"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "scope.subject"):
+            self.validate(receipt)
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        receipt["scope"]["provider"] = "data.go.kr"
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "scope.provider"):
+            self.validate(receipt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #590

## Scope

Adds the Registry-native, offline immutable receipt-admission foundation only. It does not change workflows, remove consumer checkouts, execute Datapan CLI, publish a Registry artifact, or make provider calls.

## Admission evidence

- `receipt_digest` is SHA-256 over canonical outer-envelope JSON with that field omitted; `producer.receipt_sha256` separately verifies the actual producer receipt file bytes.
- Every producer path is resolved under an explicitly supplied repository artifact root; traversal and symlink escapes are rejected. Registry manifest/source artifacts receive the same containment and byte checks.
- Each envelope binds immutable producer revision, Registry manifest/source/policy bytes, a deterministic admission time, and a per-kind maximum age; stale and future receipts fail closed.
- Health runtime admission maps the actual `datapan.health-bounded-observation-run.v1` aggregate to one outer shard envelope, byte-checks the aggregate and selected shard files, and requires all eight available/completed shard mappings, one producer revision, one Registry binding, and one scope. A partial aggregate cannot synthesize a receipt. Health canaries remain excluded.
- Schema, recursive redaction checks, and negative tests reject unsafe keys, URLs, raw bodies, identities, secret-bearing values, malformed timestamps, and byte drift without echoing sensitive values in diagnostics.

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"` — 197 passed.
- Schema/manifest/provenance/goal-ledger generated-artifact checks all passed.
- `python3 scripts/validate-external-checkout-refs.py --check` remains green with 9 `StatPan/datapan-cli` checkouts pinned to `e3b2fa44cb0f68d7e58e003fbd71ecde505878de`.

Final checkout removal and workflow cutover remain blocked on later producer, workflow, rollback, and acceptance evidence.