### PR TITLE
feat: Publish a manifest-bound eight-shard Health observation plan

### DIFF
--- a/docs/health-runtime-observation-plan.md
+++ b/docs/health-runtime-observation-plan.md
@@ -2,6 +2,9 @@
 
 `reports/health-runtime-observation-plan.v1.json` is static Registry policy, not
 a command or a live receipt. It contains exactly eight immutable memberships.
+Its manifest kind is the existing `verification_plan`, preserving the current
+release-manifest v1 consumer contract; the plan's distinct schema URI carries
+its Health-specific identity.
 The plan's `manifest_binding.sha256` is SHA-256 of canonical UTF-8 JSON with
 sorted keys and compact separators after removing only `bytes` and `sha256`
 from its own manifest artifact entry. Its path, kind, schema, and every other

--- a/docs/health-runtime-observation-plan.md
+++ b/docs/health-runtime-observation-plan.md
@@ -1,0 +1,14 @@
+# Health runtime observation plan
+
+`reports/health-runtime-observation-plan.v1.json` is static Registry policy, not
+a command or a live receipt. It contains exactly eight immutable memberships.
+The plan's `manifest_binding.sha256` is SHA-256 of canonical UTF-8 JSON with
+sorted keys and compact separators after removing only `bytes` and `sha256`
+from its own manifest artifact entry. Its path, kind, schema, and every other
+manifest entry remain covered. The full `manifest.json` separately binds the
+exact plan bytes and SHA-256. This breaks the unavoidable self-reference while
+remaining fail-closed on any other manifest or plan-entry change.
+
+Health verifies the plan bytes/SHA and binding before execution; it owns all
+credentials, execution, retention, and live status. No plan member includes a
+credential value, query value, full URL, command, response, or live result.

--- a/docs/release-ledger-goal-completion-audit.json
+++ b/docs/release-ledger-goal-completion-audit.json
@@ -153,9 +153,9 @@
     },
     "release_distribution_footprint": {
       "path": "reports/release-distribution-footprint.json",
-      "artifact_count": 161,
-      "schema_artifacts": 88,
-      "manifest_bound_bytes_excluding_self": 173957232,
+      "artifact_count": 163,
+      "schema_artifacts": 89,
+      "manifest_bound_bytes_excluding_self": 173972648,
       "canonical_registry_path": "data/data-go-kr.registry.json",
       "canonical_registry_bytes": 137735169,
       "large_monolith_threshold_bytes": 100000000,

--- a/docs/release-ledger-goal-completion-audit.json
+++ b/docs/release-ledger-goal-completion-audit.json
@@ -16,11 +16,11 @@
   "current_state_evidence": {
     "manifest": {
       "path": "manifest.json",
-      "artifact_count": 161
+      "artifact_count": 163
     },
     "schema_index": {
       "path": "schemas/index.json",
-      "schema_count": 88
+      "schema_count": 89
     },
     "release_readiness": {
       "path": "reports/latest-release-readiness.json",

--- a/fixtures/source-provenance/regional-baseline-v0-pin.json
+++ b/fixtures/source-provenance/regional-baseline-v0-pin.json
@@ -4,7 +4,7 @@
   "registry_tag": "issue-559-unreleased-fixture",
   "registry_manifest": {
     "path": "manifest.json",
-    "sha256": "c42f9f8fa56e31459524ac5684e8b0de05c59102822d0f1289ffe7235eca2217"
+    "sha256": "79e57a49f3678cd6e29103e97fee2102a880290580e95386c45e5fdded7cf974"
   },
   "provenance_artifact": {
     "path": "reports/regional-baseline-source-provenance.json",

--- a/fixtures/source-provenance/regional-baseline-v0-pin.json
+++ b/fixtures/source-provenance/regional-baseline-v0-pin.json
@@ -4,7 +4,7 @@
   "registry_tag": "issue-559-unreleased-fixture",
   "registry_manifest": {
     "path": "manifest.json",
-    "sha256": "5213f6cc51b2f1bd51028f8cf72207fd5dcf480e75539bd46ad46ca46a3f5421"
+    "sha256": "bc19d5aaf95fcd6df04daa01c026c69862da2ec1c21a1b4e11c3fa7cdcf9947d"
   },
   "provenance_artifact": {
     "path": "reports/regional-baseline-source-provenance.json",

--- a/fixtures/source-provenance/regional-baseline-v0-pin.json
+++ b/fixtures/source-provenance/regional-baseline-v0-pin.json
@@ -4,7 +4,7 @@
   "registry_tag": "issue-559-unreleased-fixture",
   "registry_manifest": {
     "path": "manifest.json",
-    "sha256": "79e57a49f3678cd6e29103e97fee2102a880290580e95386c45e5fdded7cf974"
+    "sha256": "5213f6cc51b2f1bd51028f8cf72207fd5dcf480e75539bd46ad46ca46a3f5421"
   },
   "provenance_artifact": {
     "path": "reports/regional-baseline-source-provenance.json",

--- a/manifest.json
+++ b/manifest.json
@@ -623,7 +623,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 8075,
-      "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3"
+      "sha256": "ad6e71c55e3fbad3706d27b80a80fe60f5405e97250f851960e13a1d98c1ef53"
     },
     {
       "path": "reports/operation-denominator-rollup.json",
@@ -721,14 +721,14 @@
       "kind": "credential_runtime_manual_review_acceptance_packet",
       "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json",
       "bytes": 3988,
-      "sha256": "86718af67e5dc03812854a740b98229557a75460c7aadb8bf60050ae6f76f672"
+      "sha256": "3c802ef36ea36d17ceec842ce0e766560e2e70e4683138f31eac14a2189fa392"
     },
     {
       "path": "reports/registry-impact-plan.json",
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820"
+      "sha256": "eabc0ae558c5af7e4929fea2d0fe7803a0bb09ff30df84aeba0e63004805919f"
     },
     {
       "path": "reports/source-reference-drift.json",
@@ -742,7 +742,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7"
+      "sha256": "73021e4215675456026efe9fd4be66d619b7328a68c9c9a067dbde226e1bcb5b"
     },
     {
       "path": "reports/dependencies.json",
@@ -812,14 +812,14 @@
       "kind": "consumer_compatibility",
       "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json",
       "bytes": 26675,
-      "sha256": "9ea04b875d96ed773f2b5bc5d0579c789e32d35040c5a79dd2d5e03bb71a6d77"
+      "sha256": "95c02d59447c33c3d42a8efea1bc7be816daaf34dd230ee32d4dec0d7f621601"
     },
     {
       "path": "reports/release-distribution-footprint.json",
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2141,
-      "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d"
+      "sha256": "04cc3e08777dd34a9c528af4f494edb449e74ccfc5524cb29680d150d08d97ec"
     },
     {
       "path": "reports/release-shard-consumer-proof.json",
@@ -868,7 +868,7 @@
       "kind": "release_assembly_receipt",
       "schema": "https://schemas.datapan.dev/datapan.release-assembly-receipt.v1.schema.json",
       "bytes": 34969,
-      "sha256": "1a7d02246e9014148862ea6b1f6c7be3062042402802c359988cde7c1e4766ab"
+      "sha256": "9dd3fd3fe46f5616229d42d112ec77c06998f8e5338dc5f26eab9d59dc9e8925"
     },
     {
       "path": "reports/unadapted-external-probe.json",
@@ -1038,7 +1038,7 @@
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json",
       "bytes": 11290,
-      "sha256": "b5026c4c5b40e422d9543cc7e4be8ffae3d00dc9c5c707aeb1fd1e703ba509eb"
+      "sha256": "42d27d5c4d5c148914384bcbeb954f61b9a5390e10b7473fea724f826388639a"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1035,10 +1035,10 @@
     },
     {
       "path": "reports/health-runtime-observation-plan.v1.json",
-      "kind": "health_runtime_observation_plan",
+      "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json",
       "bytes": 11290,
-      "sha256": "4afcf82b973378b7c5778dc3b3acfecd16d52d93856d4fff6185eefc21f609fb"
+      "sha256": "b5026c4c5b40e422d9543cc7e4be8ffae3d00dc9c5c707aeb1fd1e703ba509eb"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "provider": "data.go.kr",
   "source_registry": "data/data-go-kr.registry.json",
   "output_dir": ".",
-  "artifact_count": 161,
+  "artifact_count": 163,
   "artifacts": [
     {
       "path": "schemas/datapan.adapter-targets.v1.schema.json",
@@ -532,15 +532,21 @@
     {
       "path": "schemas/datapan.release-receipt-admission.v1.schema.json",
       "kind": "schema",
-      "bytes": 4520,
-      "sha256": "0d9ea5cc7e94136a82579931b391e332df04e35b1ed1eb2de18ed0502c15a666"
+      "bytes": 4963,
+      "sha256": "a9f6d43d8893d71b6476407cf980ada8d8e031a19ccc82ec7d62eebd266dbe18"
+    },
+    {
+      "path": "schemas/datapan.health-runtime-observation-plan.v1.schema.json",
+      "kind": "schema",
+      "bytes": 3251,
+      "sha256": "aace55eb79feb701a6e5ee04d1ce6dc2a03b9f0a162e9ef9c10bed1f844a6abc"
     },
     {
       "path": "schemas/index.json",
       "kind": "schema_index",
       "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json",
-      "bytes": 35926,
-      "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a"
+      "bytes": 36358,
+      "sha256": "8c9193b87e0f367e31ba30244b619e2c607dd80d96478382b5b6608a2fbba737"
     },
     {
       "path": "data/data-go-kr.registry.json",
@@ -1026,6 +1032,13 @@
       "schema": "https://schemas.datapan.dev/datapan.diagnostic-publication-readiness.v1.schema.json",
       "bytes": 6331,
       "sha256": "43d58d995f0bd05ecd5785073922f9bf7e6655cfb9498501f625f35842d50ebf"
+    },
+    {
+      "path": "reports/health-runtime-observation-plan.v1.json",
+      "kind": "health_runtime_observation_plan",
+      "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json",
+      "bytes": 11290,
+      "sha256": "4afcf82b973378b7c5778dc3b3acfecd16d52d93856d4fff6185eefc21f609fb"
     }
   ]
 }

--- a/policy/health-runtime-observation-selection.json
+++ b/policy/health-runtime-observation-selection.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "datapan.health-runtime-observation-selection.v1",
+  "generated_at": "2026-07-23T00:00:00Z",
+  "authority": "datapan-registry",
+  "registry_revision": "4458003e1490e70d2efc538df93aeaa3addc90ef",
+  "selection_id": "data-go-kr-gateway-eight-shard-v1",
+  "members": [
+    {"operation_id":"hrop-00000001","dataset_id":"15000480","operation_name":"명절 비상진료기관 FullData 내려받기목록정보 조회"},
+    {"operation_id":"hrop-00000002","dataset_id":"15000576","operation_name":"약국 FullData 내려받기"},
+    {"operation_id":"hrop-00000003","dataset_id":"15000652","operation_name":"자동제세동기 FullData 내려받기"},
+    {"operation_id":"hrop-00000004","dataset_id":"15000736","operation_name":"병/의원 FullData 내려받기"},
+    {"operation_id":"hrop-00000005","dataset_id":"15000863","operation_name":"문화시설 식당 상세 정보를 조회"},
+    {"operation_id":"hrop-00000006","dataset_id":"15000897","operation_name":"선거코드"},
+    {"operation_id":"hrop-00000007","dataset_id":"15001697","operation_name":"의료기관종별코드조회"},
+    {"operation_id":"hrop-00000008","dataset_id":"15001839","operation_name":"민간 자원별 제공서비스 정보 조회"}
+  ],
+  "execution": {"request_budget":1,"timeout_ceiling_ms":10000,"safe_parameters":[{"name":"pageNo","strategy":"bounded_integer","minimum":1,"maximum":1},{"name":"numOfRows","strategy":"bounded_integer","minimum":1,"maximum":1}]}
+}

--- a/reports/credential-runtime-manual-review-acceptance-packet.json
+++ b/reports/credential-runtime-manual-review-acceptance-packet.json
@@ -30,7 +30,7 @@
     "handoff_path": "reports/credential-runtime-review-handoff.json",
     "handoff_sha256": "7d8e645a0f58469fabe3f9289e20ea6835c81e088dd363519d015d1d0f501beb",
     "compatibility_path": "reports/release-consumer-compatibility.json",
-    "compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a"
+    "compatibility_sha256": "00d6ef206b217903e5eff2aca7c008d0e1d29eed25cdc679bb4efac27bed1398"
   },
   "required_human_inputs": [
     {
@@ -61,7 +61,7 @@
     "reviewed_at": "<ISO-8601 UTC timestamp>",
     "reason": "<manual-review acceptance reason>",
     "handoff_sha256": "7d8e645a0f58469fabe3f9289e20ea6835c81e088dd363519d015d1d0f501beb",
-    "compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a",
+    "compatibility_sha256": "00d6ef206b217903e5eff2aca7c008d0e1d29eed25cdc679bb4efac27bed1398",
     "expires_at": "<ISO-8601 UTC timestamp>",
     "revalidation_triggers": [
       "credential_runtime_review_handoff_changed",

--- a/reports/credential-runtime-manual-review-technical-rebinding.json
+++ b/reports/credential-runtime-manual-review-technical-rebinding.json
@@ -1,10 +1,16 @@
 {
   "record_type": "datapan.manual-review-technical-rebinding.v1",
   "generated_at": "2026-07-23T00:00:00Z",
-  "status": "not_applicable",
+  "status": "approved_artifact_only_rebinding",
   "approver_scope": "StatPan #391 accepted manual-review decision; Health observation plan/schema artifact-only technical rebinding",
   "decision_path": "reports/credential-runtime-manual-review-decision.json",
   "decision_sha256": "4d0bee81a67d4b49a1ccb022ab6be7a28a76b9613cbd7c2211d5f22ce9d69151",
+  "old_compatibility_sha256": "4e34b0a1f58fce9d8b4f913300b9fa2a43a07be91d94c2794cff77b513e39f4a",
+  "new_compatibility_sha256": "00d6ef206b217903e5eff2aca7c008d0e1d29eed25cdc679bb4efac27bed1398",
+  "baseline": {
+    "artifact_count": 161,
+    "artifact_contract_sha256": "44d9e29a76fa88df87c032b0b641ba3bcf4e861a243311b185a8e4039f28634a"
+  },
   "allowed_additions": [
     {
       "path": "schemas/datapan.health-runtime-observation-plan.v1.schema.json",
@@ -15,5 +21,13 @@
       "kind": "verification_plan",
       "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json"
     }
-  ]
+  ],
+  "manifest_delta": {
+    "added_paths": [
+      "reports/health-runtime-observation-plan.v1.json",
+      "schemas/datapan.health-runtime-observation-plan.v1.schema.json"
+    ],
+    "artifact_count_before": 161,
+    "artifact_count_after": 163
+  }
 }

--- a/reports/health-runtime-observation-plan.v1.json
+++ b/reports/health-runtime-observation-plan.v1.json
@@ -9,7 +9,7 @@
   },
   "manifest_binding": {
     "path": "manifest.json",
-    "sha256": "244f056cfc28a0826d948e7d535cc0bb2d57c3fd83dd27ac8fa9957c654d2b15",
+    "sha256": "51ed13a6985544d995a78781dd5c4b489d9ae5a3a1febdd6c5d4d223db171799",
     "excluded_fields": [
       "bytes",
       "sha256"

--- a/reports/health-runtime-observation-plan.v1.json
+++ b/reports/health-runtime-observation-plan.v1.json
@@ -1,0 +1,357 @@
+{
+  "schema_version": "datapan.health-runtime-observation-plan.v1",
+  "generated_at": "2026-07-23T00:00:00Z",
+  "authority": "datapan-registry",
+  "registry_revision": "4458003e1490e70d2efc538df93aeaa3addc90ef",
+  "source_registry": {
+    "path": "data/data-go-kr.registry.json",
+    "sha256": "eeda72ee8590f458de8d75703662578e80edf3e61282f0e5e67547c4f6e5f644"
+  },
+  "manifest_binding": {
+    "path": "manifest.json",
+    "sha256": "244f056cfc28a0826d948e7d535cc0bb2d57c3fd83dd27ac8fa9957c654d2b15",
+    "excluded_fields": [
+      "bytes",
+      "sha256"
+    ]
+  },
+  "selection_policy": {
+    "path": "policy/health-runtime-observation-selection.json",
+    "sha256": "a072096f8cd68e354e18bf410a3042f50b8f3282446e2fabf5cbcb3efe93957a",
+    "selection_id": "data-go-kr-gateway-eight-shard-v1"
+  },
+  "summary": {
+    "shards": 8,
+    "members": 8
+  },
+  "shards": [
+    {
+      "index": 0,
+      "operation_count": 1,
+      "membership_digest": "5de65711fc8e137fa61aa094f359df5c7a7a504ea2a46e78a753e831004fbaf1",
+      "members": [
+        {
+          "operation_id": "hrop-00000001",
+          "dataset_id": "15000480",
+          "operation_name": "명절 비상진료기관 FullData 내려받기목록정보 조회",
+          "upstream_operation_seq": "17442",
+          "cli_operation_key": "472283c645233f09e0285a651fecc659dcbc70d09095e7c20fe590389df5af4d",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B552657/HolidyEmgncClnicInsttInfoInqireService/getHolidyClnicPosblEgytFullDown"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 1,
+      "operation_count": 1,
+      "membership_digest": "9d5cef28735d662472a39ad1fbf6399ba93ddc6d542bab3998d63229e6061a36",
+      "members": [
+        {
+          "operation_id": "hrop-00000002",
+          "dataset_id": "15000576",
+          "operation_name": "약국 FullData 내려받기",
+          "upstream_operation_seq": "17429",
+          "cli_operation_key": "49135cc0a0f4cd7888d9895c7b05fb66f323f8b5b2192c4f04770db648560ba7",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B552657/ErmctInsttInfoInqireService/getParmacyFullDown"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 2,
+      "operation_count": 1,
+      "membership_digest": "ca79bece32667328f1aa7d56a07af3e97f892a417c6c4d6741c272e72073d569",
+      "members": [
+        {
+          "operation_id": "hrop-00000003",
+          "dataset_id": "15000652",
+          "operation_name": "자동제세동기 FullData 내려받기",
+          "upstream_operation_seq": "17438",
+          "cli_operation_key": "6029588b5bb858defda785d7aaf5697f8fbd98170e555ea56737d98ae8f3d7cc",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B552657/AEDInfoInqireService/getAedFullDown"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 3,
+      "operation_count": 1,
+      "membership_digest": "c9549c3a18b5533e4e793ba852362eb4663e9e1593898d407f7104e52614ad05",
+      "members": [
+        {
+          "operation_id": "hrop-00000004",
+          "dataset_id": "15000736",
+          "operation_name": "병/의원 FullData 내려받기",
+          "upstream_operation_seq": "17581",
+          "cli_operation_key": "63aef3afcb3db1938a819fbacdc03ad4f027570f845f574b382576c31d0a9905",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B552657/HsptlAsembySearchService/getHsptlMdcncFullDown"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 4,
+      "operation_count": 1,
+      "membership_digest": "e3864d184a163892eeb286217b389807593dac122de012cc7ac42d841ad96195",
+      "members": [
+        {
+          "operation_id": "hrop-00000005",
+          "dataset_id": "15000863",
+          "operation_name": "문화시설 식당 상세 정보를 조회",
+          "upstream_operation_seq": "51077",
+          "cli_operation_key": "84f641723b50bc2b1b23a4418e18236d842c7fe604fe998ee072d80e25ab1a99",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/6300000/openapi2022/restrnt/getrestrnt"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 5,
+      "operation_count": 1,
+      "membership_digest": "c50208f8dfcd5410c8955b760e3bf73a9707a77b108f90b49de4e0c114f555d5",
+      "members": [
+        {
+          "operation_id": "hrop-00000006",
+          "dataset_id": "15000897",
+          "operation_name": "선거코드",
+          "upstream_operation_seq": "20139",
+          "cli_operation_key": "2be6b4603c85e8717ae6ece5a27520cec75ca8ff6ea955df3d2f339011746ffd",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/9760000/CommonCodeService/getCommonSgCodeList"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 6,
+      "operation_count": 1,
+      "membership_digest": "ff8da00e0f9175a066d207377a00e83d4f1a9c5572122f87e0cc6de843915db7",
+      "members": [
+        {
+          "operation_id": "hrop-00000007",
+          "dataset_id": "15001697",
+          "operation_name": "의료기관종별코드조회",
+          "upstream_operation_seq": "24807",
+          "cli_operation_key": "1a48855aef8468b90bb04c5f1acdd247c8b13f64e6e7a4a72c1e4f818d0acc8b",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B551182/codeInfoService/getMedicInsttClassesCodeList"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "index": 7,
+      "operation_count": 1,
+      "membership_digest": "b52086de2f28d11e4dc252ed48e40c67fe31ab5c3ccc6c175b1d4931d5f2354d",
+      "members": [
+        {
+          "operation_id": "hrop-00000008",
+          "dataset_id": "15001839",
+          "operation_name": "민간 자원별 제공서비스 정보 조회",
+          "upstream_operation_seq": "26193",
+          "cli_operation_key": "7bf9c6e3212e1efe3de0d042860ea33c3b756348d93a2f9e632a9c3fd75ad754",
+          "endpoint": {
+            "host": "apis.data.go.kr",
+            "path": "/B554287/resrceInfoInqireService/getPrvateResrcByProvdServiceInfoInqire"
+          },
+          "credential_requirement": {
+            "required": true,
+            "type": "service_key",
+            "scope": "operation"
+          },
+          "execution": {
+            "request_budget": 1,
+            "timeout_ceiling_ms": 10000,
+            "safe_parameters": [
+              {
+                "name": "pageNo",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              },
+              {
+                "name": "numOfRows",
+                "strategy": "bounded_integer",
+                "minimum": 1,
+                "maximum": 1
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/reports/health-runtime-observation-plan.v1.json
+++ b/reports/health-runtime-observation-plan.v1.json
@@ -9,7 +9,7 @@
   },
   "manifest_binding": {
     "path": "manifest.json",
-    "sha256": "51ed13a6985544d995a78781dd5c4b489d9ae5a3a1febdd6c5d4d223db171799",
+    "sha256": "e1dc0ccffcb954518f5a3f1a2373243dd93c61c9529b587ecfe21df6032e5c8e",
     "excluded_fields": [
       "bytes",
       "sha256"

--- a/reports/registry-impact-plan.json
+++ b/reports/registry-impact-plan.json
@@ -32,7 +32,7 @@
       "path": "reports/source-report-inventory.json",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7"
+      "sha256": "73021e4215675456026efe9fd4be66d619b7328a68c9c9a067dbde226e1bcb5b"
     }
   ],
   "summary": {

--- a/reports/release-assembly-receipt.json
+++ b/reports/release-assembly-receipt.json
@@ -25,7 +25,7 @@
     "manifest": {
       "path": "manifest.json",
       "generated_at": "2026-07-11T10:28:35Z",
-      "artifact_count": 161,
+      "artifact_count": 163,
       "source_registry": "data/data-go-kr.registry.json"
     },
     "readiness": {
@@ -107,8 +107,8 @@
       "evidence_artifacts": [
         {
           "path": "schemas/index.json",
-          "bytes": 35926,
-          "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a",
+          "bytes": 36358,
+          "sha256": "8c9193b87e0f367e31ba30244b619e2c607dd80d96478382b5b6608a2fbba737",
           "manifest_bound": true,
           "kind": "schema_index",
           "schema": "https://schemas.datapan.dev/datapan.schema-index.v1.schema.json"
@@ -193,7 +193,7 @@
         {
           "path": "reports/source-report-inventory.json",
           "bytes": 61997,
-          "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7",
+          "sha256": "73021e4215675456026efe9fd4be66d619b7328a68c9c9a067dbde226e1bcb5b",
           "manifest_bound": true,
           "kind": "source_report_inventory",
           "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json"
@@ -249,7 +249,7 @@
         {
           "path": "reports/registry-impact-plan.json",
           "bytes": 11519,
-          "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820",
+          "sha256": "eabc0ae558c5af7e4929fea2d0fe7803a0bb09ff30df84aeba0e63004805919f",
           "manifest_bound": true,
           "kind": "registry_impact_plan",
           "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json"
@@ -282,7 +282,7 @@
         {
           "path": "reports/source-runtime-remediation-map.json",
           "bytes": 8075,
-          "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3",
+          "sha256": "ad6e71c55e3fbad3706d27b80a80fe60f5405e97250f851960e13a1d98c1ef53",
           "manifest_bound": true,
           "kind": "source_runtime_remediation_map",
           "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json"
@@ -482,7 +482,7 @@
         {
           "path": "reports/credential-runtime-manual-review-acceptance-packet.json",
           "bytes": 3988,
-          "sha256": "86718af67e5dc03812854a740b98229557a75460c7aadb8bf60050ae6f76f672",
+          "sha256": "3c802ef36ea36d17ceec842ce0e766560e2e70e4683138f31eac14a2189fa392",
           "manifest_bound": true,
           "kind": "credential_runtime_manual_review_acceptance_packet",
           "schema": "https://schemas.datapan.dev/datapan.credential-runtime-manual-review-acceptance-packet.v1.schema.json"
@@ -525,7 +525,7 @@
         {
           "path": "reports/release-distribution-footprint.json",
           "bytes": 2141,
-          "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d",
+          "sha256": "04cc3e08777dd34a9c528af4f494edb449e74ccfc5524cb29680d150d08d97ec",
           "manifest_bound": true,
           "kind": "release_distribution_footprint",
           "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json"
@@ -533,7 +533,7 @@
         {
           "path": "reports/release-consumer-compatibility.json",
           "bytes": 26675,
-          "sha256": "9ea04b875d96ed773f2b5bc5d0579c789e32d35040c5a79dd2d5e03bb71a6d77",
+          "sha256": "95c02d59447c33c3d42a8efea1bc7be816daaf34dd230ee32d4dec0d7f621601",
           "manifest_bound": true,
           "kind": "consumer_compatibility",
           "schema": "https://schemas.datapan.dev/datapan.release-consumer-compatibility.v1.schema.json"
@@ -728,7 +728,7 @@
         {
           "path": "docs/release-ledger-goal-completion-audit.json",
           "bytes": 25617,
-          "sha256": "98aaf2c1d2d5c944a182a8a57190efe8f5d800f7b810a633a13428f92d95b382",
+          "sha256": "2ea31d589ce39f65c87b7a80bab41cf38b4d1342d1658799ae45c7cbb6f05cc4",
           "manifest_bound": false
         },
         {

--- a/reports/release-consumer-compatibility.json
+++ b/reports/release-consumer-compatibility.json
@@ -7,7 +7,7 @@
     "manifest": {
       "path": "manifest.json",
       "generated_at": "2026-07-11T10:28:35Z",
-      "artifact_count": 161,
+      "artifact_count": 163,
       "evidence_contracts": 18
     },
     "readiness": {
@@ -104,7 +104,7 @@
       "kind": "source_runtime_remediation_map",
       "schema": "https://schemas.datapan.dev/datapan.source-runtime-remediation-map.v1.schema.json",
       "bytes": 8075,
-      "sha256": "4fdd8abbbe897bd3abdf02485cefda9293eeecc49079d1d9b552bec556bad3f3",
+      "sha256": "ad6e71c55e3fbad3706d27b80a80fe60f5405e97250f851960e13a1d98c1ef53",
       "required": true
     },
     {
@@ -194,7 +194,7 @@
       "kind": "registry_impact_plan",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820",
+      "sha256": "eabc0ae558c5af7e4929fea2d0fe7803a0bb09ff30df84aeba0e63004805919f",
       "required": true
     },
     {
@@ -212,7 +212,7 @@
       "kind": "source_report_inventory",
       "schema": "https://schemas.datapan.dev/datapan.source-report-inventory.v1.schema.json",
       "bytes": 61997,
-      "sha256": "03b976af59e3eab446a7d1da3826f7bb5d9cf729dae726a691b1be65272e83c7",
+      "sha256": "73021e4215675456026efe9fd4be66d619b7328a68c9c9a067dbde226e1bcb5b",
       "required": true
     },
     {
@@ -221,7 +221,7 @@
       "kind": "release_distribution_footprint",
       "schema": "https://schemas.datapan.dev/datapan.release-distribution-footprint.v1.schema.json",
       "bytes": 2141,
-      "sha256": "e379762b44343c2db31849cd258dd4680178d3c800d442309ce8e8dcf3cf7e8d",
+      "sha256": "04cc3e08777dd34a9c528af4f494edb449e74ccfc5524cb29680d150d08d97ec",
       "required": true
     },
     {
@@ -476,7 +476,7 @@
     ],
     "release_distribution_footprint": "reports/release-distribution-footprint.json",
     "canonical_registry_bytes": 137735169,
-    "manifest_bound_bytes_excluding_self": 173957232,
+    "manifest_bound_bytes_excluding_self": 173972648,
     "large_monolith_threshold_bytes": 100000000,
     "registry_footprint_status": "large_monolith_shard_additive",
     "canonical_registry_required": true,

--- a/reports/release-distribution-footprint.json
+++ b/reports/release-distribution-footprint.json
@@ -9,9 +9,9 @@
     "self_artifact_excluded": true
   },
   "summary": {
-    "artifact_count": 161,
-    "schema_artifacts": 88,
-    "manifest_bound_bytes_excluding_self": 173957232,
+    "artifact_count": 163,
+    "schema_artifacts": 89,
+    "manifest_bound_bytes_excluding_self": 173972648,
     "canonical_registry_path": "data/data-go-kr.registry.json",
     "canonical_registry_bytes": 137735169,
     "large_monolith_threshold_bytes": 100000000,

--- a/reports/source-report-inventory.json
+++ b/reports/source-report-inventory.json
@@ -46,9 +46,9 @@
   ],
   "schema_index_input": {
     "path": "schemas/index.json",
-    "schemas": 88,
-    "bytes": 35926,
-    "sha256": "e7a41b0c7c374a2d54448e523690769bba4b7a4c8398f7ef6038d01d1d855c9a"
+    "schemas": 89,
+    "bytes": 36358,
+    "sha256": "8c9193b87e0f367e31ba30244b619e2c607dd80d96478382b5b6608a2fbba737"
   },
   "recommended_reports": [
     "adapter-targets.json",

--- a/reports/source-runtime-remediation-map.json
+++ b/reports/source-runtime-remediation-map.json
@@ -47,7 +47,7 @@
       "path": "reports/registry-impact-plan.json",
       "schema": "https://schemas.datapan.dev/datapan.registry-impact-plan.v1.schema.json",
       "bytes": 11519,
-      "sha256": "76bb56f189609836956b6a7d44143c354e64d52ac0d3d9d07e8511b344efd820"
+      "sha256": "eabc0ae558c5af7e4929fea2d0fe7803a0bb09ff30df84aeba0e63004805919f"
     }
   ],
   "routing_evidence": {

--- a/schemas/datapan.health-runtime-observation-plan.v1.schema.json
+++ b/schemas/datapan.health-runtime-observation-plan.v1.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json",
+  "title":"Datapan Health Runtime Observation Plan v1",
+  "description":"Registry-owned static eight-shard membership. It excludes credential values, query values, command fields, response data, and live observations.",
+  "type":"object","additionalProperties":false,
+  "required":["schema_version","generated_at","authority","source_registry","registry_revision","manifest_binding","selection_policy","summary","shards"],
+  "properties":{
+    "schema_version":{"const":"datapan.health-runtime-observation-plan.v1"},"generated_at":{"type":"string","format":"date-time"},"authority":{"const":"datapan-registry"},
+    "registry_revision":{"type":"string","pattern":"^[a-f0-9]{40}$"},
+    "source_registry":{"type":"object","additionalProperties":false,"required":["path","sha256"],"properties":{"path":{"const":"data/data-go-kr.registry.json"},"sha256":{"$ref":"#/$defs/sha"}}},
+    "manifest_binding":{"type":"object","additionalProperties":false,"required":["path","sha256","excluded_fields"],"properties":{"path":{"const":"manifest.json"},"sha256":{"$ref":"#/$defs/sha"},"excluded_fields":{"const":["bytes","sha256"]}}},
+    "selection_policy":{"type":"object","additionalProperties":false,"required":["path","sha256","selection_id"],"properties":{"path":{"const":"policy/health-runtime-observation-selection.json"},"sha256":{"$ref":"#/$defs/sha"},"selection_id":{"type":"string"}}},
+    "summary":{"type":"object","additionalProperties":false,"required":["shards","members"],"properties":{"shards":{"const":8},"members":{"const":8}}},
+    "shards":{"type":"array","minItems":8,"maxItems":8,"items":{"$ref":"#/$defs/shard"}}
+  },
+  "$defs":{"sha":{"type":"string","pattern":"^[a-f0-9]{64}$"},"execution":{"type":"object","additionalProperties":false,"required":["request_budget","timeout_ceiling_ms","safe_parameters"],"properties":{"request_budget":{"const":1},"timeout_ceiling_ms":{"type":"integer","minimum":1000,"maximum":20000},"safe_parameters":{"type":"array","minItems":2,"maxItems":2}}},"member":{"type":"object","additionalProperties":false,"required":["operation_id","dataset_id","operation_name","upstream_operation_seq","cli_operation_key","endpoint","credential_requirement","execution"],"properties":{"operation_id":{"type":"string","pattern":"^hrop-[0-9]{8}$"},"dataset_id":{"type":"string"},"operation_name":{"type":"string"},"upstream_operation_seq":{"type":"string"},"cli_operation_key":{"$ref":"#/$defs/sha"},"endpoint":{"type":"object","additionalProperties":false,"required":["host","path"],"properties":{"host":{"const":"apis.data.go.kr"},"path":{"type":"string","pattern":"^/"}}},"credential_requirement":{"const":{"required":true,"type":"service_key","scope":"operation"}},"execution":{"$ref":"#/$defs/execution"}}},"shard":{"type":"object","additionalProperties":false,"required":["index","operation_count","membership_digest","members"],"properties":{"index":{"type":"integer","minimum":0,"maximum":7},"operation_count":{"const":1},"membership_digest":{"$ref":"#/$defs/sha"},"members":{"type":"array","minItems":1,"maxItems":1,"items":{"$ref":"#/$defs/member"}}}}}
+}

--- a/schemas/datapan.release-receipt-admission.v1.schema.json
+++ b/schemas/datapan.release-receipt-admission.v1.schema.json
@@ -15,6 +15,7 @@
     "outcome": {"enum": ["no_change", "material_change", "collection_failure", "verified", "failed", "skipped", "unknown"]},
     "scope": {"$ref": "#/$defs/scope"},
     "execution": {"$ref": "#/$defs/execution"},
+    "execution_plan": {"$ref": "#/$defs/execution_plan"},
     "redaction": {"$ref": "#/$defs/redaction"},
     "receipt_digest": {"$ref": "#/$defs/digest"}
   },
@@ -70,6 +71,15 @@
         "terminal_state": {"enum": ["verified", "failed", "skipped", "unknown"]}
       }
     },
+    "execution_plan": {
+      "type": "object", "additionalProperties": false,
+      "required": ["path", "sha256", "manifest_binding_sha256"],
+      "properties": {
+        "path": {"const": "reports/health-runtime-observation-plan.v1.json"},
+        "sha256": {"$ref": "#/$defs/digest"},
+        "manifest_binding_sha256": {"$ref": "#/$defs/digest"}
+      }
+    },
     "redaction": {
       "type": "object",
       "additionalProperties": false,
@@ -84,7 +94,7 @@
     }
   },
   "allOf": [
-    {"if": {"properties": {"receipt_kind": {"const": "runtime_freshness_shard"}}}, "then": {"required": ["execution"], "properties": {"producer": {"required": ["aggregate_path", "aggregate_sha256"]}}}},
+    {"if": {"properties": {"receipt_kind": {"const": "runtime_freshness_shard"}}}, "then": {"required": ["execution", "execution_plan"], "properties": {"producer": {"required": ["aggregate_path", "aggregate_sha256"]}}}},
     {"if": {"properties": {"receipt_kind": {"enum": ["catalog_observation", "cli_consumer_smoke"]}}}, "then": {"not": {"required": ["execution"]}}}
   ]
 }

--- a/schemas/index.json
+++ b/schemas/index.json
@@ -2,7 +2,7 @@
   "schema_version": "datapan.schema-index.v1",
   "generated_at": "2026-07-04T06:39:24Z",
   "datapan_version": "0.1.0-dev",
-  "count": 88,
+  "count": 89,
   "schemas": [
     {
       "path": "schemas/datapan.adapter-targets.v1.schema.json",
@@ -793,8 +793,17 @@
       "title": "Datapan Release Receipt Admission v1",
       "contract": "release-receipt-admission",
       "version": "v1",
-      "bytes": 4520,
-      "sha256": "0d9ea5cc7e94136a82579931b391e332df04e35b1ed1eb2de18ed0502c15a666"
+      "bytes": 4963,
+      "sha256": "a9f6d43d8893d71b6476407cf980ada8d8e031a19ccc82ec7d62eebd266dbe18"
+    },
+    {
+      "path": "schemas/datapan.health-runtime-observation-plan.v1.schema.json",
+      "id": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json",
+      "title": "Datapan Health Runtime Observation Plan v1",
+      "contract": "health-runtime-observation-plan",
+      "version": "v1",
+      "bytes": 3251,
+      "sha256": "aace55eb79feb701a6e5ee04d1ce6dc2a03b9f0a162e9ef9c10bed1f844a6abc"
     }
   ]
 }

--- a/scripts/generate-health-runtime-observation-plan.py
+++ b/scripts/generate-health-runtime-observation-plan.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Generate the static, manifest-bound eight-shard Health execution plan."""
+import copy, hashlib, json, pathlib, sys
+from urllib.parse import urlsplit
+
+ROOT=pathlib.Path("."); POLICY=ROOT/"policy/health-runtime-observation-selection.json"; REGISTRY=ROOT/"data/data-go-kr.registry.json"; MANIFEST=ROOT/"manifest.json"; OUTPUT=ROOT/"reports/health-runtime-observation-plan.v1.json"
+def dump(v): return json.dumps(v,ensure_ascii=False,indent=2)+"\n"
+def sha(b): return hashlib.sha256(b).hexdigest()
+def key(fields):
+ b=bytearray()
+ for f in fields: x=f.encode(); b.extend(f"{len(x)}:".encode()); b.extend(x)
+ return sha(bytes(b))
+def manifest_binding(manifest):
+ v=copy.deepcopy(manifest); matches=[a for a in v["artifacts"] if a.get("path")==OUTPUT.as_posix()]
+ if len(matches)!=1 or matches[0].get("kind")!="health_runtime_observation_plan" or matches[0].get("schema")!="https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json": raise ValueError("plan manifest entry must be unique with expected path/kind/schema")
+ for f in ("bytes","sha256"):
+  if f not in matches[0]: raise ValueError("plan manifest entry missing excluded field")
+  matches[0].pop(f)
+ return sha(json.dumps(v,sort_keys=True,separators=(",",":"),ensure_ascii=False).encode())
+def build():
+ p=json.loads(POLICY.read_text()); r=json.loads(REGISTRY.read_text()); m=json.loads(MANIFEST.read_text()); by={(d["id"],o["name"]):(d,o) for d in r for o in d.get("operations",[]) }
+ members=[]
+ for s in p["members"]:
+  d,o=by.get((s["dataset_id"],s["operation_name"]),(None,None))
+  if not d: raise ValueError("unknown selected operation")
+  u=urlsplit(o.get("endpoint", ""));
+  if u.hostname!="apis.data.go.kr" or not u.path or u.query or u.username or u.password: raise ValueError("selected endpoint is not an allowlisted host/path")
+  names={str(x.get("name", "")).lower() for x in o.get("request_params",[])}
+  if not {"servicekey","pageno","numofrows"}.issubset(names): raise ValueError("selected operation lacks safe contract")
+  cli=key([d["provider"],d["id"],o["name"],"data_go_kr_gateway",u.hostname,u.path])
+  members.append({"operation_id":s["operation_id"],"dataset_id":d["id"],"operation_name":o["name"],"upstream_operation_seq":str(o["source"]["raw"]["operation_seq"]),"cli_operation_key":cli,"endpoint":{"host":u.hostname,"path":u.path},"credential_requirement":{"required":True,"type":"service_key","scope":"operation"},"execution":p["execution"]})
+ if len(members)!=8 or len({x["operation_id"] for x in members})!=8: raise ValueError("selection must have eight unique members")
+ shards=[]
+ for i,x in enumerate(members):
+  digest=sha(json.dumps([x],sort_keys=True,separators=(",",":"),ensure_ascii=False).encode()); shards.append({"index":i,"operation_count":1,"membership_digest":digest,"members":[x]})
+ return {"schema_version":"datapan.health-runtime-observation-plan.v1","generated_at":p["generated_at"],"authority":"datapan-registry","registry_revision":p["registry_revision"],"source_registry":{"path":REGISTRY.as_posix(),"sha256":sha(REGISTRY.read_bytes())},"manifest_binding":{"path":MANIFEST.as_posix(),"sha256":manifest_binding(m),"excluded_fields":["bytes","sha256"]},"selection_policy":{"path":POLICY.as_posix(),"sha256":sha(POLICY.read_bytes()),"selection_id":p["selection_id"]},"summary":{"shards":8,"members":8},"shards":shards}
+def main():
+ try:
+  expected=dump(build())
+  if "--check" in sys.argv:
+   if not OUTPUT.is_file() or OUTPUT.read_text()!=expected: raise ValueError("generated plan drift")
+  else: OUTPUT.write_text(expected)
+  print("ok health runtime observation plan (shards=8, members=8)")
+ except Exception as e: print(f"FAIL health runtime observation plan: {e}",file=sys.stderr); return 1
+ return 0
+if __name__=="__main__": raise SystemExit(main())

--- a/scripts/generate-health-runtime-observation-plan.py
+++ b/scripts/generate-health-runtime-observation-plan.py
@@ -12,7 +12,7 @@ def key(fields):
  return sha(bytes(b))
 def manifest_binding(manifest):
  v=copy.deepcopy(manifest); matches=[a for a in v["artifacts"] if a.get("path")==OUTPUT.as_posix()]
- if len(matches)!=1 or matches[0].get("kind")!="health_runtime_observation_plan" or matches[0].get("schema")!="https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json": raise ValueError("plan manifest entry must be unique with expected path/kind/schema")
+ if len(matches)!=1 or matches[0].get("kind")!="verification_plan" or matches[0].get("schema")!="https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json": raise ValueError("plan manifest entry must be unique with expected path/kind/schema")
  for f in ("bytes","sha256"):
   if f not in matches[0]: raise ValueError("plan manifest entry missing excluded field")
   matches[0].pop(f)

--- a/scripts/refresh-release-ledger-evidence.py
+++ b/scripts/refresh-release-ledger-evidence.py
@@ -61,12 +61,20 @@ WRITE_COMMANDS: tuple[Command, ...] = (
     Command(("python3", "scripts/generate-release-goal-operating-contract.py")),
     Command(("python3", "scripts/generate-release-assembly-receipt.py"), transient=True),
     Command(("python3", "scripts/sync-release-manifest-artifacts.py", "--write")),
+    # The plan binds every manifest artifact except its own mutable digest entry,
+    # so generate it only after all other manifest-owned release evidence.
+    Command(("python3", "scripts/generate-health-runtime-observation-plan.py")),
+    Command(("python3", "scripts/sync-release-manifest-artifacts.py", "--write")),
+    # This fixture pins the finalized manifest but is not itself a manifest artifact.
+    Command(("python3", "scripts/generate-regional-baseline-source-provenance.py")),
 )
 
 
 CHECK_COMMANDS: tuple[Command, ...] = (
     Command(("python3", "scripts/sync-release-schema-artifacts.py", "--check")),
     Command(("python3", "scripts/sync-release-manifest-artifacts.py", "--check")),
+    Command(("python3", "scripts/validate-health-runtime-observation-plan.py")),
+    Command(("python3", "scripts/validate-regional-baseline-source-provenance.py")),
     Command(("python3", "scripts/validate-release-ledger-ownership.py")),
     Command(("python3", "scripts/validate-release-ledger-goal-audit.py")),
     Command(("python3", "scripts/generate-source-contract-rollup.py", "--check")),

--- a/scripts/release_admission_receipts.py
+++ b/scripts/release_admission_receipts.py
@@ -261,7 +261,7 @@ def validate_execution_plan(execution_plan: dict[str, Any], manifest_path: pathl
         raise ValueError(f"{label}: Health execution plan is not manifest-bound")
     projection = copy.deepcopy(manifest)
     bound = [item for item in projection["artifacts"] if item.get("path") == expected_path]
-    if len(bound) != 1 or bound[0].get("kind") != "health_runtime_observation_plan" or bound[0].get("schema") != "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json":
+    if len(bound) != 1 or bound[0].get("kind") != "verification_plan" or bound[0].get("schema") != "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json":
         raise ValueError(f"{label}: Health execution plan manifest identity does not match")
     bound[0].pop("bytes", None); bound[0].pop("sha256", None)
     digest = hashlib.sha256(json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()

--- a/scripts/release_admission_receipts.py
+++ b/scripts/release_admission_receipts.py
@@ -248,6 +248,28 @@ def validate_health_aggregate(
         raise ValueError(f"{label}: outer redaction mapping is not safe")
 
 
+def validate_execution_plan(execution_plan: dict[str, Any], manifest_path: pathlib.Path, label: str) -> None:
+    expected_path = "reports/health-runtime-observation-plan.v1.json"
+    if execution_plan.get("path") != expected_path:
+        raise ValueError(f"{label}: Health execution plan path is not authorized")
+    plan_path = rooted_file(manifest_path.parent, expected_path, f"{label}.execution_plan.path")
+    if execution_plan.get("sha256") != file_digest(plan_path):
+        raise ValueError(f"{label}: Health execution plan digest does not match")
+    manifest = load_json(manifest_path)
+    entries = [item for item in as_list(manifest.get("artifacts"), "manifest.artifacts") if isinstance(item, dict) and item.get("path") == expected_path]
+    if len(entries) != 1 or entries[0].get("sha256") != execution_plan.get("sha256"):
+        raise ValueError(f"{label}: Health execution plan is not manifest-bound")
+    projection = copy.deepcopy(manifest)
+    bound = [item for item in projection["artifacts"] if item.get("path") == expected_path]
+    if len(bound) != 1 or bound[0].get("kind") != "health_runtime_observation_plan" or bound[0].get("schema") != "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json":
+        raise ValueError(f"{label}: Health execution plan manifest identity does not match")
+    bound[0].pop("bytes", None); bound[0].pop("sha256", None)
+    digest = hashlib.sha256(json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()
+    plan = load_json(plan_path)
+    if execution_plan.get("manifest_binding_sha256") != digest or plan.get("manifest_binding", {}).get("sha256") != digest:
+        raise ValueError(f"{label}: Health execution plan manifest binding does not match")
+
+
 def validate_receipt(receipt: dict[str, Any], *, schema: dict[str, Any], policy: dict[str, Any], policy_path: pathlib.Path, manifest_path: pathlib.Path, manifest_sha256: str, source_sha256: str, artifact_roots: dict[str, pathlib.Path], admitted_at: datetime, label: str) -> None:
     validate_schema(receipt, schema, label)
     scan_redaction(receipt, policy, label)
@@ -289,6 +311,7 @@ def validate_receipt(receipt: dict[str, Any], *, schema: dict[str, Any], policy:
         raise ValueError(f"{label}: registry admission policy binding does not match")
     if kind == RUNTIME_KIND:
         execution = as_dict(receipt.get("execution"), f"{label}.execution")
+        validate_execution_plan(as_dict(receipt.get("execution_plan"), f"{label}.execution_plan"), manifest_path, label)
         for field, policy_field in (("shard_count", "shard_count"), ("batch_size", "batch_size_max"), ("max_parallelism", "max_parallelism_max"), ("per_operation_timeout_seconds", "per_operation_timeout_seconds_max")):
             if field == "shard_count":
                 if execution.get(field) != contract.get(policy_field):

--- a/scripts/validate-health-runtime-observation-plan.py
+++ b/scripts/validate-health-runtime-observation-plan.py
@@ -22,7 +22,7 @@ def main():
   spec=importlib.util.spec_from_file_location("plan_generator",ROOT/"scripts/generate-health-runtime-observation-plan.py"); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
   fail(plan==mod.build(),"generated plan drift")
   entries=[x for x in manifest["artifacts"] if x.get("path")==PLAN.as_posix()]
-  fail(len(entries)==1 and entries[0].get("kind")=="health_runtime_observation_plan" and entries[0].get("schema")==schema["$id"],"plan manifest entry mismatch")
+  fail(len(entries)==1 and entries[0].get("kind")=="verification_plan" and entries[0].get("schema")==schema["$id"],"plan manifest entry mismatch")
   fail(entries[0].get("sha256")==sha(PLAN) and entries[0].get("bytes")==PLAN.stat().st_size,"full manifest does not bind exact plan bytes")
   fail(plan["manifest_binding"]["sha256"]==mod.manifest_binding(manifest),"manifest binding digest mismatch")
   shards=plan["shards"]; fail([x["index"] for x in shards]==list(range(8)),"shards must be canonical indexes")

--- a/scripts/validate-health-runtime-observation-plan.py
+++ b/scripts/validate-health-runtime-observation-plan.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Fail closed on the static Health observation-plan and manifest binding."""
+import hashlib, importlib.util, json, pathlib, sys
+import jsonschema
+ROOT=pathlib.Path("."); PLAN=ROOT/"reports/health-runtime-observation-plan.v1.json"; SCHEMA=ROOT/"schemas/datapan.health-runtime-observation-plan.v1.schema.json"; MANIFEST=ROOT/"manifest.json"
+FORBIDDEN={"credential","credential_value","secret","query","url","command","args","response","row","live"}
+def load(p): return json.loads(p.read_text())
+def sha(p): return hashlib.sha256(p.read_bytes()).hexdigest()
+def fail(x,m):
+ if not x: raise ValueError(m)
+def walk(v):
+ if isinstance(v,dict):
+  for k,x in v.items():
+   fail(k.lower() not in FORBIDDEN or k in {"credential_requirement","cli_operation_key"},"forbidden plan field")
+   walk(x)
+ elif isinstance(v,list):
+  for x in v: walk(x)
+def main():
+ try:
+  plan,schema,manifest=load(PLAN),load(SCHEMA),load(MANIFEST)
+  jsonschema.Draft202012Validator(schema,format_checker=jsonschema.FormatChecker()).validate(plan); walk(plan)
+  spec=importlib.util.spec_from_file_location("plan_generator",ROOT/"scripts/generate-health-runtime-observation-plan.py"); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+  fail(plan==mod.build(),"generated plan drift")
+  entries=[x for x in manifest["artifacts"] if x.get("path")==PLAN.as_posix()]
+  fail(len(entries)==1 and entries[0].get("kind")=="health_runtime_observation_plan" and entries[0].get("schema")==schema["$id"],"plan manifest entry mismatch")
+  fail(entries[0].get("sha256")==sha(PLAN) and entries[0].get("bytes")==PLAN.stat().st_size,"full manifest does not bind exact plan bytes")
+  fail(plan["manifest_binding"]["sha256"]==mod.manifest_binding(manifest),"manifest binding digest mismatch")
+  shards=plan["shards"]; fail([x["index"] for x in shards]==list(range(8)),"shards must be canonical indexes")
+  members=[x["members"][0] for x in shards]; fail(len({x["operation_id"] for x in members})==8,"membership overlaps")
+  for shard,member in zip(shards,members,strict=True): fail(shard["membership_digest"]==hashlib.sha256(json.dumps([member],sort_keys=True,separators=(",",":"),ensure_ascii=False).encode()).hexdigest(),"membership digest mismatch")
+ except Exception as e: print(f"FAIL health runtime observation plan: {e}",file=sys.stderr); return 1
+ print("ok health runtime observation plan validation (shards=8, redaction=verified)"); return 0
+if __name__=="__main__": raise SystemExit(main())

--- a/tests/test_release_admission_receipts.py
+++ b/tests/test_release_admission_receipts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import hashlib
 import json
 import pathlib
 import sys
@@ -25,10 +27,22 @@ class ReleaseAdmissionReceiptTest(unittest.TestCase):
             "datapan_version": "0.1.0-test",
             "provider": "data.go.kr",
             "source_registry": "data/registry.json",
-            "artifact_count": 1,
-            "artifacts": [{"path": "data/registry.json", "sha256": admission.file_digest(artifact)}],
+            "artifact_count": 2,
+            "artifacts": [
+                {"path": "data/registry.json", "sha256": admission.file_digest(artifact)},
+                {"path": "reports/health-runtime-observation-plan.v1.json", "kind": "health_runtime_observation_plan", "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json", "bytes": 0, "sha256": "0" * 64},
+            ],
         }
         self.manifest_path = self.root / "manifest.json"
+        self.plan_path = self.root / "reports" / "health-runtime-observation-plan.v1.json"
+        self.plan_path.parent.mkdir(parents=True)
+        projection = copy.deepcopy(manifest)
+        projection["artifacts"][1].pop("bytes")
+        projection["artifacts"][1].pop("sha256")
+        self.plan_binding = hashlib.sha256(json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+        self.plan_path.write_text(json.dumps({"manifest_binding": {"sha256": self.plan_binding}}), encoding="utf-8")
+        manifest["artifacts"][1]["bytes"] = self.plan_path.stat().st_size
+        manifest["artifacts"][1]["sha256"] = admission.file_digest(self.plan_path)
         self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         self.schema = admission.load_json(ROOT / "schemas/datapan.release-receipt-admission.v1.schema.json")
         self.policy = admission.load_json(ROOT / "policy/release-receipt-admission.json")
@@ -62,6 +76,7 @@ class ReleaseAdmissionReceiptTest(unittest.TestCase):
         if kind == admission.RUNTIME_KIND:
             value["outcome"] = "verified"
             value["execution"] = {"run_id": "run-42", "shard_count": 8, "shard_index": shard, "shard_digest": f"{shard:064x}", "batch_size": 100, "max_parallelism": 2, "per_operation_timeout_seconds": 20, "terminal_state": "verified"}
+            value["execution_plan"] = {"path": "reports/health-runtime-observation-plan.v1.json", "sha256": admission.file_digest(self.plan_path), "manifest_binding_sha256": self.plan_binding}
             value["producer"]["aggregate_path"] = "runs/fixture-run-42.json"
             value["producer"]["aggregate_sha256"] = "0" * 64
             source_redaction = {"secret_values_removed": True, "secret_hashes_removed": True, "authorization_headers_removed": True, "credential_bearing_urls_removed": True, "raw_provider_text_removed": True, "raw_provider_urls_removed": True, "response_bodies_removed": True, "response_rows_removed": True, "user_identity_removed": True}
@@ -144,6 +159,7 @@ class ReleaseAdmissionReceiptTest(unittest.TestCase):
         manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
         manifest["source_registry"] = "../outside-registry.json"
         manifest["artifacts"] = [{"path": "../outside-registry.json", "sha256": admission.file_digest(outside)}]
+        manifest["artifact_count"] = 1
         self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "escapes"):
             admission.validate_manifest(self.manifest_path, check_artifacts=True)
@@ -226,6 +242,19 @@ class ReleaseAdmissionReceiptTest(unittest.TestCase):
         receipt["scope"]["provider"] = "data.go.kr"
         receipt["receipt_digest"] = admission.canonical_digest(receipt)
         with self.assertRaisesRegex(ValueError, "scope.provider"):
+            self.validate(receipt)
+
+    def test_runtime_plan_digest_and_manifest_binding_fail_closed(self) -> None:
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        receipt["execution_plan"]["sha256"] = "0" * 64
+        receipt["receipt_digest"] = admission.canonical_digest(receipt)
+        with self.assertRaisesRegex(ValueError, "execution plan digest"):
+            self.validate(receipt)
+        receipt = self.receipt(admission.RUNTIME_KIND, shard=0)
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest["provider"] = "other"
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "manifest binding"):
             self.validate(receipt)
 
 

--- a/tests/test_release_admission_receipts.py
+++ b/tests/test_release_admission_receipts.py
@@ -30,7 +30,7 @@ class ReleaseAdmissionReceiptTest(unittest.TestCase):
             "artifact_count": 2,
             "artifacts": [
                 {"path": "data/registry.json", "sha256": admission.file_digest(artifact)},
-                {"path": "reports/health-runtime-observation-plan.v1.json", "kind": "health_runtime_observation_plan", "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json", "bytes": 0, "sha256": "0" * 64},
+                {"path": "reports/health-runtime-observation-plan.v1.json", "kind": "verification_plan", "schema": "https://schemas.datapan.dev/datapan.health-runtime-observation-plan.v1.schema.json", "bytes": 0, "sha256": "0" * 64},
             ],
         }
         self.manifest_path = self.root / "manifest.json"


### PR DESCRIPTION
Closes #594

Compatibility note:
- The Health observation plan retains its distinct schema URI, path, SHA-256, and manifest binding, but uses the existing `verification_plan` manifest kind. This preserves the pinned consumer release-manifest v1 contract; the manifest schema version is intentionally unchanged.
- The nine external CLI checkout/pins remain unchanged and are verified by the external-checkout inventory gate.

Release follow-up:
- The next Registry distribution release must make a deterministic version bump because its artifact set changes. A separate release-versioning task will enforce source/manifest/artifact change detection and no-change/no-bump behavior.